### PR TITLE
Fix output of utility title bars

### DIFF
--- a/_components/utilities/border.md
+++ b/_components/utilities/border.md
@@ -36,7 +36,7 @@ utilities:
   responsive:   true
   active:       false
   focus:        false
-  hover:        true
+  hover:        false
   visited:      false
 - base:         border
   var:          border-width

--- a/_components/utilities/border.md
+++ b/_components/utilities/border.md
@@ -33,15 +33,15 @@ utilities:
 - base:         border
   var:          border-style
   output:       true
-  responsive:   false
+  responsive:   true
   active:       false
   focus:        false
-  hover:        false
+  hover:        true
   visited:      false
 - base:         border
   var:          border-width
   output:       true
-  responsive:   false
+  responsive:   true
   active:       false
   focus:        false
   hover:        false
@@ -106,8 +106,6 @@ utilities:
     {% include utilities/utility-title-bar.html
       title="Border"
       property="border, border-bottom, border-left, border-right, border-top"
-      responsive=true
-      hover=true
     %}
 
     <section class="utility-examples">
@@ -344,8 +342,6 @@ utilities:
     {% include utilities/utility-title-bar.html
       title="Border style"
       property="border-style"
-      responsive=true
-      hover=true
     %}
     <section class="utility-examples">
       <div class="utility-example-container">
@@ -391,7 +387,6 @@ utilities:
     {% include utilities/utility-title-bar.html
       title="Border width"
       property="border-width"
-      responsive=true
     %}
 
     <section class="utility-examples">
@@ -477,8 +472,6 @@ utilities:
     {% include utilities/utility-title-bar.html
       title="Border color"
       property="border-color"
-      responsive=true
-      hover=true
     %}
 
     <section class="utility-examples">
@@ -577,7 +570,6 @@ utilities:
     {% include utilities/utility-title-bar.html
       title="Border radius"
       property="border-radius"
-      responsive=true
     %}
 
     <section class="utility-examples">

--- a/_components/utilities/color.md
+++ b/_components/utilities/color.md
@@ -60,6 +60,7 @@ utilities:
     {% include utilities/utility-title-bar.html
       title="Text color"
       property="color"
+      var="color"
     %}
 
     <section class="utility-examples">

--- a/_components/utilities/color.md
+++ b/_components/utilities/color.md
@@ -60,8 +60,6 @@ utilities:
     {% include utilities/utility-title-bar.html
       title="Text color"
       property="color"
-      responsive=true
-      hover=true
     %}
 
     <section class="utility-examples">
@@ -154,7 +152,6 @@ utilities:
     {% include utilities/utility-title-bar.html
       title="Background color"
       property="background-color"
-      hover=true
     %}
 
     <section class="utility-examples">

--- a/_components/utilities/display.md
+++ b/_components/utilities/display.md
@@ -465,6 +465,7 @@ utilities:
     {% include utilities/utility-title-bar.html
       title="Relative position"
       property="top, bottom, left, right"
+      var="top"
     %}
 
     <section class="utility-examples">

--- a/_components/utilities/flex.md
+++ b/_components/utilities/flex.md
@@ -407,6 +407,7 @@ utilities:
   <section class="utility" id="utility-flex-align">
     {% include utilities/utility-title-bar.html
       title="Flex align"
+      var="align-items"
     %}
     <section class="utility-examples">
 
@@ -511,6 +512,7 @@ utilities:
     {% include utilities/utility-title-bar.html
       title="Flex justify"
       property="justify-content"
+      var="justify-content"
     %}
     <section class="utility-examples">
 

--- a/_components/utilities/font-size-and-family.md
+++ b/_components/utilities/font-size-and-family.md
@@ -52,6 +52,7 @@ utilities:
     {% include utilities/utility-title-bar.html
       title="Font size and family"
       property="font-size, font-family"
+      var="font"
     %}
     <section class="utility-examples">
 

--- a/_components/utilities/height-and-width.md
+++ b/_components/utilities/height-and-width.md
@@ -234,6 +234,7 @@ utilities:
     {% include utilities/utility-title-bar.html
       title="Maximum height"
       property="max-height"
+      var="max-height"
     %}
     <section class="utility-examples">
       {% for item in maxh_values %}
