### PR TITLE
Updated page nav to point to correct IDs / Anchors

### DIFF
--- a/pages/getting-started/developers.md
+++ b/pages/getting-started/developers.md
@@ -13,8 +13,10 @@ subnav:
   href: '#customization-and-theming'
 - text: Where things live
   href: '#where-things-live'
+- text: Browser Support
+  href: '#browser-support'
 - text: Accessibility
-  href: '#notes-on-accessibility'
+  href: '#accessibility'
 - text: Contributions
   href: '#contribution-guidelines'
 ---


### PR DESCRIPTION
## Description

The `Accessibility` link on in the navigation on this page is pointing to the incorrect ID.
`https://designsystem.digital.gov/getting-started/developers/#notes-on-accessibility`

I updated the page-navigation to link to the existing ID `#accessibility`

I also added in the navigation item to link to **"Browser Support"**, since that is also an `h2` on the page. I figured it should also be available in the navigation, yes?
https://designsystem.digital.gov/getting-started/developers/#browser-support