### PR TITLE
[ISSUE 992] Fix svg font size handling

### DIFF
--- a/_components/data-visualizations.md
+++ b/_components/data-visualizations.md
@@ -106,6 +106,7 @@ subnav:
 .line-st6{fill:#C05600;}
 .line-st7{fill:#005EA2;}
 .line-st8{font-size:24px;}
+.font-svg-main{font-size:26px;}
 </style>
 <g id="Roosevelts">
 <g>
@@ -217,17 +218,17 @@ subnav:
 <g>
   <g>
   </g>
-  <text class="font-lang-xl" transform="matrix(1 0 0 1 200.2261 50.7432)">Franklin D. Roosevelt</text>
-  <text class="font-lang-xl" transform="matrix(1 0 0 1 749.2261 50.8486)">Theodore Roosevelt</text>
+  <text class="font-svg-main" transform="matrix(1 0 0 1 200.2261 50.7432)">Franklin D. Roosevelt</text>
+  <text class="font-svg-main" transform="matrix(1 0 0 1 749.2261 50.8486)">Theodore Roosevelt</text>
 </g>
 <g>
-  <text class="font-lang-xl" transform="matrix(1 0 0 1 88.8032 613.895)">Mar. 1</text>
-  <text class="font-lang-xl" transform="matrix(1 0 0 1 217.6079 613.895)">Mar. 2</text>
-  <text class="font-lang-xl" transform="matrix(1 0 0 1 346.4126 613.895)">Mar. 3</text>
-  <text class="font-lang-xl" transform="matrix(1 0 0 1 475.2173 613.895)">Mar. 4</text>
-  <text class="font-lang-xl" transform="matrix(1 0 0 1 604.022 613.895)">Mar. 5</text>
-  <text class="font-lang-xl" transform="matrix(1 0 0 1 732.8267 613.895)">Mar. 6</text>
-  <text class="font-lang-xl" transform="matrix(1 0 0 1 861.6313 613.895)">Mar. 7</text>
+  <text class="font-svg-main" transform="matrix(1 0 0 1 88.8032 613.895)">Mar. 1</text>
+  <text class="font-svg-main" transform="matrix(1 0 0 1 217.6079 613.895)">Mar. 2</text>
+  <text class="font-svg-main" transform="matrix(1 0 0 1 346.4126 613.895)">Mar. 3</text>
+  <text class="font-svg-main" transform="matrix(1 0 0 1 475.2173 613.895)">Mar. 4</text>
+  <text class="font-svg-main" transform="matrix(1 0 0 1 604.022 613.895)">Mar. 5</text>
+  <text class="font-svg-main" transform="matrix(1 0 0 1 732.8267 613.895)">Mar. 6</text>
+  <text class="font-svg-main" transform="matrix(1 0 0 1 861.6313 613.895)">Mar. 7</text>
 </g>
 </g>
 </svg>
@@ -319,7 +320,7 @@ subnav:
       .st3a{fill:#dfe1e2;stroke:#dfe1e2;stroke-miterlimit:10;}
       .st4{fill:#005EA2;}
       .st5{letter-spacing:-2;}
-      .font-lang-xl-m{font-size: 1.6rem}
+      .font-lang-xl-m{font-size: 25px}
     </style>
     <g>
       <g>


### PR DESCRIPTION
For this issue: https://github.com/uswds/uswds-site/issues/992

I've changed the font-sizing in the svg's to use pixels AND be set within the svg `<style>` section. These seemed to fix how the font-size scales when font size settings are are changed in the browser preferences.

**Steps to follow**
1. Pull this branch and and run it locally
2. Open Chrome
3. Change the font size to "Large" or "Very Large" in Preferences -> Appearance -> Font size
4. Verify text is not getting cut off

**Screen shots**
These were take using the Very Large font size setting in Chrome. As you can see, it's not cut off.
<img width="1005" alt="Screen Shot 2020-07-01 at 10 07 54 PM" src="https://user-images.githubusercontent.com/1094951/86308731-f5914800-bbe7-11ea-9219-599651ee350b.png">
<img width="925" alt="Screen Shot 2020-07-01 at 10 08 04 PM" src="https://user-images.githubusercontent.com/1094951/86308738-f7f3a200-bbe7-11ea-9053-7e6d2a719988.png">
