### PR TITLE
Fix typo / inconsistency in "display-none" code example text

### DIFF
--- a/_utilities/display.md
+++ b/_utilities/display.md
@@ -148,7 +148,7 @@ utilities:
       <div class="display-inline border-1px padding-2 margin-bottom-05"><span class="utility-class">.display-inline</span></div>
       <div class="display-inline-block border-1px padding-2 margin-bottom-05"><span class="utility-class">.display-inline-block</span></div>
       <div class="display-inline-flex border-1px padding-2 margin-bottom-05"><span class="utility-class">.display-inline-flex</span></div>
-      <div class="display-none border-1px padding-2 margin-bottom-05"><span class="utility-class">.display-inline</span></div>
+      <div class="display-none border-1px padding-2 margin-bottom-05"><span class="utility-class">.display-none</span></div>
       <div class="display-table">
         <div class="display-table-row">
           <div class="display-table-cell border-1px padding-2"><span class="utility-class">.display-table-cell</span></div>


### PR DESCRIPTION
## Description

Fixes a minor text inconsistency on the ["Display" utilities page](https://designsystem.digital.gov/utilities/display/#utility-display), where each `display-` utility class includes a code snippet with (a) the class name and (b) text matching that class name. However, the text for the `display-none` example is inconsistent, showing `display-inline` instead of `display-none`. This makes it marginally more difficult to identify `display-none` as an available utility, where one would need to reference the code snippet since the nature of `display-none` would make the live preview invisible.