### PR TITLE
Update search bar lead text

### DIFF
--- a/_components/search-bar.md
+++ b/_components/search-bar.md
@@ -6,7 +6,7 @@ layout: styleguide
 type: component
 title: Search bar
 category: UI components
-lead: A block that allows users to search for specific content if they know what search terms to use or can’t find desired content in the main navigation
+lead: A box that allows users to search for specific content if they know what search terms to use or can’t find desired content in the main navigation
 ---
 
 {% include code/preview.html component="search-bar" classes="preview-search-bar" %}


### PR DESCRIPTION
The lead text on the [search bar](https://designsystem.digital.gov/components/search-bar/) says:

>**A block** that allows users to search for specific content if they know what search terms to use or can’t find desired content in the main navigation

but "a block" doesn't seem to make much sense, so I changed it to box, as in a search box. See https://www.nngroup.com/articles/search-visible-and-simple/ Another option is "an element."

