### PR TITLE
Use white background for demo pages

### DIFF
--- a/css/_uswds-theme-custom-styles.scss
+++ b/css/_uswds-theme-custom-styles.scss
@@ -80,6 +80,7 @@ $site-background-color: 'gray-2';
 
 body {
   @include u-bg($site-background-color);
+
   &.layout-demo {
     @include u-bg('white');
   }

--- a/css/_uswds-theme-custom-styles.scss
+++ b/css/_uswds-theme-custom-styles.scss
@@ -80,6 +80,9 @@ $site-background-color: 'gray-2';
 
 body {
   @include u-bg($site-background-color);
+  &.layout-demo {
+    @include u-bg('white');
+  }
 }
 
 html,

--- a/css/_uswds-theme-custom-styles.scss
+++ b/css/_uswds-theme-custom-styles.scss
@@ -76,14 +76,10 @@ $site-ink:              'black-transparent-80';
 
 $site-border-width:     2px;
 $site-base-transparent-light: 'black-transparent-10';
-$site-background-color: 'gray-2';
+$site-background-color: 'gray-1';
 
-body {
+.default-container {
   @include u-bg($site-background-color);
-
-  &.layout-demo {
-    @include u-bg('white');
-  }
 }
 
 html,


### PR DESCRIPTION
[Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds-site/dw-scope-bg-color/page-templates/docs/)

- - -

Uses a white background for all `body.layout-demo` pages.

- - -

Fixes #714 