### PR TITLE
Add instructions on how to update the USWDS version

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,30 @@ Federalist also builds public previews for each branch pushed to GitHub. For ins
 
 https://federalist.fr.cloud.gov/preview/18f/web-design-standards-docs/develop/
 
+### Updating the USWDS version
+
+To update the version of USWDS being used, change the version that
+`package.json` specifies in its `dependencies` section.
+
+We currently pull USWDS via git rather than npm, as it allows us to
+use any tag or commit during development. To install a specific commit,
+you can use e.g.:
+
+```
+npm install --save 18F/web-design-standards#fb49e4f
+```
+
+Alternatively, to use a specific version tag, use e.g.:
+
+```
+npm install --save 18F/web-design-standards#v1.3.1
+```
+
+This version number or commit hash is automatically parsed when the site
+is built and used for display on the site (see `_plugins/uswds_version.rb`
+for details). Therefore, be sure to use an actual version tag on all
+`master` branch commits--otherwise a commit hash will show up as the
+version on the production site, which would be confusing.
 
 ### Adding content to the "Updates" section
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # U.S. Web Design Standards documentation
 
-This repo includes code and documentation for the  U.S. Web Design Standards website. For information on the Standards (components) themselves, please visit [web-design-standards](https://github.com/18F/web-design-standards).
+This repo includes code and documentation for the  U.S. Web Design Standards website. For information on the Standards (components) themselves, please visit [web-design-standards](https://github.com/uswds/uswds).
 
 Note that this README includes steps to pull the latest version of the Standards into your local instance of the documentation.
 
@@ -52,7 +52,7 @@ Here are a few other utility commands you may find useful:
 
 Sometimes you will want to use the latest version of the `web-design-standards` repo. Follow these steps to do so:
 
-1. Clone the latest version of the [`web-design-standards` repo](https://github.com/18F/web-design-standards/tree/develop).
+1. Clone the latest version of the [`web-design-standards` repo](https://github.com/uswds/uswds/tree/develop).
 1. Run `npm install` to install the dependencies required for the package in the `web-design-standards` directory.
 1. Run `npm run build:package` to create the built version of the Standards in the `web-design-standards` directory.
 1. Run `npm link` in the _root level_ of the `web-design-standards` directory on your local machine.
@@ -85,13 +85,13 @@ use any tag or commit during development. To install a specific commit,
 you can use e.g.:
 
 ```
-npm install --save 18F/web-design-standards#fb49e4f
+npm install --save uswds/uswds#fb49e4f
 ```
 
 Alternatively, to use a specific version tag, use e.g.:
 
 ```
-npm install --save 18F/web-design-standards#v1.3.1
+npm install --save uswds/uswds#v1.3.1
 ```
 
 This version number or commit hash is automatically parsed when the site

--- a/_plugins/uswds_version.rb
+++ b/_plugins/uswds_version.rb
@@ -4,7 +4,7 @@ module USWDSVersion
   def make_version_nice(version)
     # If we're using a particular 'commit-ish' of the official repo,
     # just grab the 'commit-ish' part.
-    m = /^(?:github\:)?18F\/web-design-standards#(.+)/i.match(version)
+    m = /^(?:github\:)?uswds\/uswds#(.+)/i.match(version)
     if m
       version = m[1]
 

--- a/_plugins/uswds_version.rb
+++ b/_plugins/uswds_version.rb
@@ -4,7 +4,7 @@ module USWDSVersion
   def make_version_nice(version)
     # If we're using a particular 'commit-ish' of the official repo,
     # just grab the 'commit-ish' part.
-    m = /^18F\/web-design-standards#(.+)/.match(version)
+    m = /^(?:github\:)?18F\/web-design-standards#(.+)/i.match(version)
     if m
       version = m[1]
 

--- a/spec/uswds_version_spec.rb
+++ b/spec/uswds_version_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe USWDSVersion do
       expect(make_version_nice('blarg')).to eq('blarg')
     end
 
+    it 'supports the github: protocol' do
+      expect(make_version_nice('github:18f/web-design-standards#foo')).to \
+        eq('foo')
+    end
+
     it 'gets the commit-ish if based on official repo' do
       expect(make_version_nice('18F/web-design-standards#foo')).to eq('foo')
     end

--- a/spec/uswds_version_spec.rb
+++ b/spec/uswds_version_spec.rb
@@ -9,16 +9,16 @@ RSpec.describe USWDSVersion do
     end
 
     it 'supports the github: protocol' do
-      expect(make_version_nice('github:18f/web-design-standards#foo')).to \
+      expect(make_version_nice('github:uswds/uswds#foo')).to \
         eq('foo')
     end
 
     it 'gets the commit-ish if based on official repo' do
-      expect(make_version_nice('18F/web-design-standards#foo')).to eq('foo')
+      expect(make_version_nice('uswds/uswds#foo')).to eq('foo')
     end
 
     it 'removes the "v" in a version tag if needed' do
-      expect(make_version_nice('18F/web-design-standards#v1.2.3')).to \
+      expect(make_version_nice('uswds/uswds#v1.2.3')).to \
         eq('1.2.3')
     end
   end


### PR DESCRIPTION
This adds instructions on how to update the USWDS version to `README.md`.

It's not quite a `RELEASE.md` (#386) but it helps get us there.  I figure it's also useful to put in the `README.md` since devs will want to know how to do it outside of the context of a release, e.g. to get the latest fractal component HTML from a specific USWDS commit.

When writing the docs and trying out the `npm install` commands, I noticed that npm prefixes the dependency name with the `github:` protocol, and it also seems to lowercase the organization name. So I updated `_plugins/uswds_version.rb` to support that.
