### PR TITLE
Fix footer typo to make TTS plural

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -52,7 +52,7 @@
           <img src="{{ site.baseurl }}/img/gsa-logo.svg" alt="GSA">
         </a>
       </div>
-      <p>The U.S. Web Design System is a project of GSA’s <a href="https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services">Technology Transformation Service</a>, maintained by the Office of Products and Programs.</p>
+      <p>The U.S. Web Design System is a project of GSA’s <a href="https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services">Technology Transformation Services</a>, maintained by the Office of Products and Programs.</p>
       <p>This website is hosted on <a href="https://federalist.fr.cloud.gov">Federalist</a>.</p>
     </div>
   </div>


### PR DESCRIPTION
Looks like there was a name change when TTS merged into FAS: https://www.gsa.gov/about-us/newsroom/news-releases/gsa-merges-technology-and-acquisition

May want to bring this into the 1.x site as well.