### PR TITLE
USWDS - Docs: Fixes frontmatter href fragment ids to fix links

### DIFF
--- a/pages/performance/how.md
+++ b/pages/performance/how.md
@@ -8,9 +8,9 @@ subnav:
   - text: Introduction
     href: '#introduction'
   - text: Choosing metrics & tools
-    href: '#choosing-metrics-amp-tools'
+    href: '#choosing-metrics--tools'
   - text: Setting budgets & goals
-    href: '#setting-budgets-amp-goals'
+    href: '#setting-budgets--goals'
   - text: Adding site tracking
     href: '#adding-site-tracking'
 ---


### PR DESCRIPTION
I noticed the first two ordered list links at the top of this page don't link to their respective h2s; this change corrects the ids for the href values in the frontmatter.