### PR TITLE
Remove post excerpt part from meta

### DIFF
--- a/_components/page-templates/page-templates.html
+++ b/_components/page-templates/page-templates.html
@@ -15,6 +15,7 @@ subnav:
   <h2 class="usa-heading" id="landing-page">Landing page</h2>
   <p class="site-text-intro">Provide someone’s first impression of your agency or program. </p>
   <p>Often, site users arrive at a landing page without much context, like a search result or a colleague’s email. So a landing page needs to be clear, engaging, and contextualizing.</p>
+</section>
 
 <div class="preview">
   <a class="media_link" href="{{ site.components_url_v2_preview }}/layout--landing.html">

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -6,17 +6,14 @@
 {% endif %}
 <title>{{ title }}</title>
 <meta property="og:title" content="{{ title | xml_escape }}">
-{% if page.excerpt -%}
-  {% assign desc = page.excerpt %}
-{% else %}
 {% assign desc = page.description
   | default: page.lead
   | default: site.description
+  | markdownify
   | strip_html
   | strip
   | xml_escape
 %}
-{% endif %}
 {% if desc -%}
 <meta name="description" content="{{ desc }}">
 <meta property="og:description" content="{{ desc }}">


### PR DESCRIPTION
- Remove post excerpt part from meta 
- fix closing section tag on page templates.
- ensures markdown in site lead renders correctly in the meta tag

Will have to re-add post excerpt in subsequent PR as it was breaking the site cc @jeremyzilar. 