### PR TITLE
Document correct font weight for "Lead paragraph"

### DIFF
--- a/_components/typography/02-pairing-and-styles.md
+++ b/_components/typography/02-pairing-and-styles.md
@@ -440,7 +440,7 @@ order: 02
         <div class="usa-width-one-half usa-end-row">
           <p class="usa-monospace">
             font-family: ‘Source Sans Pro’<br>
-            font-weight: 400<br>
+            font-weight: 300<br>
             font-size: 22px<br>
             line-height: 1.5em/33px
           </p>


### PR DESCRIPTION
Documents the correct font weight:

Fixes part of #566:

>Source Sans Pro headings, merriweather body.
>The text "Lead paragraph" is listed as being 400 weight, but is actually displayed at 300 weight.
