### PR TITLE
USWDS - Components: Only show overflow on preview accordion.

### DIFF
--- a/_includes/code/preview.html
+++ b/_includes/code/preview.html
@@ -1,6 +1,6 @@
 {% assign level = include.level | default: "h3" %}
 
-<div class="usa-accordion usa-accordion usa-accordion--bordered site-accordion-code">
+<div class="usa-accordion usa-accordion--bordered site-accordion-code site-component-preview">
   {% assign _id = include.component | append: '-preview' %}
   {% assign _content_id = include.component | append: '-preview-content' %}
   <button class="usa-accordion__button" aria-controls="{{ _content_id }}" aria-expanded="true"><{{ level }} id="{{ _id }}">Component preview</{{ level }}></button>

--- a/css/_uswds-theme-custom-styles.scss
+++ b/css/_uswds-theme-custom-styles.scss
@@ -3677,9 +3677,6 @@ body {
 }
 
 .site-accordion-code {
-  .usa-accordion__content {
-    overflow: visible;
-  }
 
   // Don't show margin at the top of the first form-group's label
   .usa-accordion__content > .usa-form-group:first-child,
@@ -3694,5 +3691,11 @@ body {
     > .usa-label:first-child {
       margin-top: 0;
     }
+  }
+}
+
+.site-accordion-code.site-component-preview {
+  .usa-accordion__content {
+    overflow: visible;
   }
 }


### PR DESCRIPTION
## Description

Closes #1184. Hides overflow from code, but still shows it on component preview.

## Additional information

Added a new class to component preview section. Works in IE11.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
