### PR TITLE
USWDS-SITE | overrides nested accordion content borders

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -458,6 +458,9 @@ ignore:
     - uswds > gulp-sass > node-sass:
         reason: No patch available
         expires: '2021-01-11T18:00:56.004Z'
+      gulp-sass > node-sass:
+        reason: No upgrade or patch available
+        expires: '2021-04-21T21:29:09.263Z'
     - uswds > gulp-sass > node-sass:
         reason: None given
         expires: '2021-03-21T22:33:04.906Z'
@@ -492,6 +495,9 @@ ignore:
     - uswds > gulp-sass > node-sass:
         reason: No patch available
         expires: '2021-01-11T18:00:56.004Z'
+      gulp-sass > node-sass:
+        reason: No upgrade or patch available
+        expires: '2021-04-21T21:29:09.263Z'
     - uswds > gulp-sass > node-sass:
         reason: None given
         expires: '2021-03-21T22:33:04.906Z'
@@ -544,8 +550,8 @@ ignore:
         expires: '2020-10-14T16:26:55.825Z'
   SNYK-JS-GULPSCSSLINT-560114:
     - gulp-scss-lint:
-        reason: None given
-        expires: '2021-03-21T22:33:04.897Z'
+        reason: No upgrade or patch available
+        expires: '2021-04-21T21:29:09.263Z'
   SNYK-JS-HTTPPROXY-569139:
     - uswds > @frctl/fractal > browser-sync > http-proxy:
         reason: n/a
@@ -878,12 +884,21 @@ ignore:
     - gulp-eslint > eslint > glob-parent:
         reason: None given
         expires: '2021-03-20T08:01:00.235Z'
+      gulp > glob-watcher > chokidar > glob-parent:
+        reason: No upgrade or patch available
+        expires: '2021-04-21T21:29:09.263Z'
     - del > globby > fast-glob > glob-parent:
         reason: None given
         expires: '2021-02-14T18:33:52.502Z'
+      gulp > vinyl-fs > glob-stream > glob-parent:
+        reason: No upgrade or patch available
+        expires: '2021-04-21T21:29:09.263Z'
     - uswds > del > globby > fast-glob > glob-parent:
         reason: None given
         expires: '2021-02-14T18:33:52.502Z'
+      gulp-scss-lint > vinyl-fs > glob-stream > glob-parent:
+        reason: No upgrade or patch available
+        expires: '2021-04-21T21:29:09.263Z'
     - sass > chokidar > glob-parent:
         reason: None given
         expires: '2021-02-14T18:33:52.502Z'

--- a/.snyk
+++ b/.snyk
@@ -458,9 +458,6 @@ ignore:
     - uswds > gulp-sass > node-sass:
         reason: No patch available
         expires: '2021-01-11T18:00:56.004Z'
-      gulp-sass > node-sass:
-        reason: No upgrade or patch available
-        expires: '2021-04-21T21:29:09.263Z'
     - uswds > gulp-sass > node-sass:
         reason: None given
         expires: '2021-03-21T22:33:04.906Z'
@@ -491,13 +488,13 @@ ignore:
     - gulp-sass > node-sass:
         reason: None given
         expires: '2021-03-21T22:33:04.904Z'
+    - gulp-sass > node-sass:
+        reason: No upgrade or patch available
+        expires: '2021-04-21T21:29:09.263Z'
   SNYK-JS-NODESASS-541002:
     - uswds > gulp-sass > node-sass:
         reason: No patch available
         expires: '2021-01-11T18:00:56.004Z'
-      gulp-sass > node-sass:
-        reason: No upgrade or patch available
-        expires: '2021-04-21T21:29:09.263Z'
     - uswds > gulp-sass > node-sass:
         reason: None given
         expires: '2021-03-21T22:33:04.906Z'
@@ -528,6 +525,9 @@ ignore:
     - gulp-sass > node-sass:
         reason: None given
         expires: '2021-03-21T22:33:04.905Z'
