### PR TITLE
Fix z-index token documentation

### DIFF
--- a/pages/design-tokens/z-index.md
+++ b/pages/design-tokens/z-index.md
@@ -79,12 +79,14 @@ Your context and coding style determine how you access USWDS z-index tokens in c
         </td>
         <td data-title="Usage">
           <span>
-            z-index(<a href="{{ site.baseurl }}/design-tokens/z-index/" class="token">z-index</a>)
+            z-index(<a href="{{ site.baseurl }}/design-tokens/z-index/" class="token">z-index</a>)<br/>
+            z(<a href="{{ site.baseurl }}/design-tokens/z-index/" class="token">z-index</a>)
           </span>
         </td>
         <td data-title="Example">
           <span>
-            z-index: z-index(<code>'bottom'</code>)
+            z-index: z-index(<code>'bottom'</code>)<br/>
+            z-index: z(<code>'bottom'</code>)
           </span>
         </td>
       </tr>

--- a/pages/design-tokens/z-index.md
+++ b/pages/design-tokens/z-index.md
@@ -96,12 +96,12 @@ Your context and coding style determine how you access USWDS z-index tokens in c
         </td>
         <td data-title="Usage">
           <span>
-            u-z-index(<a href="{{ site.baseurl }}/design-tokens/z-index/" class="token">z-index</a>)
+            u-z(<a href="{{ site.baseurl }}/design-tokens/z-index/" class="token">z-index</a>)
           </span>
         </td>
         <td data-title="Example">
           <span>
-            @include u-z-index(<code>'bottom'</code>)<br/>
+            @include u-z(<code>'bottom'</code>)<br/>
           </span>
         </td>
       </tr>
@@ -130,12 +130,12 @@ Your context and coding style determine how you access USWDS z-index tokens in c
         </td>
         <td data-title="Usage">
           <span>
-            .z-index-<a href="{{ site.baseurl }}/design-tokens/z-index/" class="token">z-index</a>
+            .z-<a href="{{ site.baseurl }}/design-tokens/z-index/" class="token">z-index</a>
           </span>
         </td>
         <td data-title="Example">
           <span>
-            .z-index-<code>top</code>
+            .z-<code>top</code>
           </span>
         </td>
       </tr>


### PR DESCRIPTION
[Preview](https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/uswds/uswds-site/fix-z-index-utils/design-tokens/z-index/#using-z-index-tokens) :sparkles:

The **Using z-index tokens** section of the z-index token documentation was incorrect. The proper values should be:

**utility:** `.z-[token]`
**mixin:** `@include u-z([token])`
**function:** `z-index([token])` and `z([token])`

- - -

Fixes #790