### PR TITLE
[Settings]: Correct theme-link color variable names

### DIFF
--- a/_data/variables.yml
+++ b/_data/variables.yml
@@ -529,22 +529,22 @@
   - name        : Link color
     section     : true
     description : Color for text links
-    var         : $theme-color-info-family
+    var         : $theme-link-color
     default     : "'primary'"
     kind        : color
   - name        : Visited link color
     description : Color for `:visted` text links
-    var         : $theme-color-info-family
+    var         : $theme-link-visted-color
     default     : "'violet-70v'"
     kind        : color
   - name        : Hover link color
     description : Color for `:hover` text links
-    var         : $theme-color-info-family
+    var         : $theme-link-hover-color
     default     : "'primary-dark'"
     kind        : color
   - name        : Active link color
     description : Color for `:active` text links
-    var         : $theme-color-info-family
+    var         : $theme-link-active-color
     default     : "'primary-darker'"
     kind        : color
 


### PR DESCRIPTION
## Description

The theme variable names for Link colors seem incorrect – they're currently all showing as `$theme-color-info-family` but in the codebase it looks like there are unique variable names for each of these:

![image](https://user-images.githubusercontent.com/371943/73555839-4d027080-441c-11ea-9583-20f169c0cee2.png)

### After this fix:

![image](https://user-images.githubusercontent.com/371943/73557356-06fadc00-441f-11ea-9249-542b1397cacb.png)

--------------

Related: https://github.com/uswds/uswds/pull/3296

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
