### PR TITLE
USWDS - Web Mod: Remove references to components.designsystem.digital.gov.

### DIFF
--- a/_components/button-groups/button-groups.md
+++ b/_components/button-groups/button-groups.md
@@ -5,7 +5,6 @@ title: Button groups
 type: component
 category: Components
 lead: Use button groups to collect similar or related actions
-component_url: 'https://components.designsystem.digital.gov/components/detail/button-groups--default.html'
 subnav:
 - text: Default
   href: '#default-button-group'

--- a/_components/buttons.md
+++ b/_components/buttons.md
@@ -8,7 +8,6 @@ type: element
 title: Button
 category: Components
 lead: Use buttons to draw attention to important actions.
-component_url: 'https://components.designsystem.digital.gov/components/detail/buttons.html'
 ---
 
 {% include code/preview.html component="buttons" %}

--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,6 @@ title: U.S. Web Design System (USWDS)
 description: USWDS makes it easier to build accessible, mobile-friendly government websites for the American public.
 google_analytics_ua: UA-48605964-43
 uswds_version: 2.9.0
-components_url: "https://components.designsystem.digital.gov"
 federalist_base: "https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds"
 federalist_component_preview: "components/preview"
 federalist_release_prefix: "release-"

--- a/_layouts/styleguide.html
+++ b/_layouts/styleguide.html
@@ -21,11 +21,6 @@ layout: default
           {% endunless %}
         {% endif %}
         <h1 id="{{ page.title | slugify }}" class="site-page-title">{{ page.title }}</h1>
-        {% if page.category == 'UI components' and page.component_url %}
-          <span class="components-library-link">
-            <a href="{{ page.component_url }}">View in Component Library</a>
-          </span>
-        {% endif %}
       </header>
 
       {% include lead.html text=page.lead %}

--- a/pages/ui-components/overview.md
+++ b/pages/ui-components/overview.md
@@ -8,8 +8,6 @@ lead: USWDS components are designed to set a new bar for simplicity and consiste
 
 **Getting started.** For getting up and running with USWDS, head over to our [Getting started]({{ site.baseurl }}/documentation/) page for more information.
 
-**See all USWDS components.** To browse the entire collection of USWDS components, visit [components.designsystem.digital.gov]({{ site.components_url }}).
-
 ## Importing only the components your project needs
 Not every USWDS project needs to use the entire design system. We support incremental adoption, in part by allowing any USWDS project to import only the components they need.
 


### PR DESCRIPTION
Part of uswds/uswds-team#45

## Description

Removes references to `components.designsystem.digital.gov`

## Additional information

No issues on `npm run crawl` to search for broken links.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
