### PR TITLE
Use jekyll dev branch to fix "where" filter bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'jekyll', '>= 4.0.0'
+gem "jekyll", github: "jekyll/jekyll", ref: "refs/pull/7821/head"
 gem 'json'
 gem 'jekyll-redirect-from', '>= 0.13.0'
 gem 'jekyll-sitemap'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,8 @@
-GEM
-  remote: https://rubygems.org/
+GIT
+  remote: https://github.com/jekyll/jekyll.git
+  revision: 1cab76fa4db3ca879ddeb695d2c835317f34e001
+  ref: refs/pull/7821/head
   specs:
-    addressable (2.7.0)
-      public_suffix (>= 2.0.2, < 5.0)
-    colorator (1.1.0)
-    concurrent-ruby (1.1.5)
-    diff-lcs (1.3)
-    em-websocket (0.5.1)
-      eventmachine (>= 0.12.9)
-      http_parser.rb (~> 0.6.0)
-    eventmachine (1.2.7)
-    ffi (1.11.1)
-    forwardable-extended (2.6.0)
-    http_parser.rb (0.6.0)
-    i18n (1.6.0)
-      concurrent-ruby (~> 1.0)
     jekyll (4.0.0)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -30,9 +18,27 @@ GEM
       rouge (~> 3.0)
       safe_yaml (~> 1.0)
       terminal-table (~> 1.8)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    colorator (1.1.0)
+    concurrent-ruby (1.1.5)
+    diff-lcs (1.3)
+    em-websocket (0.5.1)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0.6.0)
+    eventmachine (1.2.7)
+    ffi (1.11.2)
+    forwardable-extended (2.6.0)
+    http_parser.rb (0.6.0)
+    i18n (1.7.0)
+      concurrent-ruby (~> 1.0)
     jekyll-redirect-from (0.15.0)
       jekyll (>= 3.3, < 5.0)
-    jekyll-sass-converter (2.0.0)
+    jekyll-sass-converter (2.0.1)
       sassc (> 2.0.1, < 3.0)
     jekyll-sitemap (1.3.1)
       jekyll (>= 3.7, < 5.0)
@@ -43,10 +49,9 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.3)
-    listen (3.1.5)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-      ruby_dep (~> 1.2)
+    listen (3.2.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
@@ -55,21 +60,20 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    rouge (3.11.0)
+    rouge (3.13.0)
     rspec-core (3.8.2)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.4)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
-    ruby_dep (1.5.0)
     safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sassc (2.2.0)
+    sassc (2.2.1)
       ffi (~> 1.9)
     scss_lint (0.58.0)
       rake (>= 0.9, < 13)
@@ -82,7 +86,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  jekyll (>= 4.0.0)
+  jekyll!
   jekyll-redirect-from (>= 0.13.0)
   jekyll-sitemap
   json

--- a/_components/utilities/font-size-and-family.md
+++ b/_components/utilities/font-size-and-family.md
@@ -6,33 +6,34 @@ title: Font size and family
 category: Utilities
 lead: Set the font size and the font family together.
 subnav:
-- text: Font size and family
-  href: '#utility-font'
-- text: Font family
-  href: '#utility-font-family'
-- text: Utility mixins
-  href: '#utility-mixins'
-- text: Advanced settings
-  href: '#advanced-settings'
+  - text: Font size and family
+    href: "#utility-font"
+  - text: Font family
+    href: "#utility-font-family"
+  - text: Utility mixins
+    href: "#utility-mixins"
+  - text: Advanced settings
+    href: "#advanced-settings"
 
 utilities:
-- base:         font
-  var:          font
-  output:       true
-  responsive:   true
-  active:       false
-  focus:        false
-  hover:        false
-  visited:      false
-- base:         font-family
-  var:          font-family
-  output:       true
-  responsive:   false
-  active:       false
-  focus:        false
-  hover:        false
-  visited:      false
+  - base: font
+    var: font
+    output: true
+    responsive: true
+    active: false
+    focus: false
+    hover: false
+    visited: false
+  - base: font-family
+    var: font-family
+    output: true
+    responsive: false
+    active: false
+    focus: false
+    hover: false
+    visited: false
 ---
+
 {% assign tokens = site.data.tokens.typesetting %}
 
 <div class="utilities-properties">
@@ -151,6 +152,7 @@ utilities:
         {% endif %}
       {% endfor %}
     </section><!-- examples -->
+
   </section><!-- utility -->
 
   <section class="utility" id="utility-font-family">
@@ -179,6 +181,7 @@ utilities:
       {% endfor %}
 
     </section><!-- examples -->
+
   </section><!-- utility -->
 </section><!-- utilities -->
 
@@ -232,26 +235,29 @@ utilities:
     </tbody>
   </table>
 
-  {% include utilities/utility-mixin-using.html %}
+{% include utilities/utility-mixin-using.html %}
+
 </section>
 
 <section id="advanced-settings" class="padding-top-4">
   <h2 class="site-h2 margin-y-0">Advanced settings</h2>
 
-  {% include utilities/responsive-variants.html %}
-  {% include utilities/state-variants.html %}
-  {% include utilities/output-control.html %}
+{% include utilities/responsive-variants.html %}
+{% include utilities/state-variants.html %}
+{% include utilities/output-control.html %}
 
   <section class="utilities-section margin-top-6">
     {% include utilities/values-intro.html %}
 
     <aside class="example border-left-05 border-secondary-light padding-left-105 margin-top-2">
       <h4 class="font-lang-2xs margin-top-0 margin-bottom-05">Example</h4>
+
 <pre class="font-mono-xs margin-0 padding-0 bg-transparent">
 $font-palettes: (
   'palette-font-theme-types' // note: no trailing comma
 );
 </pre>
+
     </aside>
 
     {% include utilities/standard-palettes.html %}


### PR DESCRIPTION
[Preview](https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/uswds/uswds-site/dw-fix-data/utilities/font-size-and-family/)

A "where" filter bug in Jekyll 4.0 was causing some data filtering lookups to fail. I'll link the gem to this fix branch temporarily, until we get an official release of Jekyll 4.1

Bug: https://github.com/jekyll/jekyll/issues/7820
Fix branch: https://github.com/jekyll/jekyll/pull/7821

Fixes #818 