### PR TITLE
Display proper default theme colors

### DIFF
--- a/_components/utilities/border.md
+++ b/_components/utilities/border.md
@@ -82,9 +82,7 @@ utilities:
 {% assign grayscale_colors = site.data.tokens.color.grayscale %}
 {% assign basic_colors = site.data.tokens.color.basic %}
 {% assign transparent = site.data.tokens.color.required %}
-{% assign all_colors = transparent
-  | concat: theme_colors
-  | concat: grayscale_colors
+{% assign all_colors = grayscale_colors
   | concat: basic_colors
   %}
 
@@ -485,6 +483,62 @@ utilities:
 
     <section class="utility-examples">
       <div class="grid-row">
+        {% for color in transparent %}
+          {% if color.default %}
+            {% assign system = system-colors | where: 'token', color.default %}
+            {% assign value = system[0].value %}
+            {% assign token = color.default %}
+          {% else %}
+            {% assign value = color.value %}
+            {% assign token = false %}
+          {% endif %}
+          <p class="utility-example-container grid-col-12 display-flex flex-align-center">
+            <span class="flex-fill">
+              <span class="square-4 radius-sm text-middle padding-05 display-inline-block margin-right-1 bg-white ">
+                <span class="square-3 radius-sm display-block border-1px border-{{ color.token }}"></span>
+              </span>
+              <span class="display-none tablet:display-inline-block square-4 radius-sm text-middle padding-05 margin-right-1 bg-ink">
+                <span class="square-3 radius-sm display-block border-1px border-{{ color.token }}"></span>
+              </span>
+              <span class="utility-class">.border-{{ color.token }}</span>
+            </span>
+            {% if token %}
+              <code class="display-none tablet:display-inline-block bg-secondary-lighter radius-sm">{{ token }}</code>
+            {% endif %}
+            <span class="display-none tablet:display-inline-block flex-auto utility-value-color margin-left-1">
+              <span class="utility-value-color-chip bg-{{ color.token }}"></span>
+              {{ value }}
+            </span>
+          </p>
+        {% endfor %}
+        {% for color in theme_colors %}
+          {% if color.default %}
+            {% assign system = system-colors | where: 'token', color.default %}
+            {% assign value = system[0].value %}
+            {% assign token = color.default %}
+          {% else %}
+            {% assign value = color.value %}
+            {% assign token = false %}
+          {% endif %}
+          <p class="utility-example-container grid-col-12 display-flex flex-align-center">
+            <span class="flex-fill">
+              <span class="square-4 radius-sm text-middle padding-05 display-inline-block margin-right-1 bg-white ">
+                <span class="square-3 radius-sm display-block border-1px border-default-{{ color.token }}"></span>
+              </span>
+              <span class="display-none tablet:display-inline-block square-4 radius-sm text-middle padding-05 margin-right-1 bg-ink">
+                <span class="square-3 radius-sm display-block border-1px border-{{ color.token }}"></span>
+              </span>
+              <span class="utility-class">.border-{{ color.token }}</span>
+            </span>
+            {% if token %}
+              <code class="display-none tablet:display-inline-block bg-secondary-lighter radius-sm">{{ token }}</code>
+            {% endif %}
+            <span class="display-none tablet:display-inline-block flex-auto utility-value-color margin-left-1">
+              <span class="utility-value-color-chip bg-{{ color.token }}"></span>
+              {{ value }}
+            </span>
+          </p>
+        {% endfor %}
         {% for color in all_colors %}
           {% if color.default %}
             {% assign system = system-colors | where: 'token', color.default %}

--- a/_components/utilities/color.md
+++ b/_components/utilities/color.md
@@ -76,7 +76,7 @@ utilities:
             | times: 1 %}
 
           <div class="utility-example-container grid-col-12 font-lang-xs display-flex flex-align-center flex-justify">
-            <span class="radius-md padding-05 text-{{ color.token }}{% if grade < 50 %} bg-gray-90 is-inverse{% endif %}">.text-{{ color.token }}</span>
+            <span class="radius-md padding-05 text-default-{{ color.token }}{% if grade < 50 %} bg-gray-90 is-inverse{% endif %}">.text-{{ color.token }}</span>
             <span class="flex-auto utility-value-color">
               <span class="utility-value-color-chip bg-{{ color.token }}"></span>
               {% assign system = system-colors | where: 'token', color.default %}
@@ -165,7 +165,7 @@ utilities:
           {% assign value = system[0].value %}
           <p class="utility-example-container grid-col-12 display-flex flex-align-center measure-none">
             <span class="flex-fill">
-              <span class="square-4 radius-sm display-inline-block text-middle margin-right-1 bg-{{ color.token }}"></span>
+              <span class="square-4 radius-sm display-inline-block text-middle margin-right-1 bg-default-{{ color.token }}"></span>
               <span class="utility-class">.bg-{{ color.token }}</span>
             </span>
             <span class="flex-auto utility-value-color">

--- a/_components/utilities/text-styles.md
+++ b/_components/utilities/text-styles.md
@@ -241,7 +241,7 @@ utilities:
           {% assign token = false %}
         {% endif %}
         <div class="utility-example-container grid-col-12 font-lang-xs display-flex flex-align-center flex-justify{% if forloop.last %}{% endif %}">
-          <span class="text-underline underline-{{ color.token }}">.underline-{{ color.token }}<span class="text-thin text-gray-50">.text-underline</span></span>
+          <span class="text-underline underline-default-{{ color.token }}">.underline-{{ color.token }}<span class="text-thin text-gray-50">.text-underline</span></span>
           <span class="flex-auto">
             {% if token %}
               <code class="bg-secondary-lighter radius-sm">{{ token }}</code>

