### PR TITLE
Add autoprefixer to Jekyll

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'json'
 gem 'redcarpet'
 gem 'open-uri-cached'
 gem 'jekyll-redirect-from'
+gem 'octopress-autoprefixer'
 
 gem 'rouge', '1.9'
 gem 'scss_lint', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,8 +3,11 @@ GEM
   specs:
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
+    autoprefixer-rails (8.2.0)
+      execjs
     colorator (1.1.0)
     diff-lcs (1.3)
+    execjs (2.7.0)
     ffi (1.9.18)
     forwardable-extended (2.6.0)
     jekyll (3.4.3)
@@ -33,6 +36,9 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     mercenary (0.3.6)
+    octopress-autoprefixer (2.0.1)
+      autoprefixer-rails
+      jekyll (~> 3.0)
     open-uri-cached (0.0.5)
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
@@ -63,6 +69,7 @@ DEPENDENCIES
   jekyll-compose
   jekyll-redirect-from
   json
+  octopress-autoprefixer
   open-uri-cached
   redcarpet
   rouge (= 1.9)
@@ -71,4 +78,4 @@ DEPENDENCIES
   scss_lint
 
 BUNDLED WITH
-   1.15.1
+   1.16.1

--- a/_config.yml
+++ b/_config.yml
@@ -64,6 +64,7 @@ defaults:
 
 gems:
   - jekyll-redirect-from
+  - octopress-autoprefixer
 
 exclude:
   - ".ruby-version"

--- a/pages/getting-started/developers.md
+++ b/pages/getting-started/developers.md
@@ -105,7 +105,7 @@ To use the Design System on your project, you’ll need to include the CSS and J
     </head>
     <body>
       <h1>Hello, world!</h1>
-      
+
       <!-- U.S. Web Design System JavaScript -->
       <script src="assets/uswds-{{ site.data.uswds_version }}/js/uswds.min.js"></script>
     </body>
@@ -115,7 +115,7 @@ To use the Design System on your project, you’ll need to include the CSS and J
     And that’s it — you should now be able to copy our code samples into your site's HTML and start using the Design System.
 
     Note: We offer the CSS and the JavaScript in two versions — a minified version and an un-minified one. (In the examples above, we are using the minified files.) Use the minified files in a production environment or to reduce the file size of your downloaded assets. And the un-minified files are better if you are in a development environment or would like to debug the CSS or JavaScript assets in the browser.
-    
+
     Note: We also provide Sass (SCSS) files in the zip file which you can compile to CSS. See [Sass](#sass) and [Customization and theming](#customization-and-theming).
 
 
@@ -189,6 +189,8 @@ Below is an example of how you might setup your main Sass file to achieve this:
 ```
 
 You can now use your copied version of `_variables.scss` to override any styles to create a more custom look and feel to your application.
+
+The Design System uses [gulp-autoprefixer](https://github.com/sindresorhus/gulp-autoprefixer) to automatically add vendor prefixes to the precompiled stylesheets (`css/uswds.min.css` and `css/uswds.css`) however prefixes will not be applied when using the Sass source files directly. If your project requires the use of Sass and vendor prefixes we recommend incorportaing a plugin such as [Autoprefixer](https://github.com/postcss/autoprefixer) into your build process.
 
 #### JavaScript
 


### PR DESCRIPTION
The docs site uses the Sass files directly from the uswds npm package - those Sass files do not include any browser prefixes by default, so it's up to developers to incorporate that functionality within their own build process. In the case of the docs site, we're already using Jekyll so this adds the `octopress-autoprefixer` gem to add the prefixes.

Fixes https://github.com/uswds/uswds-site/issues/523

Before: [Preview](https://designsystem.digital.gov/components/form-controls/#dropdown)
After: [Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds-site/bh-dropdown-fix/components/form-controls/#dropdown)