### PR TITLE
USWDS support email address - update across site

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,6 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
-  x86_64-darwin-21
 
 DEPENDENCIES
   html-proofer
@@ -109,4 +108,4 @@ DEPENDENCIES
   webrick (~> 1.7)
 
 BUNDLED WITH
-   2.3.6
+   2.2.33

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-21
 
 DEPENDENCIES
   html-proofer
@@ -108,4 +109,4 @@ DEPENDENCIES
   webrick (~> 1.7)
 
 BUNDLED WITH
-   2.2.33
+   2.3.6

--- a/_components/link/guidance/usability-should.md
+++ b/_components/link/guidance/usability-should.md
@@ -50,7 +50,7 @@
 - **Write out email and phone links.** For `mailto:` and `tel:` links, write out email addresses and phone numbers so users can read or copy this information without selecting the link.
 
     **Example:**
-    > Email us at [uswds@support.digitalgov.gov](mailto:uswds@support.digitalgov.gov)
+    > Email us at [{{ site.uswds_email }}](mailto:{{ site.uswds_email }})
 
 - **Encode email and phone links.** Some browsers don’t automatically display a clickable link for email addresses or phone numbers, so encode email and phone links with `mailto:` and `tel:`. Include the country code in phone numbers to support international users.
 

--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,7 @@ title: U.S. Web Design System (USWDS)
 description: USWDS makes it easier to build accessible, mobile-friendly government websites.
 google_analytics_ua: UA-48605964-43
 uswds_version: 2.13.1
+uswds_email: uswds@gsa.gov
 federalist_base: "https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds"
 federalist_component_preview: "components/preview"
 federalist_release_prefix: "release-"

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -62,7 +62,7 @@
             </div>
             <div class="usa-media-block__body">
               <h3>Get support</h3>
-              <a href="mailto:uswds@support.digitalgov.gov">
+              <a href="mailto:{{ site.uswds_email }}">
                 Email the USWDS team
               </a>
             </div>

--- a/_next/05-get-involved.md
+++ b/_next/05-get-involved.md
@@ -35,7 +35,7 @@ chapter: true
 
 - Be vocal advocates of USWDS and the benefits it provides
 
-- [Share critical, candid feedback with us](mailto:uswds@support.digitalgov.gov) to help make the design system better
+- [Share critical, candid feedback with us](mailto:{{ site.uswds_email }}) to help make the design system better
 
 ### Policy analysts can: 
 

--- a/_posts/2018-02-22-nsf-seed-fund.md
+++ b/_posts/2018-02-22-nsf-seed-fund.md
@@ -44,4 +44,4 @@ Overall the USWDS shortened the amount of time it took to implement the site, fo
 
 ---
 