+    - gulp-sass > node-sass:
+        reason: No upgrade or patch available
+        expires: '2021-04-21T21:29:09.263Z'
   'npm:braces:20180219':
     - uswds > nswatch > chokidar > anymatch > micromatch > braces:
         reason: None given
@@ -884,21 +884,15 @@ ignore:
     - gulp-eslint > eslint > glob-parent:
         reason: None given
         expires: '2021-03-20T08:01:00.235Z'
-      gulp > glob-watcher > chokidar > glob-parent:
+      sass > chokidar > glob-parent:
         reason: No upgrade or patch available
-        expires: '2021-04-21T21:29:09.263Z'
+        expires: '2021-04-22T13:53:58.430Z'
     - del > globby > fast-glob > glob-parent:
         reason: None given
         expires: '2021-02-14T18:33:52.502Z'
-      gulp > vinyl-fs > glob-stream > glob-parent:
-        reason: No upgrade or patch available
-        expires: '2021-04-21T21:29:09.263Z'
     - uswds > del > globby > fast-glob > glob-parent:
         reason: None given
         expires: '2021-02-14T18:33:52.502Z'
-      gulp-scss-lint > vinyl-fs > glob-stream > glob-parent:
-        reason: No upgrade or patch available
-        expires: '2021-04-21T21:29:09.263Z'
     - sass > chokidar > glob-parent:
         reason: None given
         expires: '2021-02-14T18:33:52.502Z'
@@ -971,6 +965,15 @@ ignore:
     - sass > chokidar > glob-parent:
         reason: None given
         expires: '2021-03-21T22:33:04.897Z'
+    - gulp > glob-watcher > chokidar > glob-parent:
+        reason: No upgrade or patch available
+        expires: '2021-04-21T21:29:09.263Z'
+    - gulp > vinyl-fs > glob-stream > glob-parent:
+        reason: No upgrade or patch available
+        expires: '2021-04-21T21:29:09.263Z'
+    - gulp-scss-lint > vinyl-fs > glob-stream > glob-parent:
+        reason: No upgrade or patch available
+        expires: '2021-04-21T21:29:09.263Z'
   SNYK-JS-NODESASS-1059081:
     - gulp-sass > node-sass:
         reason: No available upgrade or patch.
@@ -997,24 +1000,42 @@ ignore:
     - gulp-sass > lodash:
         reason: None given
         expires: '2021-03-21T22:33:04.898Z'
+      gulp-eslint > eslint > lodash:
+        reason: No upgrade or patch available
+        expires: '2021-04-22T13:53:58.430Z'
     - snyk > lodash:
         reason: None given
         expires: '2021-03-20T08:01:00.235Z'
+      gulp-eslint > eslint > inquirer > lodash:
+        reason: No upgrade or patch available
+        expires: '2021-04-22T13:53:58.430Z'
     - snyk > inquirer > lodash:
         reason: None given
         expires: '2021-03-20T08:01:00.235Z'
+      gulp-eslint > eslint > table > lodash:
+        reason: No upgrade or patch available
+        expires: '2021-04-22T13:53:58.430Z'
     - gulp-eslint > eslint > lodash:
         reason: None given
         expires: '2021-03-20T08:01:00.235Z'
+      gulp-sass > lodash:
+        reason: No upgrade or patch available
+        expires: '2021-04-22T13:53:58.430Z'
     - gulp-sass > node-sass > lodash:
-        reason: None given
-        expires: '2021-03-20T08:01:00.235Z'
+        reason: No upgrade or patch available
+        expires: '2021-04-22T13:53:58.430Z'
     - uswds > gulp-sass > lodash:
         reason: None given
         expires: '2021-03-20T08:01:00.235Z'
+      gulp-sass > node-sass > sass-graph > lodash:
+        reason: No upgrade or patch available
+        expires: '2021-04-22T13:53:58.430Z'
     - snyk > snyk-nuget-plugin > lodash:
         reason: None given
         expires: '2021-03-20T08:01:00.236Z'
