### PR TITLE
USWDS - Forms: Fix typo in USWDS template links

### DIFF
--- a/_templates/form-templates/address/guidance/accessibility.md
+++ b/_templates/form-templates/address/guidance/accessibility.md
@@ -1,1 +1,1 @@
-- As you customize this form template, make sure it continues to follow the [accessibility guidelines for form templates](https://designsystem.digital.gov/templates/form-templates/) and the [accessibility guidelines for form controls](https://designsystem.digital.gov/components/form/).
+- As you customize this form template, make sure it continues to follow the [accessibility guidelines for form templates]({{ site.baseurl }}/form-templates/) and the [accessibility guidelines for form controls]({{ site.baseurl }}/components/form/).

--- a/_templates/form-templates/address/guidance/accessibility.md
+++ b/_templates/form-templates/address/guidance/accessibility.md
@@ -1,1 +1,1 @@
-- As you customize this form template, make sure it continues to follow the [accessibility guidelines for form templates](https://designsystem.digital.gov/teampltes/form-templates/) and the [accessibility guidelines for form controls](https://designsystem.digital.gov/components/form/).
+- As you customize this form template, make sure it continues to follow the [accessibility guidelines for form templates](https://designsystem.digital.gov/templates/form-templates/) and the [accessibility guidelines for form controls](https://designsystem.digital.gov/components/form/).

--- a/_templates/form-templates/address/guidance/accessibility.md
+++ b/_templates/form-templates/address/guidance/accessibility.md
@@ -1,1 +1,1 @@
-- As you customize this form template, make sure it continues to follow the [accessibility guidelines for form templates]({{ site.baseurl }}/form-templates/) and the [accessibility guidelines for form controls]({{ site.baseurl }}/components/form/).
+- As you customize this form template, make sure it continues to follow the [accessibility guidelines for form templates]({{ site.baseurl }}/templates/form-templates/) and the [accessibility guidelines for form controls]({{ site.baseurl }}/components/form/).

--- a/_templates/form-templates/name/guidance/accessibility.md
+++ b/_templates/form-templates/name/guidance/accessibility.md
@@ -1,1 +1,1 @@
-- As you customize this form template, make sure it continues to follow the [accessibility guidelines for form templates](https://designsystem.digital.gov/teampltes/form-templates/) and the [accessibility guidelines for form controls](https://designsystem.digital.gov/components/form/).
+- As you customize this form template, make sure it continues to follow the [accessibility guidelines for form templates](https://designsystem.digital.gov/templates/form-templates/) and the [accessibility guidelines for form controls](https://designsystem.digital.gov/components/form/).

--- a/_templates/form-templates/name/guidance/accessibility.md
+++ b/_templates/form-templates/name/guidance/accessibility.md
@@ -1,1 +1,1 @@
-- As you customize this form template, make sure it continues to follow the [accessibility guidelines for form templates](https://designsystem.digital.gov/templates/form-templates/) and the [accessibility guidelines for form controls](https://designsystem.digital.gov/components/form/).
+- As you customize this form template, make sure it continues to follow the [accessibility guidelines for form templates]({{ site.baseurl }}/templates/form-templates/) and the [accessibility guidelines for form controls]({{ site.baseurl }}/components/form/).

--- a/_templates/form-templates/password-reset/guidance/accessibility.md
+++ b/_templates/form-templates/password-reset/guidance/accessibility.md
@@ -1,1 +1,1 @@
-- As you customize this form template, make sure it continues to follow the [accessibility guidelines for form templates](https://designsystem.digital.gov/teampltes/form-templates/) and the [accessibility guidelines for form controls](https://designsystem.digital.gov/components/form/).
+- As you customize this form template, make sure it continues to follow the [accessibility guidelines for form templates](https://designsystem.digital.gov/templates/form-templates/) and the [accessibility guidelines for form controls](https://designsystem.digital.gov/components/form/).

--- a/_templates/form-templates/password-reset/guidance/accessibility.md
+++ b/_templates/form-templates/password-reset/guidance/accessibility.md
@@ -1,1 +1,1 @@
-- As you customize this form template, make sure it continues to follow the [accessibility guidelines for form templates](https://designsystem.digital.gov/templates/form-templates/) and the [accessibility guidelines for form controls](https://designsystem.digital.gov/components/form/).
+- As you customize this form template, make sure it continues to follow the [accessibility guidelines for form templates]({{ site.baseurl }}/templates/form-templates/) and the [accessibility guidelines for form controls]({{ site.baseurl }}/components/form/).

--- a/_templates/form-templates/sign-in/guidance/accessibility.md
+++ b/_templates/form-templates/sign-in/guidance/accessibility.md
@@ -1,3 +1,3 @@
-- As you customize this form template, make sure it continues to follow the [accessibility guidelines for form templates](https://designsystem.digital.gov/templates/form-templates/) and the [accessibility guidelines for form controls](https://designsystem.digital.gov/components/form/).
+- As you customize this form template, make sure it continues to follow the [accessibility guidelines for form templates]({{ site.baseurl }}/templates/form-templates/) and the [accessibility guidelines for form controls]({{ site.baseurl }}/components/form/).
 - **Give adequate advance notice before automatic sign-out.** Don’t automatically sign out a user without giving them 20 seconds' advance notice to request more time. Users with disabilities sometimes require more time to respond to prompts.
 

--- a/_templates/form-templates/sign-in/guidance/accessibility.md
+++ b/_templates/form-templates/sign-in/guidance/accessibility.md
@@ -1,3 +1,3 @@
-- As you customize this form template, make sure it continues to follow the [accessibility guidelines for form templates](https://designsystem.digital.gov/teampltes/form-templates/) and the [accessibility guidelines for form controls](https://designsystem.digital.gov/components/form/).
+- As you customize this form template, make sure it continues to follow the [accessibility guidelines for form templates](https://designsystem.digital.gov/templates/form-templates/) and the [accessibility guidelines for form controls](https://designsystem.digital.gov/components/form/).
 - **Give adequate advance notice before automatic sign-out.** Don’t automatically sign out a user without giving them 20 seconds' advance notice to request more time. Users with disabilities sometimes require more time to respond to prompts.
 


### PR DESCRIPTION
## Previews
- [Address form guidance](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/jm-fix-templates-typo/templates/form-templates/address-form/)
- [Name form](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/jm-fix-templates-typo/templates/form-templates/name-form/)
- [Password reset](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/jm-fix-templates-typo/templates/form-templates/password-reset-form/#accessibility-password-reset-form)
- [Sign in form](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/jm-fix-templates-typo/templates/form-templates/sign-in-form/#sign-in-form-guidance)

## Description
Fixes typo in template links.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
