### PR TITLE
Use a more specific circle cache to avoid cache-based errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - save_cache:
           key: v2-npm-cache-{{ .Branch }}-{{ .Revision }}
           paths:
-            - ".git"
+            - node_modules
       - run:
           name: Rebuild node-sass
           command: npm rebuild node-sass

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,15 +19,16 @@ jobs:
             - vendor/bundle
       - restore_cache:
           keys:
-            - v2-npm-cache-{{ checksum "package-lock.json" }}
+            - v2-npm-cache-{{ .Branch }}-{{ .Revision }}
+            - v2-npm-cache-{{ .Branch }}
             - v2-npm-cache-
       - run:
           name: Install node dependencies
           command: npm install --ignore-scripts --verbose
       - save_cache:
-          key: v2-npm-cache-{{ checksum "package-lock.json" }}
+          key: v2-npm-cache-{{ .Branch }}-{{ .Revision }}
           paths:
-            - node_modules
+            - ".git"
       - run:
           name: Rebuild node-sass
           command: npm rebuild node-sass

--- a/package-lock.json
+++ b/package-lock.json
@@ -4873,7 +4873,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "get-uri": {


### PR DESCRIPTION
The circle cache is now only rebuilding with changes to `package-lock.json` and I've been getting a lot of circle errors on the `v2` branch because of this. This PR should result in less caching but fewer errors. Wee shall see!