### PR TITLE
Update references and banner to 2.8.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ title: U.S. Web Design System (USWDS)
 description: USWDS makes it easier to build accessible, mobile-friendly government websites for the American public.
 google_analytics_ua: UA-48605964-43
 components_url: "https://components.designsystem.digital.gov"
-components_url_v2_preview: "https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/release-2.7.1/components/preview"
+components_url_v2_preview: "https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/release-2.8.0/components/preview"
 meta:
   og:image: /img/uswds-logo/lg-black.png
 

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -1,4 +1,4 @@
-<section class="usa-banner" aria-label="Official government website">
+<section class="usa-banner site-banner" aria-label="Official government website">
   <div class="usa-accordion">
     <header class="usa-banner__header">
       <div class="usa-banner__inner">

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -1,4 +1,4 @@
-<section class="site-banner usa-banner" aria-label="Official government website">
+<section class="usa-banner" aria-label="Official government website">
   <div class="usa-accordion">
     <header class="usa-banner__header">
       <div class="usa-banner__inner">
@@ -11,7 +11,7 @@
         </div>
         <button class="usa-accordion__button usa-banner__button"
           aria-expanded="false" aria-controls="gov-banner">
-          <span class="usa-banner__button-text">Here's how you know</span>
+          <span class="usa-banner__button-text">Here’s how you know</span>
         </button>
       </div>
     </header>
@@ -21,9 +21,9 @@
           <img class="usa-banner__icon usa-media-block__img" src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg" role="img" alt="Dot gov">
           <div class="usa-media-block__body">
             <p>
-              <strong>The .gov means it’s official.</strong>
+              <strong>Official websites use .gov</strong>
               <br>
-              Federal government websites often end in .gov or .mil. Before sharing sensitive information, make sure you’re on a federal government site.
+              A <strong>.gov</strong> website belongs to an official government organization in the United States.
             </p>
           </div>
         </div>
@@ -31,9 +31,10 @@
           <img class="usa-banner__icon usa-media-block__img" src="{{ site.baseurl }}/assets/img/icon-https.svg" role="img" alt="Https">
           <div class="usa-media-block__body">
             <p>
-              <strong>The site is secure.</strong>
+              <strong>Secure .gov websites use HTTPS</strong>
               <br>
-              The <strong>https://</strong> ensures that you are connecting to the official website and that any information you provide is encrypted and transmitted securely.
+              A <strong>lock</strong> ( <span class="icon-lock"><svg xmlns="http://www.w3.org/2000/svg" width="52" height="64" viewBox="0 0 52 64" class="usa-banner__lock-image" role="img" aria-labelledby="banner-lock-title banner-lock-description"><title id="banner-lock-title">Lock</title><desc id="banner-lock-description">A locked padlock</desc><path fill="#000000" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"/></svg></span> ) or <strong>https://</strong> means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites.
+
             </p>
           </div>
         </div>

--- a/_includes/code/components/banner.html
+++ b/_includes/code/components/banner.html
@@ -3,7 +3,9 @@
   {% fractal_component banner %}
 {% endcapture %}{{ banner
   | strip
-  | replace: 'gov-banner', 'gov-banner-default' }}
+  | replace: 'gov-banner', 'gov-banner-default'
+  | replace: 'banner-lock-title', 'banner-lock-title-default'
+  | replace: 'banner-lock-description', 'banner-lock-description-default' }}
 
 <h6>.mil domains</h6>
 {% capture banner--dot-mil %}

--- a/_includes/download-buttons.html
+++ b/_includes/download-buttons.html
@@ -11,7 +11,7 @@
     href="{{ site.baseurl }}/download/"
     onclick="ga('send', 'event', 'Downloaded code and design files', 'Clicked Download code and design files from inside site');"
   >
-    Download <span class="version desktop:display-none desktop-lg:display-inline">v2.7.1</span>
+    Download <span class="version desktop:display-none desktop-lg:display-inline">v2.8.0</span>
   </a>
   <a
     class="usa-button site-button-github margin-x-0 desktop:margin-right-4 font-lang-sm"

--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -35,7 +35,7 @@ layout: default
         <a
           class="usa-button hover:bg-primary-darker text-normal font-lang-sm bg-primary-vivid margin-top-1"
           href="{{ site.baseurl }}/documentation/migration/"
-          >Migrate to v2.7.1</a
+          >Migrate to v2.8.0</a
         >
       </div>
     </div>

