### PR TITLE
Fix code sample width 

### DIFF
--- a/css/styleguide.scss
+++ b/css/styleguide.scss
@@ -1114,9 +1114,7 @@ code {
 }
 
 .highlight {
-  pre {
-    max-width: $lead-max-width;
-  }
+  max-width: $lead-max-width;
 }
 
 // Code snippet boxes


### PR DESCRIPTION
When we changed the syntax highlighter, this changed how a class was named making the code sample full-width instead of the smaller width it's supposed to be.