### PR TITLE
Change ref in install-readme from release-2.0 to master on v2 site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,7 @@ jekyll_get:
     json: 'https://api.github.com/repos/uswds/uswds/contents/CONTRIBUTING.md'
     decode_content: true
   - data: install-readme
-    json: 'https://api.github.com/repos/uswds/uswds/contents/README.md'
+    json: 'https://api.github.com/repos/uswds/uswds/contents/README.md?ref=master'
     decode_content: true
   - data: standards-sites
     json: 'https://api.github.com/repos/uswds/uswds/contents/docs/WHO_IS_USING_USWDS.md'

--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,7 @@ jekyll_get:
     json: 'https://api.github.com/repos/uswds/uswds/contents/CONTRIBUTING.md'
     decode_content: true
   - data: install-readme
-    json: 'https://api.github.com/repos/uswds/uswds/contents/README.md?ref=release-2.0'
+    json: 'https://api.github.com/repos/uswds/uswds/contents/README.md'
     decode_content: true
   - data: standards-sites
     json: 'https://api.github.com/repos/uswds/uswds/contents/docs/WHO_IS_USING_USWDS.md'


### PR DESCRIPTION
Using the `master` branch will use the latest release.

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds-site/mb-v2-update-readme-ref/documentation/developers/)