### PR TITLE
Update inactive sections to say they're not included

### DIFF
--- a/_components/utilities/text-styles.md
+++ b/_components/utilities/text-styles.md
@@ -177,13 +177,13 @@ colors:
       </div>
     </section>
     <section class="utility-examples">
-      <p class="utility-example-container-condensed text-thin">.text-thin</p>
+      <p class="utility-example-container-condensed text-thin">.text-thin <span class="text-base-dark">(Note: not included in default set)</span></p>
       <p class="utility-example-container-condensed text-light">.text-light</p>
       <p class="utility-example-container-condensed text-normal">.text-normal</p>
-      <p class="utility-example-container-condensed text-medium">.text-medium</p>
-      <p class="utility-example-container-condensed text-semibold">.text-semibold</p>
+      <p class="utility-example-container-condensed text-medium">.text-medium <span class="text-base-dark">(Note: not included in default set)</span></p>
+      <p class="utility-example-container-condensed text-semibold">.text-semibold <span class="text-base-dark">(Note: not included in default set)</span></p>
       <p class="utility-example-container-condensed text-bold">.text-bold</p>
-      <p class="utility-example-container-condensed text-heavy border-0">.text-heavy</p>
+      <p class="utility-example-container-condensed text-heavy border-0">.text-heavy <span class="text-base-dark">(Note: not included in default set)</span></p>
     </section>
   </section>
 

--- a/_components/utilities/text-styles.md
+++ b/_components/utilities/text-styles.md
@@ -177,13 +177,13 @@ colors:
       </div>
     </section>
     <section class="utility-examples">
-      <p class="utility-example-container-condensed text-thin">.text-thin <span class="text-base-dark">(Note: not included in default set)</span></p>
+      <p class="utility-example-container-condensed text-thin">.text-thin <span class="text-base-dark">(<b>Note:</b> not included in default set)</span></p>
       <p class="utility-example-container-condensed text-light">.text-light</p>
       <p class="utility-example-container-condensed text-normal">.text-normal</p>
-      <p class="utility-example-container-condensed text-medium">.text-medium <span class="text-base-dark">(Note: not included in default set)</span></p>
-      <p class="utility-example-container-condensed text-semibold">.text-semibold <span class="text-base-dark">(Note: not included in default set)</span></p>
+      <p class="utility-example-container-condensed text-medium">.text-medium <span class="text-base-dark">(<b>Note:</b>  not included in default set)</span></p>
+      <p class="utility-example-container-condensed text-semibold">.text-semibold <span class="text-base-dark">(<b>Note:</b>  not included in default set)</span></p>
       <p class="utility-example-container-condensed text-bold">.text-bold</p>
-      <p class="utility-example-container-condensed text-heavy border-0">.text-heavy <span class="text-base-dark">(Note: not included in default set)</span></p>
+      <p class="utility-example-container-condensed text-heavy border-0">.text-heavy <span class="text-base-dark">(<b>Note:</b>  not included in default set)</span></p>
     </section>
   </section>
 
@@ -238,6 +238,7 @@ colors:
         <p class="font-sans-8 text-tabular margin-0">825,489,012</p>
         <p class="font-sans-8 text-tabular margin-0">112,051,928</p>
         <p class="utility-class margin-top-2">.text-tabular</p>
+        <p class="margin-bottom-05"><b>Note:</b> not included in default set</p>
       </div>
       <div class="utility-example-container-condensed border-0">
         <p class="font-sans-8 text-no-tabular margin-0">123,456,789</p>


### PR DESCRIPTION
Add note to font weight and tabular numerals sections saying certain utilities are not included in the default set.

### This is what it looks like
<img width="532" alt="screen shot 2018-06-28 at 11 51 43 am" src="https://user-images.githubusercontent.com/5249443/42054655-d2d7ca16-7ac9-11e8-8d26-f02d49c41b2f.png">

<img width="471" alt="screen shot 2018-06-28 at 11 51 53 am" src="https://user-images.githubusercontent.com/5249443/42054660-d6318bac-7ac9-11e8-8dd1-7d0529751bf4.png">

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds-site/update-innactive-sections/text-styles/)

Refs #575 