### PR TITLE
Correct tablet-lg references in docs

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -789,7 +789,7 @@
       subsection: Modal max width (lg)
       usage: Maximum width of large modal window.
       var: $theme-modal-lg-max-width
-      default: "800px"
+      default: "880px"
       kind: px
     - name: Modal
       subsection: Modal max width (lg inner content)

--- a/_data/tokens/spacing.yml
+++ b/_data/tokens/spacing.yml
@@ -47,7 +47,7 @@ positive:
     - token: 'tablet'
       value: 640px
     - token: 'tablet-lg'
-      value: 800px
+      value: 880px
   largest:
     - token: 'desktop'
       value: 1024px

--- a/_utilities/layout-grid.md
+++ b/_utilities/layout-grid.md
@@ -532,7 +532,7 @@ $theme-utility-breakpoints: (
   'mobile':            false,   // 320px
   'mobile-lg':         true,    // 480px
   'tablet':            true,    // 640px
-  'tablet-lg':         false,   // 800px
+  'tablet-lg':         false,   // 880px
   'desktop':           true,    // 1024px
   'desktop-lg':        false,   // 1200px
   'widescreen':        false,   // 1400px

--- a/css/old settings/_uswds-project-settings.scss
+++ b/css/old settings/_uswds-project-settings.scss
@@ -123,7 +123,7 @@ $theme-output-breakpoints: (
   "tablet": true,
   // 640px
   "tablet-lg": false,
-  // 800px
+  // 880px
   "desktop": true,
   // 1040px
   "desktop-lg": false,

--- a/css/settings/_uswds-theme-utilities.scss
+++ b/css/settings/_uswds-theme-utilities.scss
@@ -77,7 +77,7 @@ $theme-utility-breakpoints: (
   "tablet": true,
   // 640px
   "tablet-lg": false,
-  // 800px
+  // 880px
   "desktop": true,
   // 1024px
   "desktop-lg": true,


### PR DESCRIPTION
## Description

Doc's reflect correct `tablet-lg` value. Closes https://github.com/uswds/uswds/issues/4549.

---

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [ ] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
