### PR TITLE
Fix mangled link to date-input

### DIFF
--- a/_components/form-controls/05-date-picker.md
+++ b/_components/form-controls/05-date-picker.md
@@ -21,8 +21,8 @@ lead: A date picker helps users select a single date.
     </ul>
     <h4>When to consider something else</h4>
     <ul class="usa-content-list">
-      <li><strong>Familiar dates.</strong> When asking users for a date they know well, or can look up without using a calendar (like a birthday), use <a href="{{ site.baseurl }}/form-controls/#date-input">date input fields</a>.</li>
-      <li><strong>When the day of the week is irrelevant.</strong> If there's no benefit to knowing the day of the week for a particular date, consider <a href="{{ site.baseurl }}/form-controls/#date-input">date input fields</a>.</li>
+      <li><strong>Familiar dates.</strong> When asking users for a date they know well, or can look up without using a calendar (like a birthday), use <a href="{{ site.baseurl }}/components/form-controls/#date-input">date input fields</a>.</li>
+      <li><strong>When the day of the week is irrelevant.</strong> If there's no benefit to knowing the day of the week for a particular date, consider <a href="{{ site.baseurl }}/components/form-controls/#date-input">date input fields</a>.</li>
     </ul>
     <h4>Usability guidance</h4>
     <ul class="usa-content-list">


### PR DESCRIPTION
[Preview](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/dw-update-date-input-links/components/form-controls/#date-picker) → 
Fixes https://github.com/uswds/uswds/issues/3878

Fixes the link to date-input in the `When to consider something else` section of the date picker component.