### PR TITLE
Use develop branch for documentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13126,9 +13126,8 @@
       "dev": true
     },
     "uswds": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/uswds/-/uswds-2.0.3.tgz",
-      "integrity": "sha512-VxiMrtdlbZZ5VCaoZ81Jie4ijVloYcN7WQ/75lEdgReJ6l7zYDcmNLsZ7l+PYJMQPP555FSjHKiBDPT6A990MA==",
+      "version": "github:uswds/uswds#cbc05547dedd810bfd7184632f7ded1650a8317a",
+      "from": "github:uswds/uswds#develop",
       "requires": {
         "@types/node": "^8.10.39",
         "array-filter": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "jquery": "^3.4.0",
     "normalize.css": "^8.0.0",
-    "uswds": "2.0.3"
+    "uswds": "github:uswds/uswds#develop"
   },
   "devDependencies": {
     "autoprefixer": "^9.1.5",


### PR DESCRIPTION
[Preview](https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/uswds/uswds-site/use-develop-2.0.3/documentation/developers/)

- - -

- This updates the USWDS package to the Github develop branch, not the `2.0.3` package

- - -

Fixes https://github.com/uswds/uswds-site/issues/778 (Sorry this took so long! 😬)