### PR TITLE
Fix incorrect typography settings var names

### DIFF
--- a/_data/variables.yml
+++ b/_data/variables.yml
@@ -1305,7 +1305,7 @@
     kind        : size
   - name        : Body line height
     description :
-    var         : $theme-body-font-size
+    var         : $theme-body-line-height
     default     : 5
     kind        : line-height
   - name        : Style body element
@@ -1369,17 +1369,17 @@
     kind        : measure
   - name        : Default measure
     description :
-    var         : $theme-h2-font-size
+    var         : $theme-text-measure
     default     : 4
     kind        : measure
   - name        : Wide measure
     description :
-    var         : $theme-h2-font-size
+    var         : $theme-text-measure-wide
     default     : 5
     kind        : measure
   - name        : Prose font family
     description : Font family used for body text in `usa-prose`. Use role-based `family` tokens.
-    var         : $theme-h2-font-size
+    var         : $theme-prose-font-family
     default     : "'body'"
     kind        : family
 


### PR DESCRIPTION
## Description

The documentation site listed incorrect variable names for some typography settings:

![image](https://user-images.githubusercontent.com/371943/76228178-c26d1800-61f6-11ea-98c5-9170d09dd355.png)

This updates those with the correct variables.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
