### PR TITLE
Add 2020 Roadmap

### DIFF
--- a/css/_uswds-theme-custom-styles.scss
+++ b/css/_uswds-theme-custom-styles.scss
@@ -599,6 +599,7 @@ body {
 }
 
 .label-upcoming {
+  @extend %label-maturity;
   @include u-text("ls-1", "normal");
   @include u-border("base-light", 1px);
   color: color("base-dark");

--- a/css/_uswds-theme-custom-styles.scss
+++ b/css/_uswds-theme-custom-styles.scss
@@ -3245,3 +3245,40 @@ body {
     height: 100%;
   }
 }
+
+.site-roadmap-list,
+.site-roadmap-list__sublist {
+  @include add-list-reset;
+}
+
+.site-roadmap-list {
+  @include u-margin-top(2);
+}
+
+.site-roadmap-list__item,
+.site-roadmap-list__subitem {
+  @include u-border-top(1px);
+  @include u-line-height("lang", 3);
+  @include u-padding-top(0.5);
+  @include u-margin-top(0.5);
+  @include u-display("flex");
+  @include u-flex("wrap", "align-start");
+}
+
+.site-roadmap-list__item {
+  @include u-border-top("ink");
+  @include u-text("bold");
+
+  .usa-tag {
+    @include u-flex("auto");
+  }
+}
+
+.site-roadmap-list__sublist {
+  @include u-width("full");
+
+  .site-roadmap-list__item {
+    @include u-border-top("base-lighter");
+    @include u-text("normal");
+  }
+}

