### PR TITLE
USWDS - Dependencies: Remove highlightjs.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5881,12 +5881,6 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
-    "highlight.js": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
-      "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==",
-      "dev": true
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "chrome-remote-interface": "^0.28.1",
     "colors": "^1.3.2",
     "express": "^4.17.1",
-    "highlight.js": "^10.1.1",
     "json-format": "^1.0.1",
     "merge-stream": "^2.0.0",
     "minimist": "^1.2.3",


### PR DESCRIPTION
## Description
Part of #1117. Originally added in 4db24df9 due to a fractal build issue. Able to build
successfully without highlightjs.

## Additional information

Makes #1114 unnecessary.


Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
