### PR TITLE
Remove vulnerable gemfile package

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gem 'jekyll'
 gem 'json'
-gem 'open-uri-cached'
 gem 'jekyll-redirect-from'
 gem 'octopress-autoprefixer'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,6 @@ GEM
     octopress-autoprefixer (2.0.1)
       autoprefixer-rails
       jekyll (~> 3.0)
-    open-uri-cached (0.0.5)
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
     public_suffix (2.0.5)
@@ -66,7 +65,6 @@ DEPENDENCIES
   jekyll-redirect-from
   json
   octopress-autoprefixer
-  open-uri-cached
   rspec-core
   rspec-expectations
   scss_lint


### PR DESCRIPTION
The `open-uri-cached` has a vulnerability in it without any resolution path (and none in sight, it hasn't been updated in over 6 years 😬). This is used in conjunction with the Fractal plugin which grabs the components and displays them within the site. It adds some additional caching, but I think the way the plugin is configured it may not actually be adding much value so I've removed it.