### PR TITLE
Change link hover to primary-dark

### DIFF
--- a/css/settings/_uswds-theme-color.scss
+++ b/css/settings/_uswds-theme-color.scss
@@ -129,5 +129,5 @@ General colors
 // Links
 $theme-link-color:             'primary';
 $theme-link-visited-color:     'violet-70v';
-$theme-link-hover-color:       'primary-darker';
+$theme-link-hover-color:       'primary-dark';
 $theme-link-active-color:      'primary-darker';


### PR DESCRIPTION
Updates the settings file to align the hover color with what's on uswds that was updated in uswds/uswds/pull/3023.

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds-site/mb-update-link-hover/)