### PR TITLE
Date picker: Update date picker a11y guidance for voiceover.

### DIFF
--- a/_includes/accessibility.html
+++ b/_includes/accessibility.html
@@ -15,6 +15,7 @@
   <h2 id="known-issues-with-screen-readers">Known issues with screen readers</h2>
   <ul class="usa-content-list">
     <li>VoiceOver on iOS currently does not support fieldset and legend for forms. You can address this by using <code>aria-labelledby="for-attribute-of-label id-of-legend id-of-additional-info"</code> on each input in the fieldset. Using <code>aria-labelledby</code> will overwrite the default text read by the screen reader, so it is important to include all relevant information.</li>
-    <li>VoiceOver on OS X currently does not support <code>aria-describedby</code>. Use <code>aria-labelledby</code> instead, and include all related fields, including, labels, legend, and hint text</li>
+    <li>
+      VoiceOver on OS X offers partial support for <code>aria-describedby</code>. There's full support for conveying description on text inputs, partial support for description changes when the text input is in focus, and no support for <code>role="alert"</code>. Visit <a href="https://a11ysupport.io/tech/aria/aria-describedby_attribute">a11ysupport.io</a> to view the full status of support.</li>
   </ul>
 </section>


### PR DESCRIPTION
## Description
[
Preview →](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/jm-describedby-guidance/components/form/#known-issues-with-screen-readers)

There's now partial support for `aria-describedby` on Voiceover. This updates the form guidance on `describedby` to reflect that.
Related to [issue #4347](https://github.com/uswds/uswds/issues/4347) in USWDS. Based on changes from [USWDS PR #4414](https://github.com/uswds/uswds/pull/4414).

## Additional information

This affects the components:
- Date range
- Date range picker

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