--- a/css/_uswds-theme-custom-styles.scss
+++ b/css/_uswds-theme-custom-styles.scss
@@ -3013,58 +3013,110 @@ $theme-table-column-gap: 4;
 }
 
 .site-banner {
-  @include typeset("lang");
+  $site-banner-bg: "ink";
+  $site-banner-icon-color: "blue-40v";
+  $site-banner-font-family: "lang";
+  $site-banner-max-width: "none";
+  $site-banner-link-color: "base-light";
 
-  .usa-accordion {
-    @include typeset("lang");
+  $banner-icon-colors: get-link-tokens-from-bg(
+    $site-banner-bg,
+    $site-banner-icon-color
+  );
+  $banner-icon-color: nth($banner-icon-colors, 1);
+  $banner-icon-hover: nth($banner-icon-colors, 2);
+  $banner-icon-chevron: (
+    "name": "chevron",
+    "svg-height": 39,
+    "svg-width": 64,
+    "height": 0.8ex,
+    "color": $banner-icon-color,
+    "color-hover": $banner-icon-hover,
+  );
+  $banner-icon-chevron-up: map-merge(
+    $banner-icon-chevron,
+    (
+      "rotate": 180deg,
+    )
+  );
+
+  @include typeset($site-banner-font-family);
+  background-color: color($site-banner-bg);
+
+  @include at-media("tablet") {
+    font-size: font-size($site-banner-font-family, "3xs");
   }
 
-  .usa-banner__header-text,
-  .usa-banner__header-action,
-  .usa-banner__button {
-    @include typeset("lang", 1, 2);
+  .usa-accordion {
+    @include typeset($site-banner-font-family);
+  }
+
+  .usa-banner__header,
+  .usa-banner__content {
+    @include set-text-from-bg($site-banner-bg);
   }
 
   .usa-banner__content {
-    @include typeset("lang", "xs", 5);
+    @include u-maxw("desktop");
+    font-size: font-size($site-banner-font-family, 4);
+  }
 
-    p {
-      line-height: lh("lang", 5);
-    }
+  .usa-banner__inner {
+    @include grid-container($site-banner-max-width);
+  }
+
+  .usa-banner__header {
+    font-size: font-size($site-banner-font-family, 1);
+  }
+
+  .usa-banner__header-text {
+    font-size: font-size($site-banner-font-family, 1);
+    line-height: line-height($site-banner-font-family, 2);
   }
 
   .usa-banner__header-action {
-    @include add-icon(
-      "angle-arrow-down-primary",
+    @include place-icon(
+      $banner-icon-chevron,
       "after",
-      1,
-      1,
-      0.5,
-      "no-hover"
+      2px,
+      middle,
+      $site-banner-bg
     );
+    @include set-link-from-bg($site-banner-bg, $site-banner-link-color);
+
+    line-height: line-height($site-banner-font-family, 2);
+  }
+
+  .usa-banner__header--expanded {
+    @include at-media("tablet") {
+      font-size: font-size($site-banner-font-family, 1);
+    }
   }
 
   .usa-banner__button {
+    @include set-link-from-bg($site-banner-bg, $site-banner-link-color);
+    font-size: font-size($site-banner-font-family, 1);
+    line-height: line-height($site-banner-font-family, 2);
+
     @include at-media("tablet") {
-      @include add-icon(
-        "angle-arrow-down-primary",
+      @include place-icon(
+        $banner-icon-chevron,
         "after",
-        1,
-        1,
         2px,
-        "no-hover"
+        middle,
+        $site-banner-bg
       );
+      @include set-link-from-bg($site-banner-bg, $site-banner-link-color);
     }
 
     &[aria-expanded="true"] {
       @include at-media("tablet") {
-        @include add-icon(
-          "angle-arrow-up-primary",
+        @include place-icon(
+          $banner-icon-chevron-up,
           "after",
-          1,
-          1,
           2px,
-          "no-hover"
+          middle,
+          $site-banner-bg
         );
       }
     }

--- a/css/settings/_uswds-theme-components.scss
+++ b/css/settings/_uswds-theme-components.scss
@@ -31,7 +31,7 @@ $theme-alert-padding-x: 2.5;
 
 // Banner
 $theme-banner-background-color: "ink" !default;
-//$theme-banner-font-family: "ui" !default;
+$theme-banner-font-family: "lang" !default;
 //$theme-banner-link-color: default !default;
 $theme-banner-max-width: "none" !default;
 

--- a/css/settings/_uswds-theme-components.scss
+++ b/css/settings/_uswds-theme-components.scss
@@ -30,10 +30,11 @@ $theme-alert-measure: 3;
 $theme-alert-padding-x: 2.5;
 
 // Banner
-$theme-banner-background-color: "ink" !default;
-$theme-banner-font-family: "lang" !default;
+// Don't use settings. It affects component examples.
+//$theme-banner-background-color: "ink" !default;
+//$theme-banner-font-family: "lang" !default;
 //$theme-banner-link-color: default !default;
-$theme-banner-max-width: "none" !default;
+//$theme-banner-max-width: "none" !default;
 
 // Button
 $theme-button-font-family: "ui";

--- a/css/settings/_uswds-theme-components.scss
+++ b/css/settings/_uswds-theme-components.scss
@@ -30,8 +30,10 @@ $theme-alert-measure: 3;
 $theme-alert-padding-x: 2.5;
 
 // Banner
-$theme-banner-font-family: "ui";
-//$theme-banner-max-width: 'full';
+$theme-banner-background-color: "ink" !default;
+//$theme-banner-font-family: "ui" !default;
+//$theme-banner-link-color: default !default;
+$theme-banner-max-width: "none" !default;
 
 // Button
 $theme-button-font-family: "ui";

--- a/pages/documentation/getting-started/download.html
+++ b/pages/documentation/getting-started/download.html
@@ -12,12 +12,12 @@ redirect_from:
 
 <a
   class="link-download"
-  href="https://github.com/uswds/uswds/releases/download/v2.7.1/uswds-2.7.1.zip"
+  href="https://github.com/uswds/uswds/releases/download/v2.8.0/uswds-2.8.0.zip"
   onclick="ga('send', 'event', 'Downloaded framework', 'Clicked download button inside site');"
   >Download code</a
 >
-<span class="link-download-subtext">Version 2.7.1</span>
-<!--<span class="link-download-subtext">Version 2.7.1</span>-->
+<span class="link-download-subtext">Version 2.8.0</span>
+<!--<span class="link-download-subtext">Version 2.8.0</span>-->
 
 <h2 class="usa-heading">Design assets</h2>
 


### PR DESCRIPTION
- Update references and links to 2.8.0
- Use new banner text. (Note that we can't style it with settings without affecting our component examples, thus the complicated overrides...)