### PR TITLE
Add newsletter signup to pre-footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -48,7 +48,7 @@
             </div>
             <div class="usa-media-block__body">
               <h3>Subscribe to our newsletter</h3>
-              <a href="https://public.govdelivery.com/accounts/USGSATTS/subscriber/new?qsp=GSA_TTS">
+              <a class="usa-link usa-link--external" href="https://public.govdelivery.com/accounts/USGSATTS/subscriber/new?qsp=GSA_TTS">
                 Sign up for USWDS updates
               </a>
             </div>
@@ -64,7 +64,7 @@
             <div class="usa-media-block__body">
               <h3>Get support</h3>
               <a href="mailto:uswds@support.digitalgov.gov">
-                Send a support email
+                Email the USWDS team
               </a>
             </div>
           </div>


### PR DESCRIPTION
Adds a newsletter signup link to our social pre-footer. Removes the Twitter link for space considerations. I think we should consider this an MVP for integrating this functionality into the site. As we move closer to 3.0, we'll likely want to rethink how we're approaching this information!

[Preview](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/dw-add-newsletter-signup/) → 