### PR TITLE
Fix download link redirect

### DIFF
--- a/_includes/download-buttons.html
+++ b/_includes/download-buttons.html
@@ -1,6 +1,6 @@
 <ul class="usa-button-list usa-unstyled-list">
   <li>
-    <a class="usa-button" href="{{ site.baseurl }}/getting-started/download/" onclick="ga('send', 'event', 'Downloaded code and design files', 'Clicked Download code and design files from inside site');">
+    <a class="usa-button" href="{{ site.baseurl }}/download/" onclick="ga('send', 'event', 'Downloaded code and design files', 'Clicked Download code and design files from inside site');">
       Download code and design files
     </a>
   </li>

--- a/pages/documentation/getting-started/download.html
+++ b/pages/documentation/getting-started/download.html
@@ -5,7 +5,6 @@ title: Download code and design files
 category: Documentation
 lead: Here you'll find all the assets you need to start working with the Design System
 redirect_from:
-  - /download/
   - /getting-started/download/
 ---
 


### PR DESCRIPTION
Removes an infinite loop redirect from our download page

[Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds-site/dw-dl-redirect/)