### PR TITLE
Add accent-warm button docs

### DIFF
--- a/_components/buttons.md
+++ b/_components/buttons.md
@@ -56,6 +56,7 @@ component_url: 'https://components.designsystem.digital.gov/components/detail/bu
             <li><code>usa-button--secondary</code></li>
             <li><code>usa-button--base</code></li>
             <li><code>usa-button--accent-cool</code></li>
+            <li><code>usa-button--accent-warm</code></li>
             <li><code>usa-button--outline</code></li>
             <li><code>usa-button--inverse</code></li>
             <li><code>usa-button--big</code></li>
@@ -89,6 +90,12 @@ component_url: 'https://components.designsystem.digital.gov/components/detail/bu
             <td data-title="Variant" class="flex-6">usa-button--accent-cool</td>
             <td data-title="Description" class="flex-6">
               <span class="font-lang-3xs">Button with a accent-cool background.</span>
+            </td>
+          </tr>
+          <tr>
+            <td data-title="Variant" class="flex-6">usa-button--accent-warm</td>
+            <td data-title="Description" class="flex-6">
+              <span class="font-lang-3xs">Button with a accent-warm background.</span>
             </td>
           </tr>
           <tr>

--- a/_includes/code/components/buttons.html
+++ b/_includes/code/components/buttons.html
@@ -13,6 +13,11 @@
   {% fractal_component buttons--accent-cool %}
 {% endcapture %}{{ accent_cool_buttons | strip }}
 
+<h6>Accent warm color</h6>
+{% capture accent_warm_buttons %}
+  {% fractal_component buttons--accent-warm %}
+{% endcapture %}{{ accent_warm_buttons | strip }}
+
 <h6>Base color</h6>
 {% capture base_buttons %}
   {% fractal_component buttons--base %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11833,7 +11833,7 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
     "uswds": {
-      "version": "github:uswds/uswds#804edf7662c87ac8fafb805c4450b0d456fab384",
+      "version": "github:uswds/uswds#e6f6678166bfa839e012960e00e23b9fe5ac8a39",
       "from": "github:uswds/uswds#develop",
       "requires": {
         "classlist-polyfill": "^1.0.3",


### PR DESCRIPTION
Despite the inaccurate name of this branch, this PR adds the accent-warm button variant into the docs!

[Preview](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/dw-add-accent-cool-docs/components/button/) → 

<img width="737" alt="Screen Shot 2020-09-14 at 5 23 51 PM" src="https://user-images.githubusercontent.com/11464021/93150856-1e858d00-f6af-11ea-8c5f-c5212fa3b4c2.png">

