### PR TITLE
Fix remaining stylelint issues

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -14,7 +14,7 @@ linters:
   ColorVariable:
     enabled: true
   Comment:
-    enabled: true
+    enabled: false
   DebugStatement:
     enabled: true
   DeclarationOrder:

--- a/css/_project-custom.scss
+++ b/css/_project-custom.scss
@@ -400,15 +400,13 @@ h2 + .tooltip {
   margin-top: 0;
 }
 
-a {
-  &.cta {
-    img {
-      height: 1.5rem;
-      margin-right: 0.4rem;
-      position: relative;
-      top: 2px;
-      vertical-align: baseline;
-    }
+.cta {
+  img {
+    height: 1.5rem;
+    margin-right: 0.4rem;
+    position: relative;
+    top: 2px;
+    vertical-align: baseline;
   }
 }
 
@@ -1042,14 +1040,8 @@ code {
     letter-spacing: -0.2em;
     content: '\00a0';
   }
-}
 
-.highlight {
-  max-width: $lead-max-width;
-}
-
-a {
-  code {
+  a & {
     @include u-border(1px, $blue-50v);
     @include u-bg(transparent);
 
@@ -1058,6 +1050,10 @@ a {
       @include u-text(white);
     }
   }
+}
+
+.highlight {
+  max-width: $lead-max-width;
 }
 
 // Code snippet boxes ----------------- //

--- a/css/_project-custom.scss
+++ b/css/_project-custom.scss
@@ -321,12 +321,6 @@ body {
   > h2 {
     color: $color-primary-darker;
   }
-
-  section {
-    > .tooltip {
-      margin-top: 56px;
-    }
-  }
 }
 
 .components-library-link {
@@ -376,18 +370,6 @@ body {
 .label-done {
   @extend %label-maturity;
   background-color: $color-green-lightest;
-}
-
-h1 + .tooltip {
-  a {
-    margin-top: 1.7rem;
-  }
-}
-
-h2 + .tooltip {
-  a {
-    margin-top: 1.3rem;
-  }
 }
 
 .heading-margin-alt {
@@ -1558,55 +1540,6 @@ code {
   .preview {
     img {
       box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3); // scss-lint:disable ColorVariable
-    }
-  }
-}
-
-// Custom tooltip styles -------------- //
-
-// TODO: Do we nee this? Not using tooltips
-// Tooltip container
-.tooltip {
-  display: inline-block;
-  position: absolute;
-
-  // Show the tooltip text when you mouse over the tooltip container
-  &:hover {
-    .tooltip-text {
-      opacity: 1;
-    }
-  }
-}
-
-.tooltip-text {
-  display: none;
-
-  @include media($medium-screen) {
-    @include margin(0 null 0 20px);
-    background-color: $color-gray-dark;
-    border-radius: $border-radius;
-    bottom: 100%;
-    color: $color-white;
-    display: block;
-    font-size: 14px;
-    left: 50%;
-    padding: 7px 10px;
-    width: 267px;
-    opacity: 0;
-    position: absolute; // Position the tooltip text
-    transition: all 0.1s ease-in-out;
-    transition-delay: 0.1s;
-    z-index: 1;
-
-    &::after {
-      border-width: 5px;
-      border-style: solid;
-      border-color: $color-base transparent transparent transparent; // scss-lint:disable Shorthand
-      content: ' ';
-      left: 10%;
-      margin-left: -12px;
-      position: absolute;
-      top: 100%; // At the bottom of the tooltip
     }
   }
 }

--- a/css/_project-custom.scss
+++ b/css/_project-custom.scss
@@ -1557,7 +1557,7 @@ code {
 .page-page-templates {
   .preview {
     img {
-      box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+      box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3); // scss-lint:disable ColorVariable
     }
   }
 }
@@ -1622,7 +1622,7 @@ code {
 // Demo fixed footer
 .demo-footer {
   background-color: $color-gray-dark;
-  box-shadow: 0 -2px 4px 0 rgba(0, 0, 0, 0.5);
+  box-shadow: 0 -2px 4px 0 rgba(0, 0, 0, 0.5); // scss-lint:disable ColorVariable
   bottom: 0;
   position: fixed;
   width: 100%;

--- a/css/_project-custom.scss
+++ b/css/_project-custom.scss
@@ -1050,7 +1050,7 @@ code {
 
     &:hover {
       @include u-bg($blue-50v);
-      @include u-text(white);
+      @include u-text('white');
     }
   }
 }
@@ -1838,7 +1838,7 @@ strong {
 }
 
 .output-token {
-  @include u-bg(white);
+  @include u-bg('white');
   @include u-border(1px, $gray-10);
   @include u-font('mono', 4);
   @include u-padding-x(0.5);
@@ -1862,7 +1862,7 @@ strong {
   @include u-padding-y(0);
   @include u-padding-x(.5);
   @include u-radius(sm);
-  @include u-text(white);
+  @include u-text('white');
 }
 
 // Ensure that inline lists do not have a bottom margin
@@ -1883,14 +1883,14 @@ li {
 }
 
 .utilities-properties {
-  @include u-bg(white);
+  @include u-bg('white');
   @include u-border(1px, $gray-10);
   @include u-padding(2);
   @include u-radius(md);
 }
 
 .utilities-property {
-  @include u-bg(white);
+  @include u-bg('white');
   @include u-display(inline-block);
   @include u-margin-top(0);
   @include u-padding(.5);
@@ -1914,7 +1914,7 @@ li {
   @include u-text(normal);
 
   code {
-    @include u-bg(white);
+    @include u-bg('white');
     @include u-border(1px);
     @include u-display(inline-block);
     @include u-font(mono, 6);
@@ -1934,7 +1934,7 @@ li {
 }
 
 .utility {
-  @include u-bg(white);
+  @include u-bg('white');
   @include u-border(1px, $gray-10);
   @include u-margin-y(2);
   @include u-padding-bottom(1);
@@ -1986,7 +1986,7 @@ li {
 
 .utility-scope-button-disabled {
   @extend .utility-scope-button;
-  @include u-bg(white);
+  @include u-bg('white');
   @include u-border(1px, $gray-20);
   @include u-text($gray-20, strike);
 }
@@ -1998,11 +1998,11 @@ li {
     @extend .utility-scope-button;
     @include add-font-smoothing;
     @include u-bg($blue-50v);
-    @include u-text(white, no-underline);
+    @include u-text('white', no-underline);
 
     &:hover {
       @include u-bg($gray-80);
-      @include u-text(white);
+      @include u-text('white');
     }
   }
 }
@@ -2043,7 +2043,7 @@ li {
 
 .utility-value-color {
   @extend .utility-class;
-  @include u-bg(white);
+  @include u-bg('white');
   @include u-border(1px, $gray-10);
   @include u-margin-top(0);
   @include u-text(light, no-wrap, lowercase);

--- a/css/_project-custom.scss
+++ b/css/_project-custom.scss
@@ -146,7 +146,10 @@ body {
   li > button {
     @include button-unstyled;
     font-weight: $font-normal;
-    padding: 1.4rem 1.5rem 1rem 1.8rem;
+    padding-bottom: 1rem;
+    padding-left: 1.8rem;
+    padding-right: 1.5rem;
+    padding-top: 1.4rem;
 
     &:hover {
       background-color: $color-gray-lightest;
@@ -1330,6 +1333,7 @@ code {
 .page-home {
   .usa-graphic_list {
     .usa-media_block-body {
+      // scss-lint:disable SelectorDepth
       > *:first-child {
         font-size: $media-block-header-font-size;
         margin-top: 0;
@@ -1388,6 +1392,7 @@ code {
 
   // Override for 4x1 media grid when it collapses to 2x2
   @media screen and (max-width: $large-screen) and (min-width: $medium-screen) {
+    // scss-lint:disable SelectorDepth
     .usa-graphic_list .usa-graphic_list-row .usa-media_block:nth-child(-n+2) {
       margin-bottom: 6rem;
     }
@@ -1499,7 +1504,7 @@ code {
 // Override max-width to ensure code blocks are wide enough
 .page-for-developers {
   ol {
-    max-width: 100% !important;
+    max-width: 100% !important; // scss-lint:disable ImportantRule
 
     p {
       max-width: $text-max-width;
@@ -1537,6 +1542,7 @@ code {
     }
   }
 
+  // scss-lint:disable SelectorDepth
   [class*="grid-gap"] {
     [class*="grid-col"] > * {
       background-color: $color-white;
@@ -1558,6 +1564,7 @@ code {
 
 // Custom tooltip styles -------------- //
 
+// TODO: Do we nee this? Not using tooltips
 // Tooltip container
 .tooltip {
   display: inline-block;
@@ -1594,7 +1601,7 @@ code {
     &::after {
       border-width: 5px;
       border-style: solid;
-      border-color: $color-base transparent transparent transparent;
+      border-color: $color-base transparent transparent transparent; // scss-lint:disable Shorthand
       content: ' ';
       left: 10%;
       margin-left: -12px;

--- a/css/_project-custom.scss
+++ b/css/_project-custom.scss
@@ -1905,6 +1905,18 @@ li {
   @include u-font(serif, 8);
   @include u-margin(0);
   @include u-text(normal);
+
+  code {
+    @include u-bg(white);
+    @include u-border(1px);
+    @include u-display(inline-block);
+    @include u-font(mono, 6);
+    @include u-margin-right(2px);
+    @include u-padding-x(0);
+    @include u-padding-y(2px);
+    @include u-radius(md);
+    @include u-text(light);
+  }
 }
 
 .utilities-section-helper {
@@ -1985,20 +1997,6 @@ li {
       @include u-bg($gray-80);
       @include u-text(white);
     }
-  }
-}
-
-.utilities-section-title {
-  code {
-    @include u-bg(white);
-    @include u-border(1px);
-    @include u-display(inline-block);
-    @include u-font(mono, 6);
-    @include u-margin-right(2px);
-    @include u-padding-x(0);
-    @include u-padding-y(2px);
-    @include u-radius(md);
-    @include u-text(light);
   }
 }
 

--- a/css/_uswds-project-settings.scss
+++ b/css/_uswds-project-settings.scss
@@ -313,7 +313,7 @@ $theme-color-accent-cool-lighter:  $theme-color-accent-cool-family, 5;
 $theme-color-accent-cool-light:    $theme-color-accent-cool-family, 20;
 $theme-color-accent-cool:          $theme-color-accent-cool-family, 30, vivid;
 $theme-color-accent-cool-dark:     $theme-color-accent-cool-family, 40, vivid;
-$theme-color-accent-cool-darker:   blue, 60;
+$theme-color-accent-cool-darker:   'blue', 60;
 $theme-color-accent-cool-darkest:  false;
 
 /*

--- a/css/_uswds-project-utilities-settings.scss
+++ b/css/_uswds-project-utilities-settings.scss
@@ -646,7 +646,10 @@ $float-manual-values: ();
 
 $font-palettes: (
   'palette-font-theme-all',
-  'palette-font-theme-roles-all'
+  'palette-font-theme-roles-all',
+  'palette-font-uswds-sans-all',
+  'palette-font-uswds-serif-all',
+  'palette-font-uswds-mono-all'
 );
 $font-manual-values: ();
 

--- a/css/_uswds-project-utilities-settings.scss
+++ b/css/_uswds-project-utilities-settings.scss
@@ -61,7 +61,7 @@ $align-items-settings: (
   responsive:   false,
   active:       false,
   focus:        false,
-  hover:        true,
+  hover:        false,
   visited:      false
 );
 
@@ -79,7 +79,7 @@ $border-settings: (
   responsive:   true,
   active:       false,
   focus:        false,
-  hover:        true,
+  hover:        false,
   visited:      false
 );
 

--- a/css/_uswds-project-utilities-settings.scss
+++ b/css/_uswds-project-utilities-settings.scss
@@ -11,7 +11,7 @@ USWDS UTILITIES SETTINGS
 ----------------------------------------
 */
 
-$utilities-use-important:     false;
+$utilities-use-important:     true;
 $output-all-utilities:        true;
 
 /*
@@ -61,7 +61,7 @@ $align-items-settings: (
   responsive:   false,
   active:       false,
   focus:        false,
-  hover:        false,
+  hover:        true,
   visited:      false
 );
 
@@ -112,7 +112,7 @@ $border-style-settings: (
 
 $border-width-settings: (
   output:       true,
-  responsive:   false,
+  responsive:   true,
   active:       false,
   focus:        false,
   hover:        false,

--- a/css/_uswds-project-utilities-settings.scss
+++ b/css/_uswds-project-utilities-settings.scss
@@ -11,14 +11,14 @@ USWDS UTILITIES SETTINGS
 ----------------------------------------
 */
 
-$utilities-use-important:     true;
+$utilities-use-important:     false;
 $output-all-utilities:        true;
 
 /*
 ----------------------------------------
 Global colors
 ----------------------------------------
-The following palettes will be added to
+The following plugins will be added to
 - background-color
 - border-color
 - color
@@ -56,15 +56,6 @@ $add-list-reset-settings: (
   visited:      false
 );
 
-$pin-settings: (
-  output:       true,
-  responsive:   false,
-  active:       false,
-  focus:        false,
-  hover:        false,
-  visited:      false
-);
-
 $align-items-settings: (
   output:       true,
   responsive:   false,
@@ -88,7 +79,7 @@ $border-settings: (
   responsive:   true,
   active:       false,
   focus:        false,
-  hover:        false,
+  hover:        true,
   visited:      false
 );
 
@@ -121,7 +112,7 @@ $border-style-settings: (
 
 $border-width-settings: (
   output:       true,
-  responsive:   true,
+  responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
@@ -425,6 +416,15 @@ $padding-settings: (
   visited:      false
 );
 
+$pin-settings: (
+  output:       true,
+  responsive:   false,
+  active:       false,
+  focus:        false,
+  hover:        false,
+  visited:      false
+);
+
 $position-settings: (
   output:       true,
   responsive:   false,
@@ -555,19 +555,17 @@ $add-aspect-manual-values: ();
 
 // .align-items
 
-$align-items-palettes: ( 'palette-standard-align-items' );
+$align-items-palettes: ('palette-standard-align-items');
 $align-items-manual-values: ();
 
 // .background-color
 
-$background-color-palettes: (
-  'palette-colors-uswds-all'
-);
+$background-color-palettes: ();
 $background-color-manual-values: ();
 
 // .border
 
-$border-palettes: ( 'palette-standard-border' );
+$border-palettes: ('palette-standard-border');
 $border-manual-values: ();
 
 // .border-color
@@ -577,213 +575,211 @@ $border-color-manual-values: ();
 
 // .border-radius
 
-$border-radius-palettes: ( 'palette-standard-border-radius' );
+$border-radius-palettes: ('palette-standard-border-radius');
 $border-radius-manual-values: ();
 
 // .border-style
 
-$border-style-palettes: ( 'palette-standard-border-style' );
+$border-style-palettes: ('palette-standard-border-style');
 $border-style-manual-values: ();
+
+// .border-width
+
+$border-width-palettes: ('palette-standard-border-width');
+$border-width-manual-values: ();
 
 // .bottom
 
-$bottom-palettes: ( 'palette-standard-bottom' );
+$bottom-palettes: ('palette-standard-bottom');
 
 $bottom-manual-values: ();
 
 // .box-shadow
 
-$box-shadow-palettes: (
-  /*
-  */
-  'palette-standard-box-shadow'
-);
+$box-shadow-palettes: ('palette-standard-box-shadow');
 
 $box-shadow-manual-values: ();
 
 // .circle
 
-$circle-palettes: ( 'palette-standard-circle' );
+$circle-palettes: ('palette-standard-circle');
 $circle-manual-values: ();
 
 // .color
 
-$color-palettes: ( 'palette-colors-uswds-all' );
+$color-palettes: ();
 $color-manual-values: ();
 
 // .cursor
 
-$cursor-palettes: ( 'palette-standard-cursor' );
+$cursor-palettes: ('palette-standard-cursor');
 $cursor-manual-values: ();
 
 // .display
 
-$display-palettes: ( 'palette-standard-display' );
+$display-palettes: ('palette-standard-display');
 $display-manual-values: ();
 
 // .flex
 
-$flex-palettes: ( 'palette-standard-flex' );
+$flex-palettes: ('palette-standard-flex');
 $flex-manual-values: ();
 
 // .flex-direction
 
-$flex-direction-palettes: ( 'palette-standard-flex-direction' );
+$flex-direction-palettes: ('palette-standard-flex-direction');
 $flex-direction-manual-values: ();
 
 // .flex-wrap
 
-$flex-wrap-palettes: ( 'palette-standard-flex-wrap' );
+$flex-wrap-palettes: ('palette-standard-flex-wrap');
 $flex-wrap-manual-values: ();
 
 // .float
 
-$float-palettes: ( 'palette-standard-float' );
+$float-palettes: ('palette-standard-float');
 $float-manual-values: ();
 
 // .font
 
 $font-palettes: (
   'palette-font-theme-all',
-  'palette-font-theme-roles-all',
-  'palette-font-uswds-sans-all',
-  'palette-font-uswds-serif-all',
-  'palette-font-uswds-mono-all'
+  'palette-font-theme-roles-all'
 );
 $font-manual-values: ();
 
 // .font-family
 
-$font-family-palettes: ( 'palette-standard-font-family' );
+$font-family-palettes: ('palette-standard-font-family');
 $font-family-manual-values: ();
 
 // .font-feature-settings
 
-$font-feature-palettes: ( 'palette-standard-font-feature-settings' );
+$font-feature-palettes: ('palette-standard-font-feature-settings');
 $font-feature-manual-values: ();
 
 // .font-style
 
-$font-style-palettes: ( 'palette-standard-font-style' );
+$font-style-palettes: ('palette-standard-font-style');
 $font-style-manual-values: ();
 
 // .font-weight
 
-$font-weight-palettes: ( 'palette-standard-font-weight' );
+$font-weight-palettes: ('palette-standard-font-weight');
 $font-weight-manual-values: ();
 
 // .height
 
-$height-palettes: ( 'palette-standard-height' );
+$height-palettes: ('palette-standard-height');
 $height-manual-values: ();
 
 // .justify-content
 
-$justify-content-palettes: ( 'palette-standard-justify-content' );
+$justify-content-palettes: ('palette-standard-justify-content');
 $justify-content-manual-values: ();
 
 // .left
 
-$left-palettes: ( 'palette-standard-left' );
+$left-palettes: ('palette-standard-left');
 $left-manual-values: ();
 
 // .letter-spacing
 
-$letter-spacing-palettes: ( 'palette-standard-letter-spacing' );
+$letter-spacing-palettes: ('palette-standard-letter-spacing');
 $letter-spacing-manual-values: ();
 
 // .line-height
 
-$line-height-palettes: ( 'palette-standard-line-height' );
+$line-height-palettes: ('palette-standard-line-height');
 $line-height-manual-values: ();
 
 // .margin
 
-$margin-palettes: ( 'palette-standard-margin' );
+$margin-palettes: ('palette-standard-margin');
 $margin-manual-values: ();
-$margin-vertical-palettes: ( 'palette-standard-margin-vertical' );
+$margin-vertical-palettes: ('palette-standard-margin-vertical');
 $margin-vertical-manual-values: ();
-$margin-horizontal-palettes: ( 'palette-standard-margin-horizontal' );
+$margin-horizontal-palettes: ('palette-standard-margin-horizontal');
 $margin-horizontal-manual-values: ();
 
 // .max-height
 
-$max-height-palettes: ( 'palette-standard-max-height' );
+$max-height-palettes: ('palette-standard-max-height');
 $max-height-manual-values: ();
 
 // .max-width
 
-$max-width-palettes: ( 'palette-standard-max-width' );
+$max-width-palettes: ('palette-standard-max-width');
 $max-width-manual-values: ();
 
 // .measure
 
-$measure-palettes: ( 'palette-standard-measure' );
+$measure-palettes: ('palette-standard-measure');
 $measure-manual-values: ();
 
 // .min-height
 
-$min-height-palettes: ( 'palette-standard-min-height' );
+$min-height-palettes: ('palette-standard-min-height');
 $min-height-manual-values: ();
 
 // .min-width
 
-$min-width-palettes: ( 'palette-standard-min-width' );
+$min-width-palettes: ('palette-standard-min-width');
 $min-width-manual-values: ();
 
 // .opacity
 
-$opacity-palettes: ( 'palette-standard-opacity' );
+$opacity-palettes: ('palette-standard-opacity');
 $opacity-manual-values: ();
 
 // .order
 
-$order-palettes: ( 'palette-standard-order' );
+$order-palettes: ('palette-standard-order');
 $order-manual-values: ();
 
 // .outline
 
-$outline-palettes: ( 'palette-standard-outline' );
+$outline-palettes: ('palette-standard-outline');
 $outline-manual-values: ();
 
 // .outline-color
 
-$outline-color-palettes: ( 'palette-standard-outline-color' );
+$outline-color-palettes: ('palette-standard-outline-color');
 $outline-color-manual-values: ();
 
 // .overflow
 
-$overflow-palettes: ( 'palette-standard-overflow' );
+$overflow-palettes: ('palette-standard-overflow');
 $overflow-manual-values: ();
 
 // .padding
 
-$padding-palettes: ( 'palette-standard-padding' );
+$padding-palettes: ('palette-standard-padding');
 $padding-manual-values: ();
 
 // .position
 
-$position-palettes: ( 'palette-standard-position' );
+$position-palettes: ('palette-standard-position');
 $position-manual-values: ();
 
 // .right
 
-$right-palettes: ( 'palette-standard-right' );
+$right-palettes: ('palette-standard-right');
 $right-manual-values: ();
 
 // .square
 
-$square-palettes: ( 'palette-standard-square' );
+$square-palettes: ('palette-standard-square');
 $square-manual-values: ();
 
 // .text-align
 
-$text-align-palettes: ( 'palette-standard-text-align' );
+$text-align-palettes: ('palette-standard-text-align');
 $text-align-manual-values: ();
 
 // .text-decoration
 
-$text-decoration-palettes: ( 'palette-standard-text-decoration' );
+$text-decoration-palettes: ('palette-standard-text-decoration');
 $text-decoration-manual-values: ();
 
 // .text-decoration-color
@@ -793,36 +789,35 @@ $text-decoration-color-manual-values: ();
 
 // .text-indent
 
-$text-indent-palettes: ( 'palette-standard-text-indent' );
+$text-indent-palettes: ('palette-standard-text-indent');
 $text-indent-manual-values: ();
 
 // .text-transform
 
-$text-transform-palettes: ( 'palette-standard-text-transform' );
+$text-transform-palettes: ('palette-standard-text-transform');
 $text-transform-manual-values: ();
 
 // .top
 
-
-$top-palettes: ( 'palette-standard-top' );
+$top-palettes: ('palette-standard-top');
 $top-manual-values: ();
 
 // .vertical-align
 
-$vertical-align-palettes: ( 'palette-standard-vertical-align' );
+$vertical-align-palettes: ('palette-standard-vertical-align');
 $vertical-align-manual-values: ();
 
 // .white-space
 
-$whitespace-palettes: ( 'palette-standard-white-space' );
+$whitespace-palettes: ('palette-standard-white-space');
 $whitespace-manual-values: ();
 
 // .width
 
-$width-palettes: ( 'palette-standard-width' );
+$width-palettes: ('palette-standard-width');
 $width-manual-values: ();
 
 // .z-index
 
-$z-index-palettes: ( 'palette-standard-z-index' );
+$z-index-palettes: ('palette-standard-z-index');
 $z-index-manual-values: ();

--- a/css/_uswds-project-utilities-settings.scss
+++ b/css/_uswds-project-utilities-settings.scss
@@ -609,7 +609,7 @@ $circle-manual-values: ();
 
 // .color
 
-$color-palettes: ();
+$color-palettes: ('palette-colors-uswds-all');
 $color-manual-values: ();
 
 // .cursor

--- a/css/_uswds-project-utilities-settings.scss
+++ b/css/_uswds-project-utilities-settings.scss
@@ -560,7 +560,9 @@ $align-items-manual-values: ();
 
 // .background-color
 
-$background-color-palettes: ();
+$background-color-palettes: (
+  'palette-colors-uswds-all'
+);
 $background-color-manual-values: ();
 
 // .border

--- a/package-lock.json
+++ b/package-lock.json
@@ -11083,7 +11083,7 @@
       }
     },
     "uswds": {
-      "version": "github:uswds/uswds#e5cf80e77b50aa6f7c6e80f5c5ddd2df965cb2b4",
+      "version": "github:uswds/uswds#c026562fc1357d5df312fe4bc4a1cb5a8034f0ea",
       "from": "github:uswds/uswds#release-2.0",
       "requires": {
         "@types/node": "^8.5.5",


### PR DESCRIPTION
Fixes additional stylelint warnings in `css/_project-custom.scss`

The issues left in `css/_project-custom.scss` are related to ColorKeyword and ColorVariable that were caused by this: `@include u-text(white);`
```
[19:41:05] _project-custom.scss:2041 [W] ColorKeyword: Color `white` should be written in hexadecimal form as `#ffffff`
[19:41:05] _project-custom.scss:2041 [W] ColorVariable: Color literals like `white` should only be used in variable declarations; they should be referred to via variable everywhere else.
```

What should we do about these @thisisdano? We probably have a lot of these in the main repo, or will.
 
---
In other files, there are more stylelint warnings, which tells me we're not linting these files in the uswds main repo bc they were copied from it:
```
Comment: Use `//` comments everywhere
[20:01:00] 18 issues found in /Users/mayaben-ari/Code/web-design-standards-docs/css/_uswds-project-settings.scss
[20:01:00] _uswds-project-settings.scss:1 [W] Comment: Use `//` comments everywhere
```

```
SpaceBetweenParens: Expected 0 spaces after `(` instead of ` `
[20:01:00] 100 issues found in /Users/mayaben-ari/Code/web-design-standards-docs/css/_uswds-project-utilities-settings.scss
[20:01:00] _uswds-project-utilities-settings.scss:558 [W] SpaceBetweenParens: Expected 0 spaces after `(` instead of ` `
```