### PR TITLE
Revert inline-block work for now

### DIFF
--- a/css/_uswds-theme-custom-styles.scss
+++ b/css/_uswds-theme-custom-styles.scss
@@ -485,6 +485,7 @@ body {
 .main-content {
   @include u-pin('right');
   @include u-pin('bottom');
+  display: inline-block; // starting: not scrolled
   margin-top: units(5); // starting: not scrolled
   position: relative;
   width: 100%;

--- a/css/_uswds-theme-custom-styles.scss
+++ b/css/_uswds-theme-custom-styles.scss
@@ -485,7 +485,7 @@ body {
 .main-content {
   @include u-pin('right');
   @include u-pin('bottom');
-  padding-top: units(5);
+  margin-top: units(5); // starting: not scrolled
   position: relative;
   width: 100%;
 


### PR DESCRIPTION
The `display: block` change regressed the nav, so we'll revert to the old change for now!