### PR TITLE
Use correct code samples for flex utilities

### DIFF
--- a/_components/utilities/flex.md
+++ b/_components/utilities/flex.md
@@ -349,6 +349,7 @@ utilities:
       title="Flex wrap"
     %}
     <section class="utility-examples">
+
     {% for value in page.values.flex_wrap %}
       <div class="border padding-1 radius-md{% if forloop.first %} margin-bottom-2{% endif %}">
         <span class="utility-class">.flex-{{ value.token }}</span>

--- a/_components/utilities/flex.md
+++ b/_components/utilities/flex.md
@@ -443,17 +443,60 @@ utilities:
       <div id="code-flex-align" class="usa-accordion__content">
 <div markdown="1" class="font-mono-xs">
 ```html
-<div class="display-flex flex-column">
-  <div class="flex-align-start"></div>
-  <div class="flex-align-center"></div>
-  <div class="flex-align-end"></div>
-  <div class="flex-align-stretch"></div>
+<div class="display-flex flex-column flex-align-start">
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
 </div>
-<div class="display-flex flex-row">
-  <div class="flex-align-start"></div>
-  <div class="flex-align-center"></div>
-  <div class="flex-align-end"></div>
-  <div class="flex-align-stretch"></div>
+
+<div class="display-flex flex-column flex-align-center">
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
+</div>
+
+<div class="display-flex flex-column flex-align-end">
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
+</div>
+
+<div class="display-flex flex-column flex-align-stretch">
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
+</div>
+
+<div class="display-flex flex-row flex-align-start">
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
+</div>
+
+<div class="display-flex flex-row flex-align-center">
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
+</div>
+
+<div class="display-flex flex-row flex-align-end">
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
+</div>
+
+<div class="display-flex flex-row flex-align-stretch">
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
 </div>
 ```
 </div><!-- markdown -->

--- a/_components/utilities/flex.md
+++ b/_components/utilities/flex.md
@@ -349,7 +349,6 @@ utilities:
       title="Flex wrap"
     %}
     <section class="utility-examples">
-
     {% for value in page.values.flex_wrap %}
       <div class="border padding-1 radius-md{% if forloop.first %} margin-bottom-2{% endif %}">
         <span class="utility-class">.flex-{{ value.token }}</span>

--- a/_components/utilities/flex.md
+++ b/_components/utilities/flex.md
@@ -545,11 +545,60 @@ utilities:
       <div id="code-flex-justify" class="usa-accordion__content">
 <div markdown="1" class="font-mono-xs">
 ```html
-<div class="display-flex flex-row">
-  <div class="flex-justify"></div>
-  <div class="flex-justify-start"></div>
-  <div class="flex-justify-center"></div>
-  <div class="flex-justify-end"></div>
+<div class="display-flex flex-column flex-justify">
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
+</div>
+
+<div class="display-flex flex-column flex-justify-start">
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
+</div>
+
+<div class="display-flex flex-column flex-justify-center">
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
+</div>
+
+<div class="display-flex flex-column flex-justify-end">
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
+</div>
+
+<div class="display-flex flex-row flex-justify">
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
+</div>
+
+<div class="display-flex flex-row flex-justify-start">
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
+</div>
+
+<div class="display-flex flex-row flex-justify-center">
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
+</div>
+
+<div class="display-flex flex-row flex-justify-end">
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
+  <div class="example"></div>
 </div>
 ```
 </div><!-- markdown -->


### PR DESCRIPTION
[Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds-site/dw-fix-flex-code/utilities/flex/#utility-flex-align)

Updates the code samples for `flex-align` and `flex-justify` to show these utilities on the parent element.

- - -

Fixes https://github.com/uswds/uswds/issues/2913