### PR TITLE
Use updated favicon and homepage title on our site

### DIFF
--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -3,7 +3,7 @@
     <header class="usa-banner__header">
       <div class="usa-banner__inner">
         <div class="grid-col-auto">
-          <img class="usa-banner__header-flag" src="{{ site.baseurl }}/assets/img/favicons/favicon-57.png" alt="U.S. flag">
+          <img class="usa-banner__header-flag" src="{{ site.baseurl }}/assets/img/us_flag_small.png" alt="U.S. flag">
         </div>
         <div class="grid-col-fill tablet:grid-col-auto">
           <p class="usa-banner__header-text">An official website of the United States government</p>

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "jquery": "^3.3.1",
     "normalize.css": "^8.0.0",
-    "uswds": "github:uswds/uswds#release-2.0"
+    "uswds": "github:uswds/uswds#dw-update-favicon"
   },
   "devDependencies": {
     "autoprefixer": "^9.1.5",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "jquery": "^3.3.1",
     "normalize.css": "^8.0.0",
-    "uswds": "github:uswds/uswds#dw-update-favicon"
+    "uswds": "github:uswds/uswds#release-2.0"
   },
   "devDependencies": {
     "autoprefixer": "^9.1.5",

--- a/pages/home.md
+++ b/pages/home.md
@@ -1,7 +1,7 @@
 ---
 permalink: /
 layout: landing
-title: "U.S. Web Design System: A design system for the federal government"
+title: "USWDS: The United States Web Design System"
 class: home
 hero:
   callout: A design system for the federal government
@@ -61,7 +61,7 @@ We work with you to assess your current system and determine the most cost-effic
         <li>We’ll ensure your Design System implementation is in compliance with the official web policy guidance from OMB and your agency.</li>
         <li>We’ll determine any gaps in skill sets, equipment, design, and code quality needed for successful implementation of the Design System.</li>
         <li>Your team will leave better prepared to adopt private-sector best practices and continue to create successful digital services.</li>
-      </ul> 
+      </ul>
     </div>
   </li>
 </ul>
@@ -90,7 +90,7 @@ Develop and implement a custom look and feel for your site or application-specif
         <li>Your digital services will stay in compliance with the official web policy guidance from OMB.</li>
         <li>Fully implementing the Design System brings a range of best practices to your digital services.</li>
         <li>This investment will reduce the cost and time to design and develop future compliant digital services.</li>
-      </ul> 
+      </ul>
     </div>
   </li>
 </ul>


### PR DESCRIPTION
[Preview 🇺🇸](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds-site/dw-check-favicon/)

- Updated favicon
- Updated banner to reference flag image
- Updated homepage title to get full acronym in small tabs

<img width="713" alt="Screen Shot 2019-03-22 at 2 34 41 PM" src="https://user-images.githubusercontent.com/11464021/54854324-c8997a00-4caf-11e9-96db-f6b17497291d.png">



