### PR TITLE
[Full Viewport Height / Width] Utility values are swapped in the documentation

### DIFF
--- a/_data/tokens/special.yml
+++ b/_data/tokens/special.yml
@@ -17,10 +17,10 @@ full_percent:
     value: 100%
 full_viewport_height:
   - token: 'viewport'
-    value: 100vw
+    value: 100vh
 full_viewport_width:
   - token: 'viewport'
-    value: 100vh
+    value: 100vw
 spacing_05:
   - token: '05'
     value: 4px


### PR DESCRIPTION
## Description

Just something minor I noticed where it appears that the `full_viewport_height` and `full_viewport_width` tokens are swapped (`100vw` vs `100vh`). This affects the documentation for `.height-viewport` and `.maxh-viewport` (https://designsystem.digital.gov/utilities/height-and-width/#height).

> For some reason `.width-viewport` and `.maxw-viewport` are not available in the documentation

