### PR TITLE
Use secondary-vivid for red text on the Migration page (Mixins section)

### DIFF
--- a/_includes/migration-table-mixins.html
+++ b/_includes/migration-table-mixins.html
@@ -10,12 +10,12 @@
     {% for command in commands %}
       <tr>
         <td scope="row" data-title="USWDS 1.x">
-          <span{% if command.deprecated %} class="text-secondary"{% endif %}>
+          <span{% if command.deprecated %} class="text-secondary-vivid"{% endif %}>
             {{ command.v1 }}
           </span>
         </td>
         <td scope="row" data-title="USWDS 2.0">
-          <span{% if command.deprecated %} class="text-secondary"{% endif %}>
+          <span{% if command.deprecated %} class="text-secondary-vivid"{% endif %}>
             {{ command.v2 }}{% if command.token %}(<a href="{{ site.baseurl }}/design-tokens/{{ command.token }}/" class="token">{{ command.token | remove: '/typesetting' }}</a>{% if command.token_2 %}, <a href="{{ site.baseurl }}/design-tokens/{{ command.token }}/" class="token">{{ command.token | remove: '/typesetting' }}</a>{% endif %}{% if command.token_3 %}, <a href="{{ site.baseurl }}/design-tokens/{{ command.token }}/" class="token">{{ command.token | remove: '/typesetting' }}</a>{% endif %}{% if command.token_4 %}, <a href="{{ site.baseurl }}/design-tokens/{{ command.token }}/" class="token">{{ command.token | remove: '/typesetting' }}</a>{% endif %}){% endif %}
           </span>
         </td>


### PR DESCRIPTION
Missed this section

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds-site/mb-update-red-text-mixins/documentation/migration/)

Related #765 #761.