@@ -249,6 +250,7 @@ utilities:
     {% include utilities/utility-title-bar.html
       title="Maximum width"
       property="max-width"
+      var="max-width"
     %}
     <section class="utility-examples">
       {% for item in maxw_values %}
@@ -264,6 +266,7 @@ utilities:
     {% include utilities/utility-title-bar.html
       title="Minimum height"
       property="min-height"
+      var="min-height"
     %}
     <section class="utility-examples">
       {% for item in minh_values %}
@@ -279,6 +282,7 @@ utilities:
     {% include utilities/utility-title-bar.html
       title="Minimum width"
       property="min-width"
+      var="min-width"
     %}
     <section class="utility-examples">
       {% for item in minw_values %}
@@ -294,6 +298,7 @@ utilities:
     {% include utilities/utility-title-bar.html
       title="Aspect ratio"
       property=false
+      var="add-aspect"
     %}
     <section class="utility-examples">
       <div class="utility-example-container">

--- a/_components/utilities/list-reset.md
+++ b/_components/utilities/list-reset.md
@@ -32,6 +32,7 @@ utilities:
       {% include utilities/utility-title-bar.html
         title="List reset"
         property=false
+        var="add-list-reset"
       %}
       <section class="utility-examples">
         {% assign thisWrap =              false %}

--- a/_components/utilities/margin-and-padding.md
+++ b/_components/utilities/margin-and-padding.md
@@ -105,7 +105,6 @@ utilities:
   <section class="utility" id="margin">
     {% include utilities/utility-title-bar.html
       title="Margin"
-      responsive=true
     %}
     <section class="utility-examples">
       <h4 class="utility-examples-title">Margin on all sides</h4>
@@ -419,7 +418,6 @@ utilities:
   <section class="utility" id="padding">
     {% include utilities/utility-title-bar.html
       title="Padding"
-      responsive=true
     %}
     <section class="utility-examples">
       <h4 class="utility-examples-title">Padding on all sides</h4>

