### PR TITLE
[Utilities] Show "responsive" bubble as enabled for Font Size utilities

### DIFF
--- a/_components/utilities/font-size-and-family.md
+++ b/_components/utilities/font-size-and-family.md
@@ -52,6 +52,7 @@ utilities:
     {% include utilities/utility-title-bar.html
       title="Font size and family"
       property="font-size, font-family"
+      responsive=true
     %}
     <section class="utility-examples">
 


### PR DESCRIPTION
## Description

I found it confusing that the Font Size utility page made it initially seem like the utility class didn't support the responsive class prefixes, but it actually does by default. I'm guessing this shows as disabled since the Font Family utilities _don't_ support those prefixes by default, so I'm not sure whether this introduces a different type of potential confusion to users.

## Additional information

### Screenshot of how this currently looks

![image](https://user-images.githubusercontent.com/371943/74353860-83c77780-4d88-11ea-8ce9-3fb84598d670.png)

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
