### PR TITLE
USWDS - Templates: Fix template screenshots link.

### DIFF
--- a/_includes/code/preview.html
+++ b/_includes/code/preview.html
@@ -8,7 +8,7 @@
     {% if include.image %}
       <a
         class="media_link"
-        href={% include component-preview-link.html component=include.component %}
+        href={% include component-preview-link.html demoLink=include.demoLink component=include.component %}
       >
         <img
           src="{{ site.baseurl }}{{ include.image }}"


### PR DESCRIPTION
## Description

This issue is related to Ticket #22141 on Zendesk. The links on the screenshots were pointing to a non-existent component because it was missing the `demoLink` variable like the button below it.

## Additional information

To test this code:

- Go to [Templates ](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/jm-template-preview-fix/templates/) section and select a template
- Click on template screenshot
- Go back and click on button below

Both should take you to the right destination.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
