### PR TITLE
[Website] - [UI component]: Fixed typo for guidance accordion on header docs

### DIFF
--- a/_components/headers/headers.html
+++ b/_components/headers/headers.html
@@ -74,7 +74,7 @@ subnav:
   {% include code/accordion.html component="header-basic" %}
   <div class="usa-accordion usa-accordion--bordered site-accordion-docs">
     <button class="usa-button-unstyled usa-accordion__button"
-      aria-expanded="true" aria-controls="docs-header-basic-mega">
+      aria-expanded="true" aria-controls="docs-header-basic">
       Guidance
     </button>
     <div id="docs-header-basic" class="usa-accordion__content site-component-usage">


### PR DESCRIPTION
## Description

The [basic header](https://designsystem.digital.gov/components/header/#basic) "Guidance" accordion doesn't collapse.

## Additional information

The `aria-controls` for the basic header controls the basic header with megamenu instead of the basic header. Simple typo fix.

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
