### PR TITLE
Remove custom focus

### DIFF
--- a/css/_project-custom.scss
+++ b/css/_project-custom.scss
@@ -1659,10 +1659,6 @@ html {
   font-size: $theme-root-font-size;
 }
 
-*:focus {
-  @include u-outline(.5, $highlight);
-}
-
 .is-inverse {
   @include add-font-smoothing;
 }


### PR DESCRIPTION
Removes the custom focus on the site that was creating two focus colors.

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds-site/remove-custom-focus)