### PR TITLE
USWDS-Site - Documentation: Fix documentation reference of usa-card__media--indent class to usa-card__media--inset.

### DIFF
--- a/_components/card.md
+++ b/_components/card.md
@@ -120,7 +120,7 @@ Finally, a card is **modular**. This means that you can vary the order of cards 
             </td>
           </tr>
           <tr>
-            <td data-title="Variant" class="flex-6">usa-card__media--indent</td>
+            <td data-title="Variant" class="flex-6">usa-card__media--inset</td>
             <td data-title="Description" class="flex-6">
               <span class="font-lang-3xs">
                 Indents the media element so it doesn't extend to the edge of the card.


### PR DESCRIPTION
## Preview
[Card component settings →](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/jeffffeffff-je-card-inset-variant-documentation/components/card/#component-variants)

## Description

Documentation for a card variant `user-card__media--inset` was referred to in documentation as `usa-card__media--indent` incorrectly. This PR updates that documentation to use the proper name of the class as implemented on the actual component.

Resolves issue 1039: https://github.com/uswds/uswds-site/issues/1039