### PR TITLE
copyedit round 1 design tokens

### DIFF
--- a/pages/design-tokens/overview.md
+++ b/pages/design-tokens/overview.md
@@ -3,7 +3,7 @@ permalink: /design-tokens/
 layout: styleguide
 title: Design tokens
 category: Design tokens
-lead: USWDS visual design is based on consistent palettes of typography, spacing units, color, and other discrete elements of style we call **design tokens**{:.font-lang-8}.
+lead: The Design System's visual design is based on consistent palettes of typography, spacing units, color, and other discrete elements of style we call **design tokens**{:.font-lang-8}.
 type: docs
 subnav:
   - text: Introducing design tokens
@@ -20,15 +20,15 @@ subnav:
 
 Anything we see on a website is built from elements of style: color, spacing, typography, line height, and opacity. The CSS rules associated with these elements can accept a broad continuum of values — in the case of color, there are over 16 million separate colors in the RGB color space. Font size, line height, spacing, and others can accept a similarly wide range of values.
 
-This degree of choice can slow down design work and make communication between designer and developer unnecessarily granular. USWDS seeks to maximize design efficiency and improve communication with **design tokens**: the discrete palettes of values from which we base all our visual design.
+This degree of choice can slow down design work and make communication between designer and developer unnecessarily granular. The Design System seeks to maximize design efficiency and improve communication with **design tokens**: the discrete palettes of values from which we base all our visual design.
 
-Design tokens are a limited set of discrete options, just like a scale of musical notes is drawn from the spectrum of all possible frequencies. Or like the presets on a car radio — not every option, just a specific selection.
+Our System design tokens are a limited set of discrete options, just like a scale of musical notes is drawn from the spectrum of all possible frequencies. Or like the presets on a car radio — not every option, just a specific selection. Take the following figure for instance: In the spectrum of hues between white and black, we provide a curated selection of five:
 
 {:.padding-y-2}
 ![continuous and tokenized values]({{ site.baseurl }}/assets/img/design-tokens/continuous-v-token.svg){: role="img"}
 
 ### Example: Measure (line length)
-For example, measure (or line length) expressed with the `max-width` CSS property can accept any value in units like `em`, `rem`, `ch`, `ex`, and `px` to at least two decimal places. USWDS limits itself to 7 [measure]({{ site.baseurl }}/design-tokens/typesetting/measure/){:.token} tokens:
+For example, measure (or line length) expressed with the `max-width` CSS property can accept any value in units like `em`, `rem`, `ch`, `ex`, and `px` to at least two decimal places. The Design System limits itself to seven [measure]({{ site.baseurl }}/design-tokens/typesetting/measure/){:.token} tokens, the values of which are given in the following table:
 
 {:.site-table}
 | token   | value
@@ -41,19 +41,19 @@ For example, measure (or line length) expressed with the `max-width` CSS propert
 |`6`      | `88ex`
 |`'none'` | no max width
 
-Anything built using USWDS will use one of these 7 [measure]({{ site.baseurl }}/design-tokens/typesetting/measure/){:.token} tokens when specifying measure.
+Anything built using the Design System will use one of these seven [measure]({{ site.baseurl }}/design-tokens/typesetting/measure/){:.token} tokens when specifying measure.
 
 ## Keys and values
 You can think of a design token as a **key** that unlocks a specific **value**. Often, the specific value is less important than its effect. Each token is a quoted string or, with only the exceptions of `1px` and `2px`, a unitless number — and the mechanism by which the final display value is unlocked is a **function**, **mixin**, or **utility class**.
 
-We can't include tokens directly in our Sass, like `max-width: 1`, rather we use a helper function like `max-width: measure(1)` or a mixin like `@include u-measure(1)`. All USWDS design tokens have helper mixins and functions to use them in component Sass.
+We can't include tokens, like `max-width: 1`, directly in our Sass. Rather, we use a helper function like `max-width: measure(1)` or a mixin like `@include u-measure(1)`. All our design tokens have helper mixins and functions to use them in component Sass.
 
 {: .site-note }
 **Note:** We do not include the token's value directly into our Sass rules.
 
 ### Example: Tokens in settings and component Sass
 
-Tokens can, themselves, be expressed as variables. And this is how most USWDS theme settings work. For instance, the following is an example of theme settings from `_uswds-theme-spacing.scss` showing settings variables assigned spacing unit tokens:
+Tokens can be expressed as variables, which is how most Design System theme settings work. For instance, the following is an example of theme settings from `_uswds-theme-spacing.scss` showing settings variables assigned spacing unit tokens:
 
 ```
 $theme-grid-container-max-width:    'desktop';
@@ -62,7 +62,7 @@ $theme-site-margins-width:          4;
 $theme-site-margins-mobile-width:   2;
 ```
 
-USWDS component Sass uses those variableized tokens to build component styles:
+The Design System's component Sass uses those variableized tokens to build component styles as in the following code:
 
 ```
 .usa-example {
@@ -75,7 +75,7 @@ USWDS component Sass uses those variableized tokens to build component styles:
 }
 ```
 
-This is the functional equivalent of:
+This example is the functional equivalent of the following code:
 
 ```
 .usa-example {
@@ -88,7 +88,7 @@ This is the functional equivalent of:
 }
 ```
 
-Which, if `$theme-respect-user-font-size` is set to true would output something like:
+In this case, if `$theme-respect-user-font-size` is set to true, the output would be something like the following code:
 
 ```
 .usa-example {
@@ -105,11 +105,11 @@ Which, if `$theme-respect-user-font-size` is set to true would output something 
 }
 ```
 
-In general, USWDS sets variables with tokens, and passes those variables into functions and mixins in the source Sass.
+In general, the Design System sets variables with tokens and passes those variables into functions and mixins in the source Sass.
 
 ## Using design tokens
 
-Use design tokens directly to set the value of settings variables in USWDS theme settings files, like `$theme-grid-container-max-width: 'desktop'`. Otherwise, use functions, mixins, or utility classes as in the examples below. See individual design token section for more details.
+Use design tokens, like `$theme-grid-container-max-width: 'desktop'`, directly to set the value of settings variables in our theme settings files. Otherwise, use functions, mixins, or utility classes as in the following tables on color, spacing units, font size, font family, and font family and size together:
 
 ### Color
 <div class="site-table-wrapper">


### PR DESCRIPTION
## Description

Replaced "USWDS" with "Design System."
Ensured figures and tables are introduced in the text (for accessibility).
Revised for inclusive language.
