### PR TITLE
Fix font-size output in docs

### DIFF
--- a/_components/utilities/font-size-and-family.md
+++ b/_components/utilities/font-size-and-family.md
@@ -135,7 +135,7 @@ utilities:
               {{ output }}px
             {% endcapture %}
             {% capture this_example %}
-              <div class="font-{{ role.token }}-{{ size.default }} line-height-{{ role.token }}-1 text-gray-90">
+              <div class="font-{{ role.default }}-{{ size.default }} line-height-{{ role.token }}-1 text-gray-90">
                 Tuscaloosa
               </div>
             {% endcapture %}

--- a/_components/utilities/font-size-and-family.md
+++ b/_components/utilities/font-size-and-family.md
@@ -84,7 +84,7 @@ utilities:
               {{ output }}px
             {% endcapture %}
             {% capture this_example %}
-              <div class="font-{{ family.token }}-{{ size.token }} line-height-{{ family.token }}-1 text-gray-90">
+              <div class="font-{{ family.token }}-{{ size.default }} line-height-{{ family.token }}-1 text-gray-90">
                 Tuscaloosa
               </div>
             {% endcapture %}
@@ -135,7 +135,7 @@ utilities:
               {{ output }}px
             {% endcapture %}
             {% capture this_example %}
-              <div class="font-{{ role.token }}-{{ size.token }} line-height-{{ role.token }}-1 text-gray-90">
+              <div class="font-{{ role.token }}-{{ size.default }} line-height-{{ role.token }}-1 text-gray-90">
                 Tuscaloosa
               </div>
             {% endcapture %}

--- a/_data/tokens/typesetting/size.yml
+++ b/_data/tokens/typesetting/size.yml
@@ -43,20 +43,20 @@ system:
     value: 140px
 theme:
   - token: 3xs
-    default: 1
+    default: 2
   - token: 2xs
     default: 3
   - token: xs
-    default: 5
+    default: 4
   - token: sm
-    default: 6
+    default: 5
   - token: md
-    default: 7
+    default: 6
   - token: lg
-    default: 10
+    default: 9
   - token: xl
     default: 12
   - token: 2xl
     default: 14
   - token: 3xl
-    default: 16
+    default: 15

--- a/pages/design-tokens/typesetting/font-size.md
+++ b/pages/design-tokens/typesetting/font-size.md
@@ -52,7 +52,7 @@ The following chart shows the USWDS default settings for the nine theme size tok
             </span>
           </td>
           <td data-title="Example"  class="line-height-sans-1 overflow-hidden">
-            <span class="font-lang-{{ item.token }}">
+            <span class="font-lang-{{ item.default }}">
               Tallahassee
             </span>
           </td>

--- a/pages/design-tokens/typesetting/font-size.md
+++ b/pages/design-tokens/typesetting/font-size.md
@@ -52,7 +52,7 @@ The following chart shows the USWDS default settings for the nine theme size tok
             </span>
           </td>
           <td data-title="Example"  class="line-height-sans-1 overflow-hidden">
-            <span class="font-sans-{{ item.token }}">
+            <span class="font-lang-{{ item.token }}">
               Tallahassee
             </span>
           </td>
@@ -114,7 +114,7 @@ The following chart shows the USWDS default settings for the nine theme size tok
             </span>
           </td>
           <td data-title="Example"  class="line-height-sans-1 overflow-hidden">
-            <span class="font-sans-{{ item.token }}">
+            <span class="font-lang-{{ item.token }}">
               Tallahassee
             </span>
           </td>


### PR DESCRIPTION
[Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds-site/dw-font-size/utilities/font-size-and-family/) ✨ 

This should update the docs to use the proper USWDS defaults and output the proper utility into the example to display the proper size.

Fixes uswds/uswds-site#745.