### PR TITLE
Add blue-cool-vivid to system color tokens page

### DIFF
--- a/pages/design-tokens/color/system-tokens.md
+++ b/pages/design-tokens/color/system-tokens.md
@@ -86,6 +86,7 @@ families:
   - cyan
   - cyan-vivid
   - blue-cool
+  - blue-cool-vivid
   - blue
   - blue-vivid
   - blue-warm


### PR DESCRIPTION
[Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds-site/dw-blue-cool-vivid/design-tokens/color/system-tokens/#blue-cool) :sparkles:

We omitted the `blue-cool-vivid` variants on the system tokens page. This reinstates them.

- - -

Fixes #743 
Thanks @bet4a!