### PR TITLE
adding a temporary redirect

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,6 +9,19 @@
   <meta name="MobileOptimized" content="320">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+
+<!-- Temporary Redirect
+================================================== -->
+  <script type="text/javascript">
+    var v2_url = 'https://v2.designsystem.digital.gov/';
+    var current_url = window.location;
+    if ( current_url.href.indexOf(v2_url) >= 0 ) {
+      var path = current_url.href.replace(v2_url, "");
+      window.location.href = 'https://designsystem.digital.gov/' + path;
+    }
+  </script>
+
+
 <!-- Title and meta description
 ================================================== -->
   {% include meta.html %}


### PR DESCRIPTION
This change puts in a temporary meta refresh redirect for `https://v2.designsystem.digital.gov/`.

**This change is being made to the v1 branch.**

- If the reader is on any page on `https://v2.designsystem.digital.gov/`, they will be redirected to the same page/path on `https://designsystem.digital.gov/`.

- If the reader is on any page on `https://v1.designsystem.digital.gov/`, nothing should happen. They should remain on the v1 site.

