### PR TITLE
use direct link to editing showcase page

### DIFF
--- a/pages/documentation/getting-started/showcase-all.md
+++ b/pages/documentation/getting-started/showcase-all.md
@@ -3,7 +3,7 @@ permalink: /getting-started/showcase/all/
 layout: styleguide
 title: USWDS powered sites
 category: How to use USWDS
-lead: Below are a list of website and applications currently using USWDS. If your project is currently using USWDS and you do not see it on this list, please feel free to [submit a pull request](https://github.com/uswds/uswds-site/blob/master/pages/documentation/getting-started/showcase-all.md) or email the core team at [uswds@support.digitalgov.gov](mailto:uswds@support.digitalgov.gov).
+lead: Below are a list of website and applications currently using USWDS. If your project is currently using USWDS and you do not see it on this list, please feel free to [submit a pull request](https://github.com/uswds/uswds/blob/develop/docs/WHO_IS_USING_USWDS.md) or email the core team at [uswds@support.digitalgov.gov](mailto:uswds@support.digitalgov.gov).
 ---
 ## Sites using the U.S. Web Design System
 {{ site.data.standards-sites.decoded | newline_to_br | split: '<br />' | where_exp: 'line', 'line contains "- ["' | join: '<br />' | markdownify | absolutify_links: site.data.standards-sites.html_url }}

--- a/pages/documentation/getting-started/showcase-all.md
+++ b/pages/documentation/getting-started/showcase-all.md
@@ -3,7 +3,7 @@ permalink: /getting-started/showcase/all/
 layout: styleguide
 title: USWDS powered sites
 category: How to use USWDS
-lead: Below are a list of website and applications currently using USWDS. If your project is currently using USWDS and you do not see it on this list, please feel free to [submit a pull request](https://github.com/uswds/uswds/pulls/) or email the core team at [uswds@support.digitalgov.gov](mailto:uswds@support.digitalgov.gov).
+lead: Below are a list of website and applications currently using USWDS. If your project is currently using USWDS and you do not see it on this list, please feel free to [submit a pull request](https://github.com/uswds/uswds-site/blob/master/pages/documentation/getting-started/showcase-all.md) or email the core team at [uswds@support.digitalgov.gov](mailto:uswds@support.digitalgov.gov).
 ---
 ## Sites using the U.S. Web Design System
 {{ site.data.standards-sites.decoded | newline_to_br | split: '<br />' | where_exp: 'line', 'line contains "- ["' | join: '<br />' | markdownify | absolutify_links: site.data.standards-sites.html_url }}


### PR DESCRIPTION
I think folks will have a hard time finding the page to edit otherwise.