### PR TITLE
Add v1 docs banner to home page

### DIFF
--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -3,6 +3,9 @@ layout: default
 ---
 
 <main id="main-content">
+  <div class="bg-gold-20v padding-x-2 desktop:padding-x-4 padding-y-1 line-height-sans-3 font-lang-4">
+    For USWDS 1.x documentation, see <a href="https://v1.designsystem.digital.gov" class="text-ink text-bold text-no-underline hover:text-underline">v1.designsystem.digital.gov</a>.
+  </div>
   <section class="site-hero">
     <div class="grid-container">
       <div class="maxw-mobile-lg">


### PR DESCRIPTION
[Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds-site/v2-add-v1-banner/) ✨ 

- - -

<img width="1010" alt="Screen Shot 2019-05-22 at 5 34 52 AM" src="https://user-images.githubusercontent.com/11464021/58174724-67603980-7c53-11e9-9032-726176d709c7.png">


This adds a banner to the top of the home page, pointing v1.x users to the new v1 documentation site: [v1.designsystem.digital.gov](https://v1.designsystem.digital.gov)

**Note: Only merge once v1.designsystem.digital.gov resolves properly.** 