### PR TITLE
Copy compiled css file to _site

### DIFF
--- a/config/gulp/sass.js
+++ b/config/gulp/sass.js
@@ -19,7 +19,8 @@ gulp.task('build-sass', function () {
         beautify: true,
       })
     )
-    .pipe(gulp.dest('assets/css'));
+    .pipe(gulp.dest('assets/css'))
+    .pipe(gulp.dest('_site/assets/css'));;
 });
 
 gulp.task('scss-lint', function (done) {


### PR DESCRIPTION

## Copy compiled css file to _site

## Description

Since we aren't relying on jeykll to compile our sass files for us, have the gulp task copy the compiled`styleguide.css` file into `_site`
