### PR TITLE
Update preview link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ title: United States Web Design System
 description: Design and build fast, accessible, mobile-friendly government websites backed by user research.
 google_analytics_ua: UA-48605964-43
 components_url: "https://components.designsystem.digital.gov"
-components_url_v2_preview: "https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/release-2.5.1/components/preview"
+components_url_v2_preview: "https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/release-2.5.1/components/preview"
 meta:
   og:image: /img/uswds-logo/lg-black.png
 


### PR DESCRIPTION
Federalist seems to have updated their URL structure, so I updated our preview URL to match.

Fixes #872 