### PR TITLE
Getting Started for Devs - move resources to subnav

### DIFF
--- a/pages/documentation/getting-started-developers/overview.md
+++ b/pages/documentation/getting-started-developers/overview.md
@@ -9,6 +9,7 @@ subnav:
   - href: /documentation/getting-started/developers/phase-one-install/
   - href: /documentation/getting-started/developers/phase-two-compile/
   - href: /documentation/getting-started/developers/phase-three-customize/
+  - href: /documentation/getting-started/developers/resources/
 redirect_from:
   - /documentation/fundamentals/
 ---

--- a/pages/documentation/getting-started-developers/phase-three.md
+++ b/pages/documentation/getting-started-developers/phase-three.md
@@ -45,30 +45,3 @@ This command will run in your Terminal window. When you want to shut it down, us
 Our showcase illustrates how other teams of developers and designers have taken the building blocks USWDS provides and redesigned them for their brand and message.
 
 We’re looking forward to hearing about your experience and seeing how USWDS's components look in your project!
-
-
-## Resources
-Now that you’ve gotten started, the following resources are available to help you stay in touch, to provide support as you continue with your projects, and to enable you to provide recommendations and feedback.
-
-### Need installation help?
-Do you have questions or need help with setup? Did you run into any weird errors while following these instructions? Feel free to [open an issue](https://github.com/uswds/uswds/issues) in GitHub.
-
-You can also email us directly at [uswds@support.digitalgov.gov](mailto:uswds@support.digitalgov.gov).
-
-### Stay involved
-USWDS is supported by an active, open-source community of engineers, content specialists, and designers.
-
-### Continue learning
-We regularly update USWDS. To stay informed of changes, tips, and tricks, join us for our monthly calls and/or [subscribe to Wave](https://public.govdelivery.com/accounts/USGSATTS/subscriber/new?qsp=GSA_TTS), our newsletter.
-
-### Contribute to the codebase
-For complete instructions on how to contribute code, please read [CONTRIBUTING.md](https://github.com/uswds/uswds/blob/develop/CONTRIBUTING.md). These instructions also include guidance on how to set up your own copy of the design system style guide website for development.
-
-If you would like to learn more about how we work, check out the [Workflow](https://github.com/uswds/uswds/wiki/Workflow) and [Issue label Glossary](https://github.com/uswds/uswds/wiki/Issue-label-glossary) pages on our wiki.
-
-If you have questions or concerns about our contributing workflow, feel free to [open an issue](https://github.com/uswds/uswds/issues), such as the following in GitHub:
-- Bug report — Report a bug and help USWDS improve.
-- Feature request — Suggest a new idea for the design system.
-- Report a security vulnerability — Report potential security issues. Review our [security policy](https://github.com/uswds/uswds/security/policy) for more details.
-
-You can also email us directly at [uswds@support.digitalgov.gov](mailto:uswds@support.digitalgov.gov).

--- a/pages/documentation/getting-started-developers/resources.md
+++ b/pages/documentation/getting-started-developers/resources.md
@@ -1,0 +1,31 @@
+---
+permalink: /documentation/getting-started/developers/resources/
+layout: styleguide
+title: "Resources"
+category: How to use USWDS
+lead: Now that you’ve gotten started, the following resources are available to help you stay in touch, to provide support as you continue with your projects, and to enable you to provide recommendations and feedback.
+type: docs
+---
+
+## Need installation help?
+Do you have questions or need help with setup? Did you run into any weird errors while following these instructions? Feel free to [open an issue](https://github.com/uswds/uswds/issues) in GitHub.
+
+You can also email us directly at [uswds@support.digitalgov.gov](mailto:uswds@support.digitalgov.gov).
+
+## Stay involved
+USWDS is supported by an active, open-source community of engineers, content specialists, and designers.
+
+## Continue learning
+We regularly update USWDS. To stay informed of changes, tips, and tricks, join us for our monthly calls and/or [subscribe to Wave](https://public.govdelivery.com/accounts/USGSATTS/subscriber/new?qsp=GSA_TTS), our newsletter.
+
+## Contribute to the codebase
+For complete instructions on how to contribute code, please read [CONTRIBUTING.md](https://github.com/uswds/uswds/blob/develop/CONTRIBUTING.md). These instructions also include guidance on how to set up your own copy of the design system style guide website for development.
+
+If you would like to learn more about how we work, check out the [Workflow](https://github.com/uswds/uswds/wiki/Workflow) and [Issue label Glossary](https://github.com/uswds/uswds/wiki/Issue-label-glossary) pages on our wiki.
+
+If you have questions or concerns about our contributing workflow, feel free to [open an issue](https://github.com/uswds/uswds/issues), such as the following in GitHub:
+- Bug report — Report a bug and help USWDS improve.
+- Feature request — Suggest a new idea for the design system.
+- Report a security vulnerability — Report potential security issues. Review our [security policy](https://github.com/uswds/uswds/security/policy) for more details.
+
+You can also email us directly at [uswds@support.digitalgov.gov](mailto:uswds@support.digitalgov.gov).


### PR DESCRIPTION
The resources for Getting Started for Devs are currently on the Phase: 3 customize page. This PR moves the resources information to its own page that is accessed via the subnav under Getting Started for Devs. 

Addresses Issue #1421 