### PR TITLE
USWDS - Dropdown: Link to Combo Box for Dropdown's "more than 15 options" guidance

### DIFF
--- a/_components/dropdown/guidance/when-to-consider-something-else.md
+++ b/_components/dropdown/guidance/when-to-consider-something-else.md
@@ -1,4 +1,4 @@
 - **Fewer than seven options.** Use radio buttons instead.
-- **More than 15 options.** If the list of options is very long. Let users type the same information into a text input that suggests possible options instead.
+- **More than 15 options.** If the list of options is very long, consider using a [combo box]({{ site.baseurl }}/components/combo-box), or let users type the same information into a text input.
 - **Multi-select.** If you need to allow users to select more than one option at once. Users often don’t understand how to select multiple items from dropdowns. Use checkboxes instead.
 - **Site navigation.** Use the navigation components instead.


### PR DESCRIPTION
## Description

Adds text to the [dropdown component documentation](https://designsystem.digital.gov/components/dropdown/) to recommend a [combo box](https://designsystem.digital.gov/components/combo-box/) when there are more than 15 options.

## Additional information

The combo box guidance explicitly mentions this use-case:

>### When to use the combo box component
>
> - **More than 15 options.** When there are more than 15 choices in a drop-down list it can be hard to navigate with scrolling only.

---

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
