### PR TITLE
USWDS-916: Add `Edit this Page` button to support community page edits.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'json', '>= 2.3.0'
 gem 'jekyll-redirect-from', '>= 0.13.0'
 gem 'jekyll-sitemap'
 gem 'scss_lint'
+gem 'jekyll-github-metadata'
 
 gem 'rspec-core'
 gem 'rspec-expectations'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,11 +31,16 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     eventmachine (1.2.7)
+    faraday (1.0.1)
+      multipart-post (>= 1.2, < 3)
     ffi (1.11.2)
     forwardable-extended (2.6.0)
     http_parser.rb (0.6.0)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
+    jekyll-github-metadata (2.13.0)
+      jekyll (>= 3.4, < 5.0)
+      octokit (~> 4.0, != 4.4.0)
     jekyll-redirect-from (0.15.0)
       jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (2.1.0)
@@ -54,6 +59,10 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
+    multipart-post (2.1.1)
+    octokit (4.18.0)
+      faraday (>= 0.9)
+      sawyer (~> 0.8.0, >= 0.5.3)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.4)
@@ -77,6 +86,9 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
     sassc (2.3.0)
       ffi (~> 1.9)
+    sawyer (0.8.2)
+      addressable (>= 2.3.5)
+      faraday (> 0.8, < 2.0)
     scss_lint (0.58.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5, >= 3.5.5)
@@ -89,6 +101,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll!
+  jekyll-github-metadata
   jekyll-redirect-from (>= 0.13.0)
   jekyll-sitemap
   json (>= 2.3.0)

--- a/_config.yml
+++ b/_config.yml
@@ -61,9 +61,14 @@ defaults:
     values:
       layout: post
 
+github:
+  source:
+    branch: master
+
 plugins:
   - jekyll-redirect-from
   - jekyll-sitemap
+  - jekyll-github-metadata
 
 exclude:
   - ".ruby-version"

--- a/_includes/contribute-cta.html
+++ b/_includes/contribute-cta.html
@@ -1,0 +1,6 @@
+<div class="usa-alert usa-alert--info usa-alert--no-icon">
+  <div class="usa-alert__body">
+    <h3 class="usa-alert__heading">Contribute</h3>
+    <p class="usa-alert__text">This site is open source. <a href="{% github_edit_link %}">Help us improve this page</a></p>
+  </div>
+</div>

--- a/_layouts/styleguide.html
+++ b/_layouts/styleguide.html
@@ -31,6 +31,8 @@ layout: default
       {% include lead.html text=page.lead %}
 
       {{ content }}
+
+      {% include contribute-cta.html %}
     </div>
   </main>
 </div>


### PR DESCRIPTION
## Description
Resolves #916 

Adds basic alert with call to action on styleguide pages (for now) as
proof of concept.

- Add `jekyll-github-metadata` plugin
- Create CTA for page edits on styleguide

## Additional information

![image](https://user-images.githubusercontent.com/3385219/81602724-bdf9e280-9392-11ea-9125-06e2a005701b.png)

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [ ] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