--- a/_data/tokens/color.yml
+++ b/_data/tokens/color.yml
@@ -185,7 +185,7 @@ system:
     - token: red-cool-5v
       value: false
     - token: red-cool-10v
-      value: false
+      value: '#f8dfe2'
     - token: red-cool-20v
       value: '#f8b9c5'
     - token: red-cool-30v

--- a/css/settings/_uswds-theme-utilities.scss
+++ b/css/settings/_uswds-theme-utilities.scss
@@ -17,6 +17,39 @@ https://v2.designsystem.digital.gov/utilities
 ----------------------------------------
 */
 
+$site-default-colors: (
+  'default-base-lightest': '#f0f0f0',
+  'default-base-lighter': '#dcdee0',
+  'default-base-light': '#a9aeb1',
+  'default-base': '#71767a',
+  'default-base-dark': '#565c65',
+  'default-base-darker': '#3d4551',
+  'default-base-darkest': '#1b1b1b',
+  'default-ink': '#1b1b1b',
+  'default-primary-lighter': '#d9e8f6',
+  'default-primary-light': '#d9e8f6',
+  'default-primary': '#d9e8f6',
+  'default-primary-vivid': '#d9e8f6',
+  'default-primary-dark': '#1a4480',
+  'default-primary-darker': '#162e51',
+  'default-secondary-lighter': false,
+  'default-secondary-light': '#f2938c',
+  'default-secondary': '#d83933',
+  'default-secondary-vivid': '#e41d3d',
+  'default-secondary-dark': '#b51d09',
+  'default-secondary-darker': '#8b1303',
+  'default-accent-warm-lighter': '#f2e4d4',
+  'default-accent-warm-light': '#ffbc78',
+  'default-accent-warm': '#fa9441',
+  'default-accent-warm-dark': '#c05600',
+  'default-accent-warm-darker': '#775540',
+  'default-accent-cool-lighter': '#e1f3f8',
+  'default-accent-cool-light': '#97d4ea',
+  'default-accent-cool': '#00bde3',
+  'default-accent-cool-dark': '#28a0cb',
+  'default-accent-cool-darker': '#07648d',
+);
+
 $utilities-use-important:     true;
 $output-utilities:        true;
 
@@ -590,7 +623,7 @@ $background-color-palettes: (
   'palette-color-system',
   'palette-color-state'
 );
-$background-color-manual-values: ();
+$background-color-manual-values: $site-default-colors;
 
 // .border
 

--- a/css/settings/_uswds-theme-utilities.scss
+++ b/css/settings/_uswds-theme-utilities.scss
@@ -27,12 +27,12 @@ $site-default-colors: (
   'default-base-darkest': '#1b1b1b',
   'default-ink': '#1b1b1b',
   'default-primary-lighter': '#d9e8f6',
-  'default-primary-light': '#d9e8f6',
-  'default-primary': '#d9e8f6',
-  'default-primary-vivid': '#d9e8f6',
+  'default-primary-light': '#73b3e7',
+  'default-primary': '#005ea2',
+  'default-primary-vivid': '#0050d8',
   'default-primary-dark': '#1a4480',
   'default-primary-darker': '#162e51',
-  'default-secondary-lighter': false,
+  'default-secondary-lighter': '#f8dfe2',
   'default-secondary-light': '#f2938c',
   'default-secondary': '#d83933',
   'default-secondary-vivid': '#e41d3d',
@@ -633,7 +633,7 @@ $border-manual-values: ();
 // .border-color
 
 $border-color-palettes: ();
-$border-color-manual-values: ();
+$border-color-manual-values: $site-default-colors;
 
 // .border-radius
 
@@ -670,7 +670,7 @@ $circle-manual-values: ();
 // .color
 
 $color-palettes: ('palette-color-system');
-$color-manual-values: ();
+$color-manual-values: $site-default-colors;
 
 // .cursor
 
@@ -849,7 +849,7 @@ $text-decoration-manual-values: ();
 // .text-decoration-color
 
 $text-decoration-color-palettes: ();
-$text-decoration-color-manual-values: ();
+$text-decoration-color-manual-values: $site-default-colors;
 
 // .text-indent
 

--- a/pages/design-tokens/color/theme-tokens.md
+++ b/pages/design-tokens/color/theme-tokens.md
@@ -46,7 +46,7 @@ Customize theme color tokens using the variables listed below in `_uswds_theme_c
       {% for item in colors.theme %}
         <tr>
           <td scope="row" data-title="Color" class="flex-align-center">
-            <span class="site-inline-swatch bg-{{ item.token }}"></span>
+            <span class="site-inline-swatch bg-default-{{ item.token }}"></span>
           </td>
           <td data-title="Token">
             <span class="utility-class font-mono-2xs">'{{ item.token }}'</span>


### PR DESCRIPTION
This one was one of those little quirks of having a documentation site that does not share the same defaults as its product — similar to the issue of not rendering Source Sans Pro in our component previews.

Since `uswds-site` color settings don't match USWDS defaults, we had a situation where the docs were outputting the default hex code for color tokens/utilities (since that value is set in site data) but were displaying the `uswds-site`-specific defaults in the examples (since the site settings determine the output of the theme utilities and the examples use utilities for styling).

One solution might be to use the USWDS defaults on our site. Ha! That would be too consistent.

For this one, I used custom utility values to make a set of color utilities that output the USWDS defaults — like `bg-default-base` and applied this new utility to the examples. As much as anything, a proof of concept for utility custom values.