### PR TITLE
Update blog link to site blog on "What's new" page

### DIFF
--- a/pages/whats-new/overview.md
+++ b/pages/whats-new/overview.md
@@ -18,11 +18,12 @@ redirect_from:
 {% capture blog %}
 ## Latest blog posts
 
-You can read more about the Design System on the 18F blog, where we cover the
+You can read more about the Design System in our [News and updates]({{ site.baseurl }}/whats-new/updates/), where we cover the
 latest development releases as well as interviews with the teams from across
 government who have successfully implemented the Design System at their agencies.
+You can read some older posts on the [18F Blog](https://18f.gsa.gov/tags/web-design-system/).
 
-<a href="https://18f.gsa.gov/tags/web-design-system/" class="usa-button">Read the latest blog posts</a>
+<a href="{{ site.baseurl }}/whats-new/updates/" class="usa-button">Read the latest blog posts</a>
 {% endcapture %}
 
 {% capture in_wild %}


### PR DESCRIPTION
Updates the blog link to the site's blog (News and updates) instead of the 18F blog. Added a sentence that links to the 18F blog for older posts and historical preservation.

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds-site/update-blog-link/whats-new/)