### PR TITLE
Fix out-of-sync color tokens

### DIFF
--- a/_data/tokens/color.yml
+++ b/_data/tokens/color.yml
@@ -238,9 +238,9 @@ system:
     - token: red-50v
       value: "#e52207"
     - token: red-60v
-      value: "#b51d09"
+      value: "#b50909"
     - token: red-70v
-      value: "#8b1303"
+      value: "#8b0a03"
     - token: red-80v
       value: "#5c1111"
     - token: red-90v


### PR DESCRIPTION
[Preview](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/dw-fix-color-tokens/design-tokens/color/system-tokens/) → 

There are a couple color tokens out of sync with their proper token values. 

Red 60v `#b51d09` → `#b50909`
Red 70v `#8b1303` → `#8b0a03`

Note: This PR is a companion to https://github.com/uswds/uswds/pull/3455. Merge that PR first. Then, rebuild this PR to check that we also see the correct values for the following:

Indigo cool 60v → `#3e4ded`
Indigo cool 70v → `#222fbf`
Indigo cool 80v → `#1b2b85`

When both PR's are merged, this fixes https://github.com/uswds/uswds/issues/3398  