-We’re looking to learn more [from agencies that have used USWDS](https://github.com/uswds/uswds/blob/develop/docs/WHO_IS_USING_USWDS.md) (see list on GitHub); if you’re interested in talking to us about your experience or have any feedback, feel free to send us an email at [uswds@support.digitalgov.gov](mailto:uswds@support.digitalgov.gov). You can also chat with the team in the [public Slack channel for USWDS](https://chat.18f.gov/) via Google Forms!
+We’re looking to learn more [from agencies that have used USWDS](https://github.com/uswds/uswds/blob/develop/docs/WHO_IS_USING_USWDS.md) (see list on GitHub); if you’re interested in talking to us about your experience or have any feedback, feel free to send us an email at [{{ site.uswds_email }}](mailto:{{ site.uswds_email }}). You can also chat with the team in the [public Slack channel for USWDS](https://chat.18f.gov/) via Google Forms!

--- a/_posts/2018-03-22-dds-case-study.md
+++ b/_posts/2018-03-22-dds-case-study.md
@@ -45,4 +45,4 @@ I’m pretty happy with the level of engagement from USWDS team. They have been 
 
 ---
 
-We’re looking to learn more [from agencies that have used USWDS](https://github.com/uswds/uswds/blob/develop/docs/WHO_IS_USING_USWDS.md). If you’re interested in talking to us about your experience or have any feedback, feel free to send us an email at [uswds@support.digitalgov.gov](mailto:uswds@support.digitalgov.gov). You can also chat with the team in the [public Slack channel for USWDS](https://chat.18f.gov/) (sign up via Google Forms).
+We’re looking to learn more [from agencies that have used USWDS](https://github.com/uswds/uswds/blob/develop/docs/WHO_IS_USING_USWDS.md). If you’re interested in talking to us about your experience or have any feedback, feel free to send us an email at [{{ site.uswds_email }}](mailto:{{ site.uswds_email }}). You can also chat with the team in the [public Slack channel for USWDS](https://chat.18f.gov/) (sign up via Google Forms).

--- a/_posts/2019-04-08-introducing-uswds-2-0.md
+++ b/_posts/2019-04-08-introducing-uswds-2-0.md
@@ -189,7 +189,7 @@ USWDS 2.0 is built to grow and designed to adapt. It exists to help teams build 
 - Prepared to grow and adapt to user needs and industry best practices
 
 {:.margin-top-6}
-Like any true 2.0, this is a living product. We’ll continue to test our decisions and assumptions with real-world feedback as it develops and evolves. We encourage you to explore USWDS 2.0, contribute your own code and ideas, and leave feedback on [GitHub](https://github.com/uswds/uswds/issues), [email](mailto:uswds@support.digitalgov.gov), or our [Slack channel](https://chat.18f.gov/) (sign-up via Google Forms). And join our new mailing list by sending an email to [uswds-subscribe-request@listserv.gsa.gov](mailto:uswds-subscribe-request@listserv.gsa.gov). We’ll use your input to continuously improve the system with ongoing regular releases. We’re listening.
+Like any true 2.0, this is a living product. We’ll continue to test our decisions and assumptions with real-world feedback as it develops and evolves. We encourage you to explore USWDS 2.0, contribute your own code and ideas, and leave feedback on [GitHub](https://github.com/uswds/uswds/issues), [email](mailto:{{ site.uswds_email }}), or our [Slack channel](https://chat.18f.gov/) (sign-up via Google Forms). And join our new mailing list by sending an email to [uswds-subscribe-request@listserv.gsa.gov](mailto:uswds-subscribe-request@listserv.gsa.gov). We’ll use your input to continuously improve the system with ongoing regular releases. We’re listening.
 
 ---
 

--- a/files/next/README.md
+++ b/files/next/README.md
@@ -6,4 +6,4 @@ We interviewed 60 government content managers, designers, engineers, and other s
 
 [Read the report](Transforming-the-American-digital-experience-v0.1-DRAFT.pdf) (PDF, 947 KB, Draft v0.1, January 2021) included in this directory to learn how teams are using the design system and how, together, we can improve government services and transform the American digital experience. Throughout the report, we list opportunities to get involved and prompts to investigate ways to move these efforts forward.
 
-Have a story related to using the design system? Whether it’s a big win or a roadblock, we want to hear it! Please email us at uswds@support.digitalgov.gov.
+Have a story related to using the design system? Whether it’s a big win or a roadblock, we want to hear it! Please email us at {{ site.uswds_email }}.

--- a/pages/404.md
+++ b/pages/404.md
@@ -30,7 +30,7 @@ permalink: /404.html
                 </a>
               </li>
               <li class="usa-button-group__item">
-                <a href="mailto:uswds@support.digitalgov.gov" class="usa-button usa-button--outline">
+                <a href="mailto:{{ site.uswds_email }}" class="usa-button usa-button--outline">
                   Contact us
                 </a>
               </li>

--- a/pages/about/community.md
+++ b/pages/about/community.md
@@ -16,7 +16,7 @@ Join us in the `#uswds-public` channel in Slack by [filling out our form](https:
 
 <a href="https://chat.18f.gov/" class="usa-button width-card-lg margin-top-2">Join the USWDS Community</a>
 
-If you're having trouble, email [uswds@support.digitalgov.gov](mailto:uswds@support.digitalgov.gov?subject=Join%20USWDS%20Slack) with _Join the USWDS Community_ in the subject.
+If you're having trouble, email [{{ site.uswds_email }}](mailto:{{ site.uswds_email }}?subject=Join%20USWDS%20Slack) with _Join the USWDS Community_ in the subject.
 
 
 ## Contribute to USWDS

--- a/pages/about/key-benefits.md
+++ b/pages/about/key-benefits.md
@@ -101,7 +101,7 @@ We are as committed as you are to public service, and we reflect this in our pro
         </svg>
       </div>
       <div class="usa-icon-list__content">
-        <p><b>Use these key benefits listed to make the case to your team and management.</b> You may customize the themes and messages for your audience, and email us at <a href="mailto:uswds@support.digitalgov.gov">uswds@support.digitalgov.gov</a> if you have feedback on things to add or remove from this list.</p>
+        <p><b>Use these key benefits listed to make the case to your team and management.</b> You may customize the themes and messages for your audience, and email us at <a href="mailto:{{ site.uswds_email }}">{{ site.uswds_email }}</a> if you have feedback on things to add or remove from this list.</p>
       </div>
     </li>
     <li class="usa-icon-list__item">

--- a/pages/documentation/getting-started-designers/designers/overview.md
+++ b/pages/documentation/getting-started-designers/designers/overview.md
@@ -26,7 +26,7 @@ Alternatively, you can view the design assets on [Figma](https://figma.com/commu
 
 
 ### Retired design files
-USWDS no longer maintains the following design files. The most recent versions remain available for download at the links below. While USWDS is no longer maintaining these files, we'd love to hear from any teams that are using them and adding new components when new versions of USWDS are released. [Send us an email](mailto:@uswds@support.digitalgov.gov).
+USWDS no longer maintains the following design files. The most recent versions remain available for download at the links below. While USWDS is no longer maintaining these files, we'd love to hear from any teams that are using them and adding new components when new versions of USWDS are released. [Send us an email](mailto:@{{ site.uswds_email }}).
 
 #### 1.6.10
 {% include download-buttons-design-retired-1.6.10.html %}
@@ -44,4 +44,4 @@ We’re glad you’re considering contributing to USWDS — their success relies
 
 Please visit our [wiki](https://github.com/uswds/uswds/wiki/Contribution-Guidelines:-Design) to read our full contribution guidelines. Also, please note that every submission we receive goes through a full design review. (Changes that only affect underlying code are reviewed by our developers.)
 
-Questions or comments? [Email us](mailto:uswds@support.digitalgov.gov) and we’ll get back to you as quickly as we can.
+Questions or comments? [Email us](mailto:{{ site.uswds_email }}) and we’ll get back to you as quickly as we can.

--- a/pages/documentation/getting-started-developers/resources.md
+++ b/pages/documentation/getting-started-developers/resources.md
@@ -19,7 +19,7 @@ subnav:
 ## Need installation help?
 Do you have questions or need help with setup? Did you run into any weird errors while following these instructions? Feel free to [open an issue](https://github.com/uswds/uswds/issues) in GitHub.
 
-You can also email us directly at [uswds@support.digitalgov.gov](mailto:uswds@support.digitalgov.gov).
+You can also email us directly at [{{ site.uswds_email }}](mailto:{{ site.uswds_email }}).
 
 ## Stay involved
 USWDS is supported by an active, open-source community of engineers, content specialists, and designers.
@@ -37,4 +37,4 @@ If you have questions or concerns about our contributing workflow, feel free to 
 - Feature request — Suggest a new idea for the design system.
 - Report a security vulnerability — Report potential security issues. Review our [security policy](https://github.com/uswds/uswds/security/policy) for more details.
 
-You can also email us directly at [uswds@support.digitalgov.gov](mailto:uswds@support.digitalgov.gov).
+You can also email us directly at [{{ site.uswds_email }}](mailto:{{ site.uswds_email }}).

--- a/pages/documentation/implementations.md
+++ b/pages/documentation/implementations.md
@@ -72,4 +72,4 @@ If you have a new implementation to add to this list, please [open an issue] on 
 </div>
 
 [open an issue]: https://github.com/uswds/uswds-site/issues/new
-[send us an email]: mailto:uswds@support.digitalgov.gov
+[send us an email]: mailto:{{ site.uswds_email }}

--- a/pages/documentation/maturity-model.md
+++ b/pages/documentation/maturity-model.md
@@ -174,7 +174,7 @@ understanding and adopting the design principles and individual components.
 This is a work in progress, and we want your input.
 - Share your feedback and collaborate with the [USWDS community](https://digital.gov/communities/uswds/)
 on the [#uswds-public](https://app.slack.com/client/T025AQGAN/C3F14AHSQ){:target="_blank" rel="noopener"} Slack channel.
-- If you can't access slack, email us your feedback directly at [uswds@support.digitalgov.gov](mailto:uswds@support.digitalgov.gov)
+- If you can't access slack, email us your feedback directly at [{{ site.uswds_email }}](mailto:{{ site.uswds_email }})
 
 If you’re new to the maturity model, listen to [USWDS January Monthly Call](https://digital.gov/event/2020/01/16/uswds-january-monthly-call/)
 on the using the USWDS maturity model.

--- a/pages/documentation/showcase-all.md
+++ b/pages/documentation/showcase-all.md
@@ -3,7 +3,7 @@ permalink: /getting-started/showcase/all/
 layout: styleguide
 title: USWDS powered sites
 category: How to use USWDS
-lead: Below are a list of website and applications currently using USWDS. If your project is currently using USWDS and you do not see it on this list, please feel free to [submit a pull request](https://github.com/uswds/uswds/blob/develop/docs/WHO_IS_USING_USWDS.md) via GitHub or email the core team at [{{ site.uswds_email }}](mailto:{{ site.uswds_email }}).
+lead: Below are a list of website and applications currently using USWDS. If your project is currently using USWDS and you do not see it on this list, please feel free to [submit a pull request](https://github.com/uswds/uswds/blob/develop/docs/WHO_IS_USING_USWDS.md) via GitHub or email the core team at [uswds@gsa.gov](mailto:uswds@gsa.gov).
 ---
 ## Sites using the U.S. Web Design System
 {{ site.data.standards-sites.decoded | newline_to_br | split: '<br />' | where_exp: 'line', 'line contains "- ["' | join: '<br />' | markdownify | absolutify_links: site.data.standards-sites.html_url }}

--- a/pages/documentation/showcase-all.md
+++ b/pages/documentation/showcase-all.md
@@ -3,7 +3,9 @@ permalink: /getting-started/showcase/all/
 layout: styleguide
 title: USWDS powered sites
 category: How to use USWDS
-lead: Below are a list of website and applications currently using USWDS. If your project is currently using USWDS and you do not see it on this list, please feel free to [submit a pull request](https://github.com/uswds/uswds/blob/develop/docs/WHO_IS_USING_USWDS.md) via GitHub or email the core team at [uswds@gsa.gov](mailto:uswds@gsa.gov).
 ---
+{:.site-text-intro}
+Below are a list of website and applications currently using USWDS. If your project is currently using USWDS and you do not see it on this list, please feel free to [submit a pull request](https://github.com/uswds/uswds/blob/develop/docs/WHO_IS_USING_USWDS.md) via GitHub or email the core team at [{{ site.uswds_email }}](mailto:{{ site.uswds_email }}).
+
 ## Sites using the U.S. Web Design System
 {{ site.data.standards-sites.decoded | newline_to_br | split: '<br />' | where_exp: 'line', 'line contains "- ["' | join: '<br />' | markdownify | absolutify_links: site.data.standards-sites.html_url }}

--- a/pages/documentation/showcase-all.md
+++ b/pages/documentation/showcase-all.md
@@ -3,7 +3,7 @@ permalink: /getting-started/showcase/all/
 layout: styleguide
 title: USWDS powered sites
 category: How to use USWDS
-lead: Below are a list of website and applications currently using USWDS. If your project is currently using USWDS and you do not see it on this list, please feel free to [submit a pull request](https://github.com/uswds/uswds/blob/develop/docs/WHO_IS_USING_USWDS.md) via GitHub or email the core team at [uswds@support.digitalgov.gov](mailto:uswds@support.digitalgov.gov).
+lead: Below are a list of website and applications currently using USWDS. If your project is currently using USWDS and you do not see it on this list, please feel free to [submit a pull request](https://github.com/uswds/uswds/blob/develop/docs/WHO_IS_USING_USWDS.md) via GitHub or email the core team at [{{ site.uswds_email }}](mailto:{{ site.uswds_email }}).
 ---
 ## Sites using the U.S. Web Design System
 {{ site.data.standards-sites.decoded | newline_to_br | split: '<br />' | where_exp: 'line', 'line contains "- ["' | join: '<br />' | markdownify | absolutify_links: site.data.standards-sites.html_url }}

--- a/pages/whats-new/overview.md
+++ b/pages/whats-new/overview.md
@@ -33,7 +33,7 @@ You can read some older posts on the [18F Blog](https://18f.gsa.gov/tags/web-des
 Interested in seeing who else is using USWDS? We
 maintain a list of sites in our GitHub repo. Feel free to
 [open an issue](https://github.com/uswds/uswds-assets/issues/new) using GitHub
-or [email us](mailto:uswds@support.digitalgov.gov) if you’d like to add your
+or [email us](mailto:{{ site.uswds_email }}) if you’d like to add your
 project to our list.
 
 <a href="https://github.com/uswds/uswds/blob/develop/docs/WHO_IS_USING_USWDS.md" class="usa-button site-button">View our list on GitHub</a>


### PR DESCRIPTION
Created a site-wide variable for the uswds support email address, updated the value to match the new gsa.gov address, and replaced all existing references. 

old address: uswds@support.digitalgov.gov 
new address: uswds@gsa.gov

Closes #1451