--- a/css/_uswds-theme-custom-styles.scss
+++ b/css/_uswds-theme-custom-styles.scss
@@ -573,8 +573,8 @@ body {
 // Label links
 
 %label-maturity {
-  @include u-font("lang", "2xs");
-  color: color("gray-cool-80");
+  @include typeset("lang", "2xs", 4);
+  color: color("ink");
   font-weight: font-weight("bold");
   margin-left: units(1.5);
   position: absolute;
@@ -588,13 +588,21 @@ body {
 .label-alpha,
 .label-in-progress {
   @extend %label-maturity;
-  background-color: color("gold-5v");
+  background-color: color("gold-20v");
 }
 
 .label-beta,
-.label-to-do {
+.label-next {
   @extend %label-maturity;
-  background-color: color("accent-cool-lighter");
+  background-color: color("primary-vivid");
+  color: color("white");
+}
+
+.label-upcoming {
+  @include u-text("ls-1", "normal");
+  @include u-border("base-light", 1px);
+  color: color("base-dark");
+  background-color: color("transparent");
 }
 
 .label-recommended,

--- a/pages/whats-new/product-roadmap.md
+++ b/pages/whats-new/product-roadmap.md
@@ -27,7 +27,7 @@ You can also <a href="https://github.com/uswds/uswds/milestone/52" class="">view
 
 <div class="maxw-tablet">
   <ul class="site-roadmap-list">
-    <li class="site-roadmap-list__item"><span class="flex-fill">Build most requested new components</span> <span class="usa-tag label-in-progress flex-auto">In progress</span>
+    <li class="site-roadmap-list__item"><span class="flex-fill">Build most-requested new components</span> <span class="usa-tag label-in-progress flex-auto">In progress</span>
       <ul class="site-roadmap-list__sublist">
         <li class="site-roadmap-list__item"><span class="flex-fill">Card</span> <span class="usa-tag label-in-progress">In progress</span></li>
         <li class="site-roadmap-list__item"><span class="flex-fill">Breadcrumb</span> <span class="usa-tag label-to-do">Upcoming</span></li>
@@ -52,13 +52,13 @@ You can also <a href="https://github.com/uswds/uswds/milestone/52" class="">view
         <li class="site-roadmap-list__item">Top tasks</li>
       </ul>
     </li>
-    <li class="site-roadmap-list__item"><span class="flex-fill">Create tailored guides for common user types</span> <span class="usa-tag label-to-do">Upcoming</span></li>
-    <li class="site-roadmap-list__item">Rebuild component library</li>
-    <li class="site-roadmap-list__item"><span class="flex-fill">Improve design assets</span> <span class="usa-tag label-in-progress">In progress</span></li>
-    <li class="site-roadmap-list__item">Develop contribution model</li>
-    <li class="site-roadmap-list__item">Improve test suite</li>
+    <li class="site-roadmap-list__item"><span class="flex-fill">Simplify and improve design assets</span> <span class="usa-tag label-in-progress">In progress</span></li>
     <li class="site-roadmap-list__item"><span class="flex-fill">Develop product design principles</span> <span class="usa-tag label-in-progress">In progress</span></li>
     <li class="site-roadmap-list__item"><span class="flex-fill">Update USWDS Jekyll theme to USWDS 2</span> <span class="usa-tag label-in-progress">In progress</span></li>
+    <li class="site-roadmap-list__item"><span class="flex-fill">Create tailored guides for common user types</span> <span class="usa-tag label-to-do">Upcoming</span></li>
+    <li class="site-roadmap-list__item">Rebuild component library</li>
+    <li class="site-roadmap-list__item">Develop contribution model</li>
+    <li class="site-roadmap-list__item">Improve test suite</li>
   </ul>
 </div>
 

--- a/pages/whats-new/product-roadmap.md
+++ b/pages/whats-new/product-roadmap.md
@@ -30,15 +30,14 @@ You can also <a href="https://github.com/uswds/uswds/milestone/52" class="">view
     <li class="site-roadmap-list__item"><span class="flex-fill">Build most requested new components</span> <span class="usa-tag label-in-progress flex-auto">In progress</span>
       <ul class="site-roadmap-list__sublist">
         <li class="site-roadmap-list__item"><span class="flex-fill">Card</span> <span class="usa-tag label-in-progress">In progress</span></li>
-        <li class="site-roadmap-list__item">Breadcrumb</li>
-        <li class="site-roadmap-list__item">Tooltip</li>
+        <li class="site-roadmap-list__item"><span class="flex-fill">Breadcrumb</span> <span class="usa-tag label-to-do">Upcoming</span></li>
         <li class="site-roadmap-list__item"><span class="flex-fill">Character limit</span> <span class="usa-tag label-in-progress">In progress</span></li>
         <li class="site-roadmap-list__item"><span class="flex-fill">Autocomplete combobox</span> <span class="usa-tag label-in-progress">In progress</span></li>
         <li class="site-roadmap-list__item"><span class="flex-fill">Button group</span> <span class="usa-tag label-in-progress">In progress</span></li>
-        <li class="site-roadmap-list__item">Date picker</li>
-        <li class="site-roadmap-list__item">Date range picker</li>
-        <li class="site-roadmap-list__item">Time picker</li>
-        <li class="site-roadmap-list__item">Date and time picker</li>
+        <li class="site-roadmap-list__item"><span class="flex-fill">Date picker</span>  <span class="usa-tag label-to-do">Upcoming</span></li>
+        <li class="site-roadmap-list__item"><span class="flex-fill">Date range picker</span>  <span class="usa-tag label-to-do">Upcoming</span></li>
+        <li class="site-roadmap-list__item"><span class="flex-fill">Time picker</span>  <span class="usa-tag label-to-do">Upcoming</span></li>
+        <li class="site-roadmap-list__item"><span class="flex-fill">Date and time picker</span> <span class="usa-tag label-to-do">Upcoming</span></li>
         <li class="site-roadmap-list__item">Tooltip</li>
         <li class="site-roadmap-list__item">Document upload</li>
         <li class="site-roadmap-list__item">Progress bar</li>
@@ -53,7 +52,7 @@ You can also <a href="https://github.com/uswds/uswds/milestone/52" class="">view
         <li class="site-roadmap-list__item">Top tasks</li>
       </ul>
     </li>
-    <li class="site-roadmap-list__item">Create tailored guides for common user types</li>
+    <li class="site-roadmap-list__item"><span class="flex-fill">Create tailored guides for common user types</span> <span class="usa-tag label-to-do">Upcoming</span></li>
     <li class="site-roadmap-list__item">Rebuild component library</li>
     <li class="site-roadmap-list__item"><span class="flex-fill">Improve design assets</span> <span class="usa-tag label-in-progress">In progress</span></li>
     <li class="site-roadmap-list__item">Develop contribution model</li>

--- a/pages/whats-new/product-roadmap.md
+++ b/pages/whats-new/product-roadmap.md
@@ -26,35 +26,35 @@ You can also <a href="https://github.com/uswds/uswds/milestone/52" class="">view
     <li class="site-roadmap-list__item"><span class="flex-fill">Build most-requested new components</span> <span class="usa-tag label-in-progress flex-auto">In progress</span>
       <ul class="site-roadmap-list__sublist">
         <li class="site-roadmap-list__item"><span class="flex-fill">Card</span> <span class="usa-tag label-in-progress">In progress</span></li>
-        <li class="site-roadmap-list__item"><span class="flex-fill">Breadcrumb</span> <span class="usa-tag label-to-do">Upcoming</span></li>
+        <li class="site-roadmap-list__item"><span class="flex-fill">Breadcrumb</span> <span class="usa-tag label-next">On deck</span></li>
         <li class="site-roadmap-list__item"><span class="flex-fill">Character limit</span> <span class="usa-tag label-in-progress">In progress</span></li>
         <li class="site-roadmap-list__item"><span class="flex-fill">Autocomplete combobox</span> <span class="usa-tag label-in-progress">In progress</span></li>
         <li class="site-roadmap-list__item"><span class="flex-fill">Button group</span> <span class="usa-tag label-in-progress">In progress</span></li>
-        <li class="site-roadmap-list__item"><span class="flex-fill">Date picker</span>  <span class="usa-tag label-to-do">Upcoming</span></li>
-        <li class="site-roadmap-list__item"><span class="flex-fill">Date range picker</span>  <span class="usa-tag label-to-do">Upcoming</span></li>
-        <li class="site-roadmap-list__item"><span class="flex-fill">Time picker</span>  <span class="usa-tag label-to-do">Upcoming</span></li>
-        <li class="site-roadmap-list__item"><span class="flex-fill">Date and time picker</span> <span class="usa-tag label-to-do">Upcoming</span></li>
-        <li class="site-roadmap-list__item">Tooltip</li>
-        <li class="site-roadmap-list__item">Document upload</li>
-        <li class="site-roadmap-list__item">Progress bar</li>
-        <li class="site-roadmap-list__item">Anchor</li>
-        <li class="site-roadmap-list__item">Tabs</li>
-        <li class="site-roadmap-list__item">Icons</li>
-        <li class="site-roadmap-list__item">Button icon</li>
-        <li class="site-roadmap-list__item">Paginator</li>
-        <li class="site-roadmap-list__item">Advanced layout</li>
-        <li class="site-roadmap-list__item">Glossary</li>
-        <li class="site-roadmap-list__item">Data tables</li>
-        <li class="site-roadmap-list__item">Top tasks</li>
+        <li class="site-roadmap-list__item"><span class="flex-fill">Date picker</span>  <span class="usa-tag label-next">On deck</span></li>
+        <li class="site-roadmap-list__item"><span class="flex-fill">Date range picker</span>  <span class="usa-tag label-next">On deck</span></li>
+        <li class="site-roadmap-list__item"><span class="flex-fill">Time picker</span>  <span class="usa-tag label-next">On deck</span></li>
+        <li class="site-roadmap-list__item"><span class="flex-fill">Date and time picker</span> <span class="usa-tag label-next">On deck</span></li>
+        <li class="site-roadmap-list__item"><span class="flex-fill">Tooltip</span> <span class="usa-tag label-upcoming">Upcoming</span></li>
+        <li class="site-roadmap-list__item"><span class="flex-fill">Document upload</span> <span class="usa-tag label-upcoming">Upcoming</span></li>
+        <li class="site-roadmap-list__item"><span class="flex-fill">Progress bar</span> <span class="usa-tag label-upcoming">Upcoming</span></li>
+        <li class="site-roadmap-list__item"><span class="flex-fill">Anchor</span> <span class="usa-tag label-upcoming">Upcoming</span></li>
+        <li class="site-roadmap-list__item"><span class="flex-fill">Tabs</span> <span class="usa-tag label-upcoming">Upcoming</span></li>
+        <li class="site-roadmap-list__item"><span class="flex-fill">Icons</span> <span class="usa-tag label-upcoming">Upcoming</span></li>
+        <li class="site-roadmap-list__item"><span class="flex-fill">Button icon</span> <span class="usa-tag label-upcoming">Upcoming</span></li>
+        <li class="site-roadmap-list__item"><span class="flex-fill">Paginator</span> <span class="usa-tag label-upcoming">Upcoming</span></li>
+        <li class="site-roadmap-list__item"><span class="flex-fill">Advanced layout</span> <span class="usa-tag label-upcoming">Upcoming</span></li>
+        <li class="site-roadmap-list__item"><span class="flex-fill">Glossary</span> <span class="usa-tag label-upcoming">Upcoming</span></li>
+        <li class="site-roadmap-list__item"><span class="flex-fill">Data tables</span> <span class="usa-tag label-upcoming">Upcoming</span></li>
+        <li class="site-roadmap-list__item"><span class="flex-fill">Top tasks</span> <span class="usa-tag label-upcoming">Upcoming</span></li>
       </ul>
     </li>
     <li class="site-roadmap-list__item"><span class="flex-fill">Simplify and improve design assets</span> <span class="usa-tag label-in-progress">In progress</span></li>
     <li class="site-roadmap-list__item"><span class="flex-fill">Develop product design principles</span> <span class="usa-tag label-in-progress">In progress</span></li>
     <li class="site-roadmap-list__item"><span class="flex-fill">Update USWDS Jekyll theme to USWDS 2</span> <span class="usa-tag label-in-progress">In progress</span></li>
-    <li class="site-roadmap-list__item"><span class="flex-fill">Create tailored guides for common user types</span> <span class="usa-tag label-to-do">Upcoming</span></li>
-    <li class="site-roadmap-list__item">Rebuild component library</li>
-    <li class="site-roadmap-list__item">Develop contribution model</li>
-    <li class="site-roadmap-list__item">Improve test suite</li>
+    <li class="site-roadmap-list__item"><span class="flex-fill">Create tailored guides for common user types</span> <span class="usa-tag label-next">On deck</span></li>
+    <li class="site-roadmap-list__item"><span class="flex-fill">Rebuild component library</span> <span class="usa-tag label-upcoming">Upcoming</span></li>
+    <li class="site-roadmap-list__item"><span class="flex-fill">Develop contribution model</span> <span class="usa-tag label-upcoming">Upcoming</span></li>
+    <li class="site-roadmap-list__item"><span class="flex-fill">Improve test suite</span> <span class="usa-tag label-upcoming">Upcoming</span></li>
   </ul>
 </div>
 

--- a/pages/whats-new/product-roadmap.md
+++ b/pages/whats-new/product-roadmap.md
@@ -7,10 +7,6 @@ layout: styleguide
 title: Product roadmap
 category: About USWDS
 lead: Here, you’ll find our product roadmap — an up-to-date report on the work we’re doing.
-subnav:
-  data: milestones
-  href: ['#%', id]
-  text: title
 redirect_from:
   - /whats-new/product-roadmap/
 ---

--- a/pages/whats-new/product-roadmap.md
+++ b/pages/whats-new/product-roadmap.md
@@ -66,7 +66,7 @@ You can also <a href="https://github.com/uswds/uswds/milestone/52" class="">view
     <li class="site-roadmap-list__item">Blueprint incremental upgrade path</li>
     <li class="site-roadmap-list__item">Blueprint USWDS API</li>
     <li class="site-roadmap-list__item">Improve communication of system state and changes</li>
-    <li class="site-roadmap-list__item">Pilot github communities</li>
+    <li class="site-roadmap-list__item">Pilot GitHub communities</li>
     <li class="site-roadmap-list__item">Blueprint research repo</li>
   </ul>
 </div>

--- a/pages/whats-new/product-roadmap.md
+++ b/pages/whats-new/product-roadmap.md
@@ -18,24 +18,60 @@ redirect_from:
 Below is our product roadmap: a long-term plan of the goals, features,
 and long-term direction of USWDS. We update this
 every few months with the status of our progress, as well as add new
-high-level future requests and ideas. You can also <a href="https://github.com/uswds/uswds/milestone/52" class="">view our product roadmap goals on GitHub</a>.
+high-level future requests and ideas.
 
-{% for milestone in site.data.milestones %}
-<section>
-  <h2 id="{{ milestone.id }}">{{ milestone.title }}</h2>
-  <ul class="product-roadmap-list usa-list">
-  {% for task in milestone.tasks %}
-    <li>
-      <a href="{{ task.url }}">
-        {{ task.title }}
-      </a>
-      {% if task.status %}
-        <span class="usa-tag label-{{ task.status | slugify }}">
-          {{ task.status }}
-        </span>
-      {% endif %}
+<!-- TODO: Make these into issues; add roadmap project board
+You can also <a href="https://github.com/uswds/uswds/milestone/52" class="">view our product roadmap goals on GitHub</a>. -->
+
+<h2>2020 Roadmap</h2>
+
+<div class="maxw-tablet">
+  <ul class="site-roadmap-list">
+    <li class="site-roadmap-list__item"><span class="flex-fill">Build most requested new components</span> <span class="usa-tag label-in-progress flex-auto">In progress</span>
+      <ul class="site-roadmap-list__sublist">
+        <li class="site-roadmap-list__item"><span class="flex-fill">Card</span> <span class="usa-tag label-in-progress">In progress</span></li>
+        <li class="site-roadmap-list__item">Breadcrumb</li>
+        <li class="site-roadmap-list__item">Tooltip</li>
+        <li class="site-roadmap-list__item"><span class="flex-fill">Character limit</span> <span class="usa-tag label-in-progress">In progress</span></li>
+        <li class="site-roadmap-list__item"><span class="flex-fill">Autocomplete combobox</span> <span class="usa-tag label-in-progress">In progress</span></li>
+        <li class="site-roadmap-list__item"><span class="flex-fill">Button group</span> <span class="usa-tag label-in-progress">In progress</span></li>
+        <li class="site-roadmap-list__item">Date picker</li>
+        <li class="site-roadmap-list__item">Date range picker</li>
+        <li class="site-roadmap-list__item">Time picker</li>
+        <li class="site-roadmap-list__item">Date and time picker</li>
+        <li class="site-roadmap-list__item">Tooltip</li>
+        <li class="site-roadmap-list__item">Document upload</li>
+        <li class="site-roadmap-list__item">Progress bar</li>
+        <li class="site-roadmap-list__item">Anchor</li>
+        <li class="site-roadmap-list__item">Tabs</li>
+        <li class="site-roadmap-list__item">Icons</li>
+        <li class="site-roadmap-list__item">Button icon</li>
+        <li class="site-roadmap-list__item">Paginator</li>
+        <li class="site-roadmap-list__item">Advanced layout</li>
+        <li class="site-roadmap-list__item">Glossary</li>
+        <li class="site-roadmap-list__item">Data tables</li>
+        <li class="site-roadmap-list__item">Top tasks</li>
+      </ul>
     </li>
-  {% endfor %}
+    <li class="site-roadmap-list__item">Create tailored guides for common user types</li>
+    <li class="site-roadmap-list__item">Rebuild component library</li>
+    <li class="site-roadmap-list__item"><span class="flex-fill">Improve design assets</span> <span class="usa-tag label-in-progress">In progress</span></li>
+    <li class="site-roadmap-list__item">Develop contribution model</li>
+    <li class="site-roadmap-list__item">Improve test suite</li>
+    <li class="site-roadmap-list__item"><span class="flex-fill">Develop product design principles</span> <span class="usa-tag label-in-progress">In progress</span></li>
+    <li class="site-roadmap-list__item"><span class="flex-fill">Update USWDS Jekyll theme to USWDS 2</span> <span class="usa-tag label-in-progress">In progress</span></li>
   </ul>
-</section>
-{% endfor %}
+</div>
+
+<h3>Reach goals</h3>
+<div class="maxw-tablet">
+  <ul class="site-roadmap-list__sublist">
+    <li class="site-roadmap-list__item"><span class="flex-fill">Streamline and modernize USWDS Jekyll theme</span></li>
+    <li class="site-roadmap-list__item">Add more page templates</li>
+    <li class="site-roadmap-list__item">Blueprint incremental upgrade path</li>
+    <li class="site-roadmap-list__item">Blueprint USWDS API</li>
+    <li class="site-roadmap-list__item">Improve communication of system state and changes</li>
+    <li class="site-roadmap-list__item">Pilot github communities</li>
+    <li class="site-roadmap-list__item">Blueprint research repo</li>
+  </ul>
+</div>


### PR DESCRIPTION
This adds the USWDS 2020 Roadmap with the current status of each roadmap item.

[Preview](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/dw-update-roadmap/about/product-roadmap/)→ 

Fixes #905 