### PR TITLE
Fix data and url structure in preview include

### DIFF
--- a/_includes/component-preview-link.html
+++ b/_includes/component-preview-link.html
@@ -1,2 +1,2 @@
-{%- capture federalist-preview %}{{ site.federalist_base }}/{{ site.federalist_release_prefix }}{{ site.uswds_version }}/{{ federalist_component_preview }}{% endcapture -%}
-"{{ federalist-preview }}{{ include.component }}.html"
+{%- capture federalist-preview %}{{ site.federalist_base }}/{{ site.federalist_release_prefix }}{{ site.uswds_version }}/{{ site.federalist_component_preview }}{% endcapture -%}
+"{{ federalist-preview }}/{{ include.component }}.html"


### PR DESCRIPTION
Fixes the preview link include so it outputs the proper link to federalist previews of complex components and templates.

[Templates](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/dw-update-preview-links/page-templates/) →
[Headers](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/dw-update-preview-links/components/header/) → 
