### PR TITLE
Implement new colors and color values

### DIFF
--- a/_data/uswds_tokens.yml
+++ b/_data/uswds_tokens.yml
@@ -143,7 +143,7 @@ colors:
     - token: white
       value: '#ffffff'
     - token: highlight
-      value: '#E6A100'
+      value: '#e6a100'
       var: $gold-30v
 
   transparent:
@@ -179,50 +179,81 @@ colors:
       value: '#171717'
       var: $ink
     - token: primary-lighter
-      value: '#dae9f6'
+      value: '#dae9f7'
       reverse: true
       var: $primary-lighter
     - token: primary-light
-      value: '#7cbdf0'
+      value: '#79bcf2'
       reverse: true
       var: $primary-light
     - token: primary
-      value: '#0f6bb2'
+      value: '#0069b4'
       var: $primary
     - token: primary-vivid
-      value: '#0e57da'
+      value: '#0052de'
       var: $primary-vivid
     - token: primary-dark
-      value: '#215192'
+      value: '#1e4f94'
       var: $primary-dark
     - token: primary-darker
-      value: '#122b4c'
+      value: '#112a4d'
       var: $primary-darker
+    - token: secondary-lighter
+      value: '#f7ddda'
+      reverse: true
+      var: $secondary-lighter
     - token: secondary-light
-      value: '#F08F8A'
+      value: '#f28f88'
       reverse: true
       var: $secondary-light
     - token: secondary
-      value: '#A93B3D'
+      value: '#d83731'
       var: $secondary
     - token: secondary-vivid
-      value: '#e6251b'
+      value: '#e82207'
       var: $secondary-vivid
     - token: secondary-dark
-      value: '#3b2523'
+      value: '#c31f0a'
       var: $secondary-dark
+    - token: secondary-darker
+      value: '#9c1503'
+      var: $secondary-darker
+    - token: accent-cool-lighter
+      value: '#e8f7fa'
+      var: $accent-cool-lighter
+      reverse: true
+    - token: accent-cool-light
+      value: '#9ddceb'
+      var: $accent-cool-light
+      reverse: true
     - token: accent-cool
-      value: '#fd7b28'
+      value: '#02c2e8'
       var: $accent-cool
+      reverse: true
     - token: accent-cool-dark
-      value: '#1babcf'
+      value: '#00abd1'
       var: $accent-cool-dark
+    - token: accent-cool-darker
+      value: '#2f6794'
+      var: $accent-cool-darker
+    - token: accent-warm-lighter
+      value: '#fce2c5'
+      var: $accent-warm-lighter
+      reverse: true
+    - token: accent-warm-light
+      value: '#ffba75'
+      var: $accent-warm-light
+      reverse: true
     - token: accent-warm
-      value: '#fd974c'
+      value: '#ff9742'
       var: $accent-warm
+      reverse: true
     - token: accent-warm-dark
-      value: '#fd7b28'
+      value: '#c25700'
       var: $accent-warm-dark
+    - token: accent-warm-darker
+      value: '#73563e'
+      var: $accent-warm-darker
   grayscale:
     - token: white
       value: '#ffffff'
@@ -252,37 +283,37 @@ colors:
       value: '#000000'
   basic:
     - token: red
-      value: '#e6251b'
+      value: '#e82207'
       var: $red-50v
     - token: orange
-      value: '#fd7b28'
+      value: '#ff7b0f'
       var: $orange-40v
     - token: gold
-      value: '#f8ae29'
+      value: '#e6a100'
       var: $gold-30v
     - token: yellow
-      value: '#fcd344'
+      value: '#edc730'
       var: $yellow-20v
     - token: green
-      value: '#548114'
+      value: '#73a22b'
       var: $green-40v
     - token: mint
-      value: '#20c688'
-      var: $mint-40v
+      value: '#04c786'
+      var: $mint-30v
     - token: cyan
-      value: '#1babcf'
+      value: '#02c2e8'
       var: $cyan-30v
     - token: blue
-      value: '#137cdb'
+      value: '#367bb4'
       var: $blue-50
     - token: indigo
-      value: '#6970c7'
+      value: '#8889db'
       var: $indigo-40
     - token: violet
-      value: '#836bb3'
+      value: '#b07bed'
       var: $violet-40v
     - token: magenta
-      value: '#df2d7a'
+      value: '#c84180'
       var: $magenta-50
 
 opacity:

--- a/css/_uswds-project-settings.scss
+++ b/css/_uswds-project-settings.scss
@@ -241,39 +241,53 @@ Palette colors
 ----------------------------------------
 */
 
-$theme-color-base-family:         'gray';
-$theme-color-base-lightest:       $theme-color-base-family, 2;
-$theme-color-base-lighter:        $theme-color-base-family, 5;
-$theme-color-base-light:          $theme-color-base-family, 10;
-$theme-color-base:                $theme-color-base-family, 30;
-$theme-color-base-dark:           $theme-color-base-family, 50;
-$theme-color-base-darker:         $theme-color-base-family, 70;
-$theme-color-base-darkest:        $theme-color-base-family, 90;
-$theme-color-text:                $theme-color-base-darkest;
+$theme-color-base-family:          'gray';
+$theme-color-base-lightest:        $theme-color-base-family, 2;
+$theme-color-base-lighter:         $theme-color-base-family, 5;
+$theme-color-base-light:           $theme-color-base-family, 10;
+$theme-color-base:                 $theme-color-base-family, 30;
+$theme-color-base-dark:            $theme-color-base-family, 50;
+$theme-color-base-darker:          $theme-color-base-family, 70;
+$theme-color-base-darkest:         $theme-color-base-family, 90;
+$theme-color-text:                 $theme-color-base-darkest;
 
