### PR TITLE
USWDS-3316: Add img role to meaningful SVG images.

### DIFF
--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -18,7 +18,7 @@
     <div class="usa-banner__content usa-accordion__content" id="gov-banner">
       <div class="grid-row grid-gap-lg">
         <div class="usa-banner__guidance tablet:grid-col-6">
-          <img class="usa-banner__icon usa-media-block__img" src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg" alt="Dot gov">
+          <img class="usa-banner__icon usa-media-block__img" src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg" role="img" alt="Dot gov">
           <div class="usa-media-block__body">
             <p>
               <strong>The .gov means it’s official.</strong>
@@ -28,7 +28,7 @@
           </div>
         </div>
         <div class="usa-banner__guidance tablet:grid-col-6">
-          <img class="usa-banner__icon usa-media-block__img" src="{{ site.baseurl }}/assets/img/icon-https.svg" alt="Https">
+          <img class="usa-banner__icon usa-media-block__img" src="{{ site.baseurl }}/assets/img/icon-https.svg" role="img" alt="Https">
           <div class="usa-media-block__body">
             <p>
               <strong>The site is secure.</strong>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -86,7 +86,7 @@
       <div class="grid-container">
         <div class="logo-links">
           <a href="http://www.gsa.gov/">
-            <img src="{{ site.baseurl }}/img/gsa-logo.svg" alt="GSA" />
+            <img src="{{ site.baseurl }}/img/gsa-logo.svg" alt="GSA" role="img" />
           </a>
         </div>
         <p>

--- a/pages/design-tokens/overview.md
+++ b/pages/design-tokens/overview.md
@@ -25,7 +25,7 @@ This degree of choice can slow down design work and make communication between d
 Design tokens are a limited set of discrete options, just like a scale of musical notes is drawn from the spectrum of all possible frequencies. Or like the presets on a car radio — not every option, just a specific selection.
 
 {:.padding-y-2}
-![continuous and tokenized values]({{ site.baseurl }}/assets/img/design-tokens/continuous-v-token.svg)
+![continuous and tokenized values]({{ site.baseurl }}/assets/img/design-tokens/continuous-v-token.svg){: role="img"}
 
 ### Example: Measure (line length)
 For example, measure (or line length) expressed with the `max-width` CSS property can accept any value in units like `em`, `rem`, `ch`, `ex`, and `px` to at least two decimal places. USWDS limits itself to 7 [measure]({{ site.baseurl }}/design-tokens/typesetting/measure/){:.token} tokens:

--- a/pages/design-tokens/typesetting/overview.md
+++ b/pages/design-tokens/typesetting/overview.md
@@ -24,7 +24,7 @@ Typefaces vary in optical size. This means that at any specific pixel value, an 
 ### Fonts at native size
 
 {:.padding-top-2}
-![optical size of typefaces]({{ site.baseurl }}/assets/img/design-tokens/font-comparison.svg)
+![optical size of typefaces]({{ site.baseurl }}/assets/img/design-tokens/font-comparison.svg){: role="img"}
 
 USWDS 2 is designed so each size token outputs a consistent optical size regardless of the typeface. This makes our guidance more reliable and our theming more flexible.
 
@@ -32,7 +32,7 @@ USWDS 2 is designed so each size token outputs a consistent optical size regardl
 ### Fonts with normalization applied
 
 {:.padding-y-2}
-![normalized typefaces]({{ site.baseurl }}/assets/img/design-tokens/font-comparison-normalized.svg)
+![normalized typefaces]({{ site.baseurl }}/assets/img/design-tokens/font-comparison-normalized.svg){: role="img"}
 
 To make different typefaces appear the same size (here called the _target size_) at each step of the scale (below, we see the output of [size]({{ site.baseurl }}/design-tokens/typesetting/font-size/){:.token} token `10`), the absolute size of each token's output varies depending on the font family.
 

--- a/pages/documentation/maturity-model.md
+++ b/pages/documentation/maturity-model.md
@@ -31,7 +31,7 @@ subnav:
     </div>
     <div class="tablet:grid-col-5">
       <div class="padding-2 tablet:padding-left-4">
-        <img src="{{ site.baseurl }}/img/maturity-model.svg" alt="A diagram showing the concentric circles of the USWDS maturity model, progressing from Principles on the outside, through Guidance, and finally to Code in the innermost circle.">
+        <img src="{{ site.baseurl }}/img/maturity-model.svg" role="img" alt="A diagram showing the concentric circles of the USWDS maturity model, progressing from Principles on the outside, through Guidance, and finally to Code in the innermost circle.">
       </div>
     </div>
   </div>

--- a/pages/documentation/overview.md
+++ b/pages/documentation/overview.md
@@ -58,7 +58,7 @@ redirect_from:
     </div>
     <div class="tablet:grid-col-5">
       <div class="padding-2 tablet:padding-left-4">
-        <img src="{{ site.baseurl }}/img/maturity-model.svg" alt="A diagram showing the concentric circles of the USWDS maturity model, progressing from Principles on the outside, through Guidance, and finally to Code in the innermost circle.">
+        <img src="{{ site.baseurl }}/img/maturity-model.svg" role="img" alt="A diagram showing the concentric circles of the USWDS maturity model, progressing from Principles on the outside, through Guidance, and finally to Code in the innermost circle.">
       </div>
     </div>
 


### PR DESCRIPTION
## Description

Adding `role="img"` to SVG's withtin `<img />` so voiceover on Safari
properly identifies them as images instead of group.

https://github.com/uswds/uswds/issues/3316


Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