+      gulp-sass > node-sass > gaze > globule > lodash:
+        reason: No upgrade or patch available
+        expires: '2021-04-22T13:53:58.430Z'
     - uswds > @babel/core > lodash:
         reason: None given
         expires: '2021-03-20T08:01:00.236Z'
@@ -1229,24 +1250,42 @@ ignore:
     - gulp-sass > lodash:
         reason: None given
         expires: '2021-03-21T22:33:04.898Z'
+      gulp-eslint > eslint > lodash:
+        reason: No upgrade or patch available
+        expires: '2021-04-22T13:53:58.430Z'
     - snyk > lodash:
         reason: None given
         expires: '2021-03-20T08:01:00.235Z'
+      gulp-eslint > eslint > inquirer > lodash:
+        reason: No upgrade or patch available
+        expires: '2021-04-22T13:53:58.430Z'
     - snyk > inquirer > lodash:
         reason: None given
         expires: '2021-03-20T08:01:00.235Z'
+      gulp-eslint > eslint > table > lodash:
+        reason: No upgrade or patch available
+        expires: '2021-04-22T13:53:58.430Z'
     - gulp-eslint > eslint > lodash:
         reason: None given
         expires: '2021-03-20T08:01:00.235Z'
+      gulp-sass > lodash:
+        reason: No upgrade or patch available
+        expires: '2021-04-22T13:53:58.430Z'
     - gulp-sass > node-sass > lodash:
-        reason: None given
-        expires: '2021-03-20T08:01:00.235Z'
+        reason: No upgrade or patch available
+        expires: '2021-04-22T13:53:58.430Z'
     - uswds > gulp-sass > lodash:
         reason: None given
         expires: '2021-03-20T08:01:00.235Z'
+      gulp-sass > node-sass > sass-graph > lodash:
+        reason: No upgrade or patch available
+        expires: '2021-04-22T13:53:58.430Z'
     - snyk > snyk-nuget-plugin > lodash:
         reason: None given
         expires: '2021-03-20T08:01:00.236Z'
+      gulp-sass > node-sass > gaze > globule > lodash:
+        reason: No upgrade or patch available
+        expires: '2021-04-22T13:53:58.430Z'
     - uswds > @babel/core > lodash:
         reason: None given
         expires: '2021-03-20T08:01:00.236Z'

--- a/css/_uswds-theme-custom-styles.scss
+++ b/css/_uswds-theme-custom-styles.scss
@@ -2842,6 +2842,12 @@ $theme-table-column-gap: 4;
   padding-top: units(3);
 }
 
+// because any accordion__content inside of a bordered accordion get's
+// borders, we need to overide for this nested component preview.
+.site-component-preview .usa-accordion:not(.usa-accordion--bordered) .usa-accordion__content {
+  border: none;
+}
+
 .usa-content-list {
   @include unstyled-list;
   > li {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3389,12 +3389,19 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "copy-props": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/copy-props/-/copy-props-2.0.4.tgz",
-      "integrity": "sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/copy-props/-/copy-props-2.0.5.tgz",
+      "integrity": "sha512-XBlx8HSqrT0ObQwmSzM7WE5k8FxTV75h1DX1Z3n6NhQ/UYYAvInWYmG06vFt7hQZArE2fuO62aihiWIVQwh1sw==",
       "requires": {
-        "each-props": "^1.3.0",
-        "is-plain-object": "^2.0.1"
+        "each-props": "^1.3.2",
+        "is-plain-object": "^5.0.0"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+        }
       }
     },
     "core-js-compat": {
@@ -4879,9 +4886,9 @@
       "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
     "fastq": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.10.1.tgz",
-      "integrity": "sha512-AWuv6Ery3pM+dY7LYS8YIaCiQvUaos9OB1RyNgaOWnaX+Tik7Onvcsf8x8c+YtDeT0maYLniBip2hox5KtEXXA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
+      "integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
       "requires": {
         "reusify": "^1.0.4"
       }
@@ -5408,9 +5415,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -5511,9 +5518,9 @@
       }
     },
     "globby": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.2.tgz",
