### PR TITLE
USWDS-Site - Form Component Markdown: Switched package name from usa-form-controls to form-controls

### DIFF
--- a/_components/combo-box/combo-box.md
+++ b/_components/combo-box/combo-box.md
@@ -2,7 +2,7 @@
 category: Components
 component:
   status: ready
-  package: usa-form-controls
+  package: form-controls
   dependencies:
 implementation:
   initProps:

--- a/_components/date-input/date-input.md
+++ b/_components/date-input/date-input.md
@@ -2,7 +2,7 @@
 category: Components
 component:
   status: ready
-  package: usa-form-controls
+  package: form-controls
   dependencies:
 layout: component
 lead: Three text fields are the easiest way for users to enter most dates.

--- a/_components/date-picker/date-picker.md
+++ b/_components/date-picker/date-picker.md
@@ -2,7 +2,7 @@
 category: Components
 component:
   status: ready
-  package: usa-form-controls
+  package: form-controls
   dependencies:
 implementation:
   initProps:

--- a/_components/date-range-picker/date-range-picker.md
+++ b/_components/date-range-picker/date-range-picker.md
@@ -1,7 +1,7 @@
 ---
 component:
   status: ready
-  package: usa-form-controls
+  package: form-controls
   dependencies:
 category: Components
 implementation:

--- a/_components/file-input/file-input.md
+++ b/_components/file-input/file-input.md
@@ -2,7 +2,7 @@
 category: Components
 component:
   status: ready
-  package: usa-form-controls
+  package: form-controls
   dependencies:
 lead: File input allows users to attach one or multiple files.
 permalink: /components/file-input/

--- a/_components/input-prefix-suffix/input-prefix-suffix.md
+++ b/_components/input-prefix-suffix/input-prefix-suffix.md
@@ -3,7 +3,7 @@ category: Components
 component:
   name: input-prefix-suffix
   status: ready
-  package: usa-form-controls
+  package: form-controls
   dependencies:
 lead: Use input prefixes and suffixes to show symbols or abbreviations that help users enter the right type of information in a form’s text input.
 permalink: /components/input-prefix-suffix/

--- a/_components/radio-buttons/radio-buttons.md
+++ b/_components/radio-buttons/radio-buttons.md
@@ -2,7 +2,7 @@
 category: Components
 component:
   status: ready
-  package: usa-form-controls
+  package: form-controls
   dependencies:
 lead: Radio buttons allow users to select exactly one choice from a group.
 permalink: /components/radio-buttons/

--- a/_components/text-input/text-input.md
+++ b/_components/text-input/text-input.md
@@ -2,7 +2,7 @@
 category: Components
 component:
   status: ready
-  package: usa-form-controls
+  package: form-controls
   dependencies:
 permalink: /components/text-input/
 redirect_from:


### PR DESCRIPTION
## Description

Resolves #1468 

Switches all `@include usa-form-controls` to `@include form-controls`. This affects the following component pages:

- Combo-box
- Date-input
- Date-picker
- Date-range-picker
- file-input
- Input-prefix-suffix
- Radio-buttons
- Text-input


## Additional information

**Before**
![image](https://user-images.githubusercontent.com/25211650/161128416-33bdea5e-7349-47fb-8bdd-928f6f47e9da.png)

**After**
![image](https://user-images.githubusercontent.com/25211650/161128511-9a450251-526a-490d-8254-74d2b1d694b0.png)


Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
