### PR TITLE
Update deprecated text to secondary-vivid on Migration page

### DIFF
--- a/_includes/migration-table.html
+++ b/_includes/migration-table.html
@@ -16,12 +16,12 @@
     {% endif %}
       <tr>
         <td scope="row" data-title="USWDS 1.x">
-          <span{% if class.deprecated %} class="text-secondary"{% endif %}>
+          <span{% if class.deprecated %} class="text-secondary-vivid"{% endif %}>
             {{ class.v1 }}
           </span>
         </td>
         <td scope="row" data-title="USWDS 2.0">
-          <span{% if class.deprecated %} class="text-secondary"{% endif %}>
+          <span{% if class.deprecated %} class="text-secondary-vivid"{% endif %}>
             {% if variant %}<span class="text-light text-primary">{{ base }}</span>{% endif %}{{ class.v2 }}
           </span>
         </td>


### PR DESCRIPTION
Current red text used on Migration page is too light to pass a11y requirements. `secondary-vivid` seemed the closest to `secondary` although`secondary-dark` would work and may be easier on the eyes.

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds-site/mb-update-red-text/documentation/migration/)

Fixes #761.