### PR TITLE
Strip and escape any description metadata

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -17,10 +17,10 @@
 {% endif %}
 {% if desc -%}
   {% assign desc = desc
-        | strip_html
-        | strip
-        | xml_escape
-      %}
+    | strip_html
+    | strip
+    | xml_escape
+  %}
 <meta name="description" content="{{ desc }}">
 <meta property="og:description" content="{{ desc }}">
 {% endif %}

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -13,12 +13,14 @@
     | default: page.lead
     | default: site.description
     | markdownify
-    | strip_html
-    | strip
-    | xml_escape
   %}
 {% endif %}
 {% if desc -%}
+  {% assign desc = desc
+        | strip_html
+        | strip
+        | xml_escape
+      %}
 <meta name="description" content="{{ desc }}">
 <meta property="og:description" content="{{ desc }}">
 {% endif %}


### PR DESCRIPTION
[USA Gov blog post](https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/uswds/uswds-site/fix-busted-metadata/whats-new/updates/2017/11/08/USAGov-case-study/)
[Code.gov blog post](https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/uswds/uswds-site/fix-busted-metadata/whats-new/updates/2017/07/24/code-gov-case-study/)

- - -

Escape any description to prevent including markup-breaking code in the meta description field.

Fixes #796 