### PR TITLE
Add slim and no-icon alerts

### DIFF
--- a/_includes/code/components/alerts.html
+++ b/_includes/code/components/alerts.html
@@ -1,8 +1,8 @@
 <h6>Standard alerts</h6>
 
-{% capture alerts--default %}
-  {% fractal_component alerts--default %}
-{% endcapture %}{{ alerts--default | strip }}
+{% capture alerts--info %}
+  {% fractal_component alerts--info %}
+{% endcapture %}{{ alerts--info | strip }}
 
 {% capture alerts--warning %}
   {% fractal_component alerts--warning %}
@@ -12,10 +12,9 @@
   {% fractal_component alerts--error %}
 {% endcapture %}{{ alerts--error | strip }}
 
-<!-- TODO: The success alert is rendering as info -->
-{% capture alerts--info %}
-  {% fractal_component alerts--info %}
-{% endcapture %}{{ alerts--info | strip }}
+{% capture alerts--success %}
+  {% fractal_component alerts--success %}
+{% endcapture %}{{ alerts--success | strip }}
 
 
 <h6>Slim alert</h6>

--- a/_includes/code/components/alerts.html
+++ b/_includes/code/components/alerts.html
@@ -16,7 +16,6 @@
   {% fractal_component alerts--success %}
 {% endcapture %}{{ alerts--success | strip }}
 
-
 <h6>Slim alert</h6>
 
 {% capture alerts--slim %}

--- a/_includes/code/components/alerts.html
+++ b/_includes/code/components/alerts.html
@@ -1,15 +1,31 @@
-{% capture alerts--info %}
-  {% fractal_component alerts--info %}
-{% endcapture %}{{ alerts--info | strip }}
+<h6>Standard alerts</h6>
+
+{% capture alerts--default %}
+  {% fractal_component alerts--default %}
+{% endcapture %}{{ alerts--default | strip }}
 
 {% capture alerts--warning %}
   {% fractal_component alerts--warning %}
 {% endcapture %}{{ alerts--warning | strip }}
 
-{% capture alerts--warning %}
+{% capture alerts--error %}
   {% fractal_component alerts--error %}
-{% endcapture %}{{ alerts--warning | strip }}
+{% endcapture %}{{ alerts--error | strip }}
 
-{% capture alerts--warning %}
-  {% fractal_component alerts--default %}
-{% endcapture %}{{ alerts--warning | strip }}
+<!-- TODO: The success alert is rendering as info -->
+{% capture alerts--info %}
+  {% fractal_component alerts--info %}
+{% endcapture %}{{ alerts--info | strip }}
+
+
+<h6>Slim alert</h6>
+
+{% capture alerts--slim %}
+  {% fractal_component alerts--slim %}
+{% endcapture %}{{ alerts--slim | strip }}
+
+<h6>Alert with no icon</h6>
+
+{% capture alerts--no-icon %}
+  {% fractal_component alerts--no-icon %}
+{% endcapture %}{{ alerts--no-icon | strip }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12962,9 +12962,8 @@
       "dev": true
     },
     "uswds": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/uswds/-/uswds-2.6.0.tgz",
-      "integrity": "sha512-5Q8ijTMBJdJSoiU01RTTk/eGVkjeKBsIOTiY1l5xq8M0wURKWeHzfh0a/Lj4vozwbh1h0onrvPJkyaklHKtFOQ==",
+      "version": "github:uswds/uswds#01cce9e0323d8ff6319233f3fe1a11a6c96fc5a1",
+      "from": "github:uswds/uswds#develop",
       "requires": {
         "@types/node": "^13.9.1",
         "classlist-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "jquery": "^3.4.1",
-    "uswds": "^2.6.0"
+    "uswds": "github:uswds/uswds#develop"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",


### PR DESCRIPTION
[Preview](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/dw-add-slim-alert/components/alert/)→ 
This adds the `slim` and `no-icon` variants into the preview and code sections of the Alert page.

<img width="956" alt="Screen Shot 2020-04-09 at 9 24 16 AM" src="https://user-images.githubusercontent.com/11464021/78917627-ffba0500-7a43-11ea-8e6c-ebbab78d2871.png">

**Note:** This is in draft pending merge of https://github.com/uswds/uswds/pull/3388