--- a/_components/utilities/paragraph-styles.md
+++ b/_components/utilities/paragraph-styles.md
@@ -298,6 +298,7 @@ vals_negative:
       {% include utilities/utility-title-bar.html
         title="Text alignment"
         property="text-align"
+        var="text-align"
       %}
       <section class="utility-examples">
         {% assign alignments = 'left, center, right, justify'

--- a/_components/utilities/shadow.md
+++ b/_components/utilities/shadow.md
@@ -36,6 +36,7 @@ utilities:
     {% include utilities/utility-title-bar.html
       title="Shadow"
       property="box-shadow"
+      var="box-shadow"
     %}
     <section class="utility-examples">
       {% for item in site.data.tokens.shadow %}

--- a/_components/utilities/text-styles.md
+++ b/_components/utilities/text-styles.md
@@ -156,6 +156,7 @@ utilities:
     {% include utilities/utility-title-bar.html
       title="Letterspacing"
       property="letter-spacing"
+      var="letter-spacing"
     %}
     <section class="utility-examples">
       <p class="utility-example-container grid-row">
@@ -193,6 +194,7 @@ utilities:
     {% include utilities/utility-title-bar.html
       title="Tabular numerals"
       property="font-feature-settings"
+      var="font-feature-settings"
     %}
     <section class="utility-examples">
       <div class="utility-example-container">
@@ -214,7 +216,6 @@ utilities:
   <section class="utility" id="text-decoration">
     {% include utilities/utility-title-bar.html
       title="Text decoration"
-      hover=true
     %}
     <section class="utility-examples">
       <p class="utility-example-container text-underline">.text-underline</p>
@@ -227,7 +228,6 @@ utilities:
   <section class="utility" id="text-decoration-color">
     {% include utilities/utility-title-bar.html
       title="Text decoration color"
-      hover=true
     %}
     <section class="utility-examples">
 
@@ -260,7 +260,7 @@ utilities:
     {% include utilities/utility-title-bar.html
       title="Uppercase and lowercase"
       property="text-transform"
-      active=true
+      var="text-transform"
     %}
     <section class="utility-examples">
       <p class="utility-example-container text-uppercase">.text-uppercase</p>
@@ -274,6 +274,7 @@ utilities:
     {% include utilities/utility-title-bar.html
       title="Vertical alignment"
       property="vertical-align"
+      var="vertical-align"
     %}
     <section class="utility-examples">
       <p class="utility-example-container">A line of text and <span class="display-inline-block bg-red height-2px width-4 text-baseline"></span> <span class="text-baseline text-red">.text-baseline</span></p>
@@ -291,6 +292,7 @@ utilities:
     {% include utilities/utility-title-bar.html
       title="Whitespace formatting"
       property="white-space"
+      var="whitespace"
     %}
     <section class="utility-examples">
       <p class="utility-example-container"><span class="display-inline-block width-card padding-1 border-1px"> <span class="text-pre"><span class="text-red">.text-pre</span> formatted line   with     multiple       spaces</span></span></p>

--- a/_includes/utilities/utility-title-bar.html
+++ b/_includes/utilities/utility-title-bar.html
@@ -1,3 +1,7 @@
+
+{% assign this_var = include.title | slugify %}
+{% assign utility = page.utilities | where: "var", this_var | first%}
+
 <section class="utility-title-bar">
   <div class="usa-grid-row">
     <div class="usa-grid-col utility-name">
@@ -8,27 +12,27 @@
     </div>
 
     <ul class="usa-grid-col utility-scope">
-      {% if include.responsive %}
+      {% if utility.responsive %}
         <li class="utility-scope-button-active"><a href="#responsive-variants">responsive</a></li>
       {% else %}
         <li class="utility-scope-button-disabled">responsive</li>
       {% endif %}
-      {% if include.active %}
+      {% if utility.active %}
         <li class="utility-scope-button-active"><a href="#state-variants">active</a></li>
       {% else %}
         <li class="utility-scope-button-disabled">active</li>
       {% endif %}
-      {% if include.hover %}
+      {% if utility.hover %}
         <li class="utility-scope-button-active"><a href="#state-variants">hover</a></li>
       {% else %}
         <li class="utility-scope-button-disabled">hover</li>
       {% endif %}
-      {% if include.focus %}
+      {% if utility.focus %}
         <li class="utility-scope-button-active"><a href="#state-variants">focus</a></li>
       {% else %}
         <li class="utility-scope-button-disabled">focus</li>
       {% endif %}
-      {% if include.visited %}
+      {% if utility.visited %}
         <li class="utility-scope-button-active"><a href="#state-variants">visited</a></li>
       {% else %}
         <li class="utility-scope-button-disabled">visited</li>

--- a/_includes/utilities/utility-title-bar.html
+++ b/_includes/utilities/utility-title-bar.html
@@ -1,5 +1,9 @@
+{% if include.var %}
+  {% assign this_var = include.var %}
+{% else %}
+  {% assign this_var = include.title | slugify %}
+{% endif %}
 
-{% assign this_var = include.title | slugify %}
 {% assign utility = page.utilities | where: "var", this_var | first%}
 
 <section class="utility-title-bar">

--- a/package-lock.json
+++ b/package-lock.json
@@ -7519,9 +7519,9 @@
       "dev": true
     },
     "jquery": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
+      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ=="
     },
     "js-base64": {
       "version": "2.5.2",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "prepare": "npm run snyk-protect"
   },
   "dependencies": {
-    "jquery": "^3.4.1",
+    "jquery": "^3.5.0",
     "uswds": "github:uswds/uswds#develop"
   },
   "devDependencies": {


### PR DESCRIPTION
There were some instances where the utility title bar on our website wasn't showing the accurate options available to the utility (ie, not showing that a utility was responsive when it actually was). This simplifies the code to use fewer custom overrides, and check the data against the defaults in `uswds`.

For instance [this update](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/dw-fix-utility-title-bar/utilities/color/) now shows that `color` outputs only `hover` variants by default and [the current site](https://designsystem.digital.gov/utilities/color/) indicates that `color` is also responsive by default, which it is not.

This also updates jquery to `3.5.0` to fix a Snyk warning