-      "integrity": "sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
+      "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
       "requires": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
@@ -6330,9 +6337,9 @@
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -6852,9 +6859,9 @@
       }
     },
     "just-debounce": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.0.0.tgz",
-      "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.1.0.tgz",
+      "integrity": "sha512-qpcRocdkUmf+UTNBYx5w6dexX5J31AKK1OmPwH630a83DdVVUIngk55RSAiIGpQyoH0dlr872VHfPjnQnK1qDQ=="
     },
     "keyboardevent-key-polyfill": {
       "version": "1.1.0",
@@ -9158,6 +9165,11 @@
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
     },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+    },
     "quick-lru": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
@@ -9749,9 +9761,12 @@
       "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
     },
     "run-parallel": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
-      "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
     },
     "rxjs": {
       "version": "6.6.3",
@@ -12205,9 +12220,9 @@
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "v8-compile-cache": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
-      "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA=="
     },
     "v8flags": {
       "version": "3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9795,9 +9795,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass": {
-      "version": "1.32.6",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.6.tgz",
-      "integrity": "sha512-1bcDHDcSqeFtMr0JXI3xc/CXX6c4p0wHHivJdru8W7waM7a1WjKMm4m/Z5sY7CbVw4Whi2Chpcw6DFfSWwGLzQ==",
+      "version": "1.32.8",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.8.tgz",
+      "integrity": "sha512-Sl6mIeGpzjIUZqvKnKETfMf0iDAswD9TNlv13A7aAF3XZlRPMq4VvJWBC2N2DXbp94MQVdNSFG6LfF/iOXrPHQ==",
       "requires": {
         "chokidar": ">=2.0.0 <4.0.0"
       }
@@ -12131,9 +12131,9 @@
       }
     },
     "urijs": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.5.tgz",
-      "integrity": "sha512-48z9VGWwdCV5KfizHsE05DWS5fhK6gFlx5MjO7xu0Krc5FGPWzjlXEVV0nPMrdVuP7xmMHiPZ2HoYZwKOFTZOg==",
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.6.tgz",
+      "integrity": "sha512-eSXsXZ2jLvGWeLYlQA3Gh36BcjF+0amo92+wHPyN1mdR8Nxf75fuEuYTd9c0a+m/vhCjRK0ESlE9YNLW+E1VEw==",
       "dev": true
     },
     "urix": {

--- a/package.json
+++ b/package.json
@@ -76,9 +76,9 @@
     "node-notifier": "^9.0.1",
     "postcss": "^8.2.1",
     "postcss-csso": "^5.0.0",
-    "sass": "^1.26.10",
+    "sass": "^1.32.6",
     "snyk": "^1.462.0",
-    "uswds": "2.11.1",
+    "uswds": "^2.11.1",
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "node-notifier": "^9.0.1",
     "postcss": "^8.2.1",
     "postcss-csso": "^5.0.0",
-    "sass": "^1.32.6",
+    "sass": "^1.32.8",
     "snyk": "^1.462.0",
     "uswds": "^2.11.1",
     "vinyl-buffer": "^1.0.1",


### PR DESCRIPTION
## USWDS-SITE | overrides nested accordion content borders

closes https://github.com/uswds/uswds-site/issues/1189

## Description

because our accordion component applies borders to all `.usa-accordion__content` we were getting undesired results when previewing our accordion component in these nested previews. This updates so that our accordions appear as expected, borderless, with border, borderless + multi-select

![Screen Shot 2021-03-22 at 4 14 47 PM](https://user-images.githubusercontent.com/37077057/112053189-6daeed80-8b2a-11eb-8767-4a1c9ed8affa.png)


Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error-free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
