### PR TITLE
[USWDS-Site] - [Mobile Search]: Fix search being cutoff on Firefox mobile.

### DIFF
--- a/css/_uswds-theme-custom-styles.scss
+++ b/css/_uswds-theme-custom-styles.scss
@@ -3151,6 +3151,10 @@ body {
 }
 
 .site-nav {
+  // Search input gets cutoff on mobile.
+  .usagov-search-autocomplete {
+    min-width: 0;
+  }
   .usa-button {
     display: block;
   }


### PR DESCRIPTION
https://github.com/uswds/uswds-site/issues/863

## Description

Added `min-width: 0` to `.usagov-search-autocomplete` to prevent
search from being cutoff.

#### Before
![image](https://user-images.githubusercontent.com/3385219/74553920-eaca6500-4f1d-11ea-9777-5ea98f2442ea.png)

#### After
![image](https://user-images.githubusercontent.com/3385219/74553865-cff7f080-4f1d-11ea-98e0-f5a871658151.png)

---
Additional notes `npm test` error'd out. Investigating.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [ ] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
