### PR TITLE
Use `main` instead of `master` for default branch refs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 We’re so glad you’re thinking about contributing to a Technology Transformation Services (TTS) open source project! If you’re unsure about anything, just ask — or submit your issue or pull request anyway. The worst that can happen is we’ll politely ask you to change something. We appreciate all friendly contributions.
 
-TTS is committed to building a safe, welcoming, harassment-free culture for everyone. We expect everyone on the TTS team and everyone within TTS spaces, including contributors to our projects, to follow the [TTS Code of Conduct](https://github.com/18F/code-of-conduct/blob/master/code-of-conduct.md).
+TTS is committed to building a safe, welcoming, harassment-free culture for everyone. We expect everyone on the TTS team and everyone within TTS spaces, including contributors to our projects, to follow the [TTS Code of Conduct](https://github.com/18F/code-of-conduct/blob/main/code-of-conduct.md).
 
 We encourage you to read this project’s CONTRIBUTING policy (you are here), its [LICENSE](LICENSE.md), [README](README.md) and its [Workflow](https://github.com/uswds/uswds/wiki/Workflow) process.
 
@@ -58,9 +58,9 @@ Here are a few guidelines to follow when submitting a pull request:
 1. Create a GitHub account or sign in to your existing account.
 1. Fork this repo into your GitHub account (or just clone it if you’re an 18F team member). Read more about forking a repo here on GitHub:
 [https://help.github.com/articles/fork-a-repo/](https://help.github.com/articles/fork-a-repo/)
-1. Create a branch from `master` that lightly defines what you’re working on (for example, add-styles).
+1. Create a branch from `main` that lightly defines what you’re working on (for example, add-styles).
 1. Once you’re ready to submit a pull request, fill out the `PULL REQUEST TEMPLATE` provided.
-1. Submit your pull request against the `master` branch.
+1. Submit your pull request against the `main` branch.
 
 Have questions or need help with setup? Open an issue here [https://github.com/uswds/uswds-site/issues](https://github.com/uswds/uswds-site/issues).
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ USWDS uses the [fractal design system builder](http://fractal.build/) to organiz
 
 ### Deployment and previews
 
-This site is deployed on [Federalist](https://federalist.18f.gov/), which automatically builds the public site whenever commits are pushed to `master`. Federalist also builds public previews for each branch pushed to GitHub.
+This site is deployed on [Federalist](https://federalist.18f.gov/), which automatically builds the public site whenever commits are pushed to `main`. Federalist also builds public previews for each branch pushed to GitHub.
 
 ### Updating the USWDS version
 
@@ -93,7 +93,7 @@ npm install --save "uswds/uswds#v1.3.1"
 This version number or commit hash is automatically parsed when the site
 is built and used for display on the site (see `_plugins/uswds_version.rb`
 for details). Therefore, be sure to use an actual version tag on all
-`master` branch commits--otherwise a commit hash will show up as the
+`main` branch commits--otherwise a commit hash will show up as the
 version on the production site, which would be confusing.
 
 ### Adding content to the "Updates" section


### PR DESCRIPTION
This is the final step of updating the `uswds-site` repo to a default brach of `main` as planned in https://github.com/uswds/uswds-team/issues/23

Generally following the steps outlined [here](http://www.kapwing.com/blog/how-to-rename-your-master-branch-to-main-in-git/).

- [x] Move `master` to `main` in a local branch
- [x] Push branch to HEAD
- [x] Update Github default branch
- [x] Update Github branch protection
- [x] Update site settings in Federalist
- [x] Update branch references in the wiki
- [x] Update base of existing PRs
- [x] Update branch references in the documentation
