### PR TITLE
Integrate history content on about landing page

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -108,7 +108,6 @@ Page templates:
 About USWDS:
   - text: Overview
     href: /about/
-  - href: /about/history/
   - href: /about/product-principles/
   - href: /about/whats-new/
   - href: /about/releases/

--- a/pages/about/history.md
+++ b/pages/about/history.md
@@ -1,9 +1,0 @@
----
-title: The history
-permalink: /about/history/
-layout: styleguide
-category: About USWDS
-lead: A brief history of the United States Web Design System
----
-
-The United States Web Design System was created by a collaborative team at 18F and the U.S. Digital Service in 2015, under the guidance of an advisory board of talented, experienced government workers in the CFPB, the Food and Drug Administration, the Department of Veterans Affairs, the Social Security Administration, the Department of Education, the Internal Revenue Service, and GSA. It is currently a project of GSA’s [Technology Transformation Service](https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services), maintained by the Office of Products and Programs. Read about the [initial process](https://18f.gsa.gov/2015/09/28/web-design-standards/) as well as [where we’ve been and where we’re going](https://designsystem.digital.gov/whats-new/updates/2017/12/20/2017-where-weve-been-where-were-going/).

--- a/pages/about/overview.md
+++ b/pages/about/overview.md
@@ -1,6 +1,8 @@
 ---
 title: About USWDS
 permalink: /about/
+redirect_from:
+- /about/history/
 layout: styleguide
 category: About USWDS
 lead: Here you can find the latest news and information about the U.S. Web Design System. Read our latest release notes, learn about USWDS’s impact in the government, and learn how we conduct user research to continuously improve our product and process.

--- a/pages/about/overview.md
+++ b/pages/about/overview.md
@@ -7,7 +7,12 @@ lead: Here you can find the latest news and information about the U.S. Web Desig
 ---
 
 ## Vision
-Empowered agency digital teams share solutions and use effective human-centered design practices.
+Empowered agency digital teams share solutions, use effective human-centered design practices, and improve the lives of the public.
 
 ## Mission
 USWDS is a design system for the federal government. We make it easier to build accessible, mobile-friendly government websites for the American public.
+
+## History
+USWDS was created by a collaborative team at [18F](https://18f.gsa.gov/) and the [U.S. Digital Service](https://www.usds.gov/) in 2015, under the guidance of an advisory board of talented, experienced government workers in the Consumer Financial Protection Bureau, Food and Drug Administration, Department of Veterans Affairs, Social Security Administration, Department of Education, Internal Revenue Service, and GSA. 
+
+It is currently a project of GSA’s [Technology Transformation Services](https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services), maintained by the Office of Solutions. Read about the [initial process](https://18f.gsa.gov/2015/09/28/web-design-standards/) as well as [where we’ve been and where we’re going](https://designsystem.digital.gov/whats-new/updates/2017/12/20/2017-where-weve-been-where-were-going/).


### PR DESCRIPTION
**Description**
As a user, I want to learn about the history of USWDS within the context of its mission and vision.

**Requirement**
Move content from [/About/History](https://designsystem.digital.gov/about/history/) to [/About](https://designsystem.digital.gov/about/)

**Supporting Data**
Simplify content within About section. Make content more accessible.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [ ] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
