### PR TITLE
Use kramdown for markdown engine

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -62,14 +62,6 @@ defaults:
     values:
       layout: post
 
-# Build settings
-markdown: RedcarpetExtender
-redcarpet:
-  extensions:
-    - smart
-    - tables
-    - with_toc_data # automatic heading ids
-
 gems:
   - jekyll-redirect-from
 


### PR DESCRIPTION
Kramdown is Jekyll's default markdown engine, so we should probably use it instead of redcarpet. This removes redcarpet to use kramdown by default. All of the extensions we've added are default in kramdown. Kramdown also allows us to use attributes.

Note: I haven't checked this thoroughly to make sure nothing broke.