-$theme-color-primary-family:      'blue';
-$theme-color-primary-lighter:     $theme-color-primary-family, 10;
-$theme-color-primary-light:       $theme-color-primary-family, 30;
-$theme-color-primary:             $theme-color-primary-family, 60, vivid;
-$theme-color-primary-vivid:       'blue-warm', 60, vivid;
-$theme-color-primary-dark:        'blue-warm', 70, vivid;
-$theme-color-primary-darker:      'blue-warm', 80, vivid;
+$theme-color-primary-family:       'blue';
+$theme-color-primary-lightest:     false;
+$theme-color-primary-lighter:      $theme-color-primary-family, 10;
+$theme-color-primary-light:        $theme-color-primary-family, 30;
+$theme-color-primary:              $theme-color-primary-family, 60, vivid;
+$theme-color-primary-vivid:        'blue-warm', 60, vivid;
+$theme-color-primary-dark:         'blue-warm', 70, vivid;
+$theme-color-primary-darker:       'blue-warm', 80, vivid;
+$theme-color-primary-darkest:      false;
 
-$theme-color-secondary-family:    'red';
-$theme-color-secondary-lighter:   $theme-color-secondary-family, 10;
-$theme-color-secondary-light:     $theme-color-secondary-family, 30;
-$theme-color-secondary:           $theme-color-secondary-family, 60;
-$theme-color-secondary-vivid:     $theme-color-secondary-family, 50, vivid;
-$theme-color-secondary-dark:      $theme-color-secondary-family, 70, vivid;
-$theme-color-secondary-darker:    false;
+$theme-color-secondary-family:     'red';
+$theme-color-secondary-lightest:   false;
+$theme-color-secondary-lighter:    $theme-color-secondary-family, 10;
+$theme-color-secondary-light:      $theme-color-secondary-family, 30;
+$theme-color-secondary:            $theme-color-secondary-family, 50;
+$theme-color-secondary-vivid:      $theme-color-secondary-family, 50, vivid;
+$theme-color-secondary-dark:       $theme-color-secondary-family, 60, vivid;
+$theme-color-secondary-darker:     $theme-color-secondary-family, 70, vivid;
+$theme-color-secondary-darkest:    false;
 
-$theme-color-accent-warm-family:  'orange';
-$theme-color-accent-warm:         $theme-color-accent-warm-family, 30, vivid;
-$theme-color-accent-warm-dark:    $theme-color-accent-warm-family, 50, vivid;
+$theme-color-accent-warm-family:   'orange';
+$theme-color-accent-warm-lightest: false;
+$theme-color-accent-warm-lighter:  $theme-color-accent-warm-family, 10;
+$theme-color-accent-warm-light:    $theme-color-accent-warm-family, 20, vivid;
+$theme-color-accent-warm:          $theme-color-accent-warm-family, 30, vivid;
+$theme-color-accent-warm-dark:     $theme-color-accent-warm-family, 50, vivid;
+$theme-color-accent-warm-darker:   $theme-color-accent-warm-family, 60;
+$theme-color-accent-warm-darkest:  false;
 
-$theme-color-accent-cool-family:  'cyan';
-$theme-color-accent-cool:         $theme-color-accent-cool-family, 30, vivid;
-$theme-color-accent-cool-dark:    $theme-color-accent-cool-family, 40, vivid;
+$theme-color-accent-cool-family:   'cyan';
+$theme-color-accent-cool-lightest: false;
+$theme-color-accent-cool-lighter:  $theme-color-accent-cool-family, 5;
+$theme-color-accent-cool-light:    $theme-color-accent-cool-family, 20;
+$theme-color-accent-cool:          $theme-color-accent-cool-family, 30, vivid;
+$theme-color-accent-cool-dark:     $theme-color-accent-cool-family, 40, vivid;
+$theme-color-accent-cool-darker:   blue, 60;
+$theme-color-accent-cool-darkest:  false;
 
 /*
 ----------------------------------------

--- a/package-lock.json
+++ b/package-lock.json
@@ -11396,7 +11396,7 @@
       }
     },
     "uswds": {
-      "version": "github:uswds/uswds#1662708d993a38db7969220927a5ef544bcfd1e2",
+      "version": "github:uswds/uswds#f2db66666dc298c6125f7de5009a7daef9d597ad",
       "from": "github:uswds/uswds#release-2.0",
       "requires": {
         "@types/node": "^8.5.5",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "jquery": "^3.3.1",
     "normalize.css": "^8.0.0",
-    "uswds": "github:uswds/uswds#dw-fix-colors"
+    "uswds": "github:uswds/uswds#release-2.0"
   },
   "devDependencies": {
     "axe-core": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "jquery": "^3.3.1",
     "normalize.css": "^8.0.0",
-    "uswds": "github:uswds/uswds#release-2.0"
+    "uswds": "github:uswds/uswds#dw-fix-colors"
   },
   "devDependencies": {
     "axe-core": "^2.6.1",


### PR DESCRIPTION
Dependent on https://github.com/uswds/uswds/pull/2566

- - -

Add new colors and values from USWDS
- Use correct hex values
- Assure all grade 50 colors are AA against white and black
- Sync theme colors with current USWDS defaults
- Add more darker and lighter variants for some theme families

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds-site/dw-update-colors)