### PR TITLE
[Website] - Form controls: Fix typo in 'Text input' section

### DIFF
--- a/_components/form-controls/01-text-input.md
+++ b/_components/form-controls/01-text-input.md
@@ -14,7 +14,7 @@ lead: Text inputs allow people to enter any combination of letters, numbers, or 
   </button>
   <div id="text-input-docs" aria-hidden="false" class="usa-accordion-content">
     <h4 class="usa-heading">Accessibility</h4>
-    <p>If you customize the text inputs, ensure they continue to meet the the <a href="{{ site.baseurl }}/form-controls/"> accessibility requirements that apply to all form controls.</a></p>
+    <p>If you customize the text inputs, ensure they continue to meet the <a href="{{ site.baseurl }}/form-controls/"> accessibility requirements that apply to all form controls.</a></p>
     <ul class="usa-content-list">
       <li>Avoid placeholder text for accessibility reasons. Most browsers’ default rendering of placeholder text does not provide a high enough contrast ratio.</li>
       <li>Avoid breaking numbers with distinct sections (such as phone numbers, Social Security Numbers, or credit card numbers) into separate input fields. For example, use one input for phone number, not three (one for area code, one for local code, and one for number). Each field needs to be labeled for a screen reader and the labels for fields broken into segments are often not meaningful.</li>


### PR DESCRIPTION
## Description
Changes an instance of `the the` to `the`.

## Additional information
* Content review needed: copy editing