### PR TITLE
USWDS-site - Header: update icon markup on header search

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -78,7 +78,7 @@
         class="usa-button margin-top-0"
         type="submit"
         name="commit">
-        <span class="usa-sr-only">Search</span>
+        <img src="{{ site.baseurl }}/assets/img/usa-icons-bg/search--white.svg" class="usa-search__submit-icon" alt="Search">
       </button>
     </div>
   </form>

--- a/_includes/touchpoint-survey-script.html
+++ b/_includes/touchpoint-survey-script.html
@@ -1,0 +1,5 @@
+<script src="https://touchpoints.app.cloud.gov/touchpoints/5c2410e4.js" async></script>
+
+<section class="touchpoints__container" role="complementary" aria-label="Page feedback">
+    <button type="button" class="usa-button usa-button--outline" id="#touchpoints-modal-button" aria-label="Provide feedback about this page" tabindex="0">Is this page helpful?</button>
+</section>

--- a/_includes/touchpoint-survey-script.html
+++ b/_includes/touchpoint-survey-script.html
@@ -1,5 +1,0 @@
-<script src="https://touchpoints.app.cloud.gov/touchpoints/5c2410e4.js" async></script>
-
-<section class="touchpoints__container" role="complementary" aria-label="Page feedback">
-    <button type="button" class="usa-button usa-button--outline" id="#touchpoints-modal-button" aria-label="Provide feedback about this page" tabindex="0">Is this page helpful?</button>
-</section>


### PR DESCRIPTION
## Description

- [x] Update the header search markup to match the update from [2.13.0](https://github.com/uswds/uswds/releases/tag/v2.13.0)

Closes #1485

[Preview Link](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/al-icon-markup-update/)