### PR TITLE
USWDS - Docs: Fix font-weight function docs

### DIFF
--- a/pages/design-tokens/typesetting/font-weight.md
+++ b/pages/design-tokens/typesetting/font-weight.md
@@ -149,12 +149,12 @@ Your context and coding style determine how you access USWDS font weight tokens 
         </td>
         <td data-title="Usage">
           <span class="line-height-sans-6">
-            weight(<a href="{{ site.baseurl }}/design-tokens/typesetting/font-weight/" class="token">weight</a>)
+            font-weight(<a href="{{ site.baseurl }}/design-tokens/typesetting/font-weight/" class="token">weight</a>)
           </span>
         </td>
         <td data-title="Example">
           <span class="line-height-sans-6">
-            font-weight: weight(<code>'bold'</code>)
+            font-weight: font-weight(<code>'bold'</code>)
           </span>
         </td>
       </tr>


### PR DESCRIPTION
## Description

Changes the name of the font-weight function in the docs from `weight()` to `font-weight()`.

Fixes #989.

## Additional information

* Relevant code in USWDS: https://github.com/uswds/uswds/blob/v2.7.1/src/stylesheets/core/_functions.scss#L1467-L1483

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [X] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [X] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
