### PR TITLE
Load components from the proper Fractal source

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  ffi (~> 1.15)
   html-proofer
   jekyll (>= 4.2.0)
   jekyll-include-cache
@@ -117,5 +116,4 @@ DEPENDENCIES
   webrick (~> 1.7)
 
 BUNDLED WITH
-   2.3.8
-   
+   2.3.9

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 title: U.S. Web Design System (USWDS)
 description: USWDS makes it easier to build accessible, mobile-friendly government websites.
 google_analytics_ua: UA-48605964-43
-uswds_version: 2.13.1
+uswds_version: 2.13.2
 uswds_email: uswds@gsa.gov
 federalist_base: "https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds"
 federalist_component_preview: "components/preview"

--- a/_plugins/fractal_component.rb
+++ b/_plugins/fractal_component.rb
@@ -8,7 +8,7 @@ module Jekyll
       super
       @name = name.strip
       @base_url = ENV[BASE_URL_ENV_VAR]
-      @fs_path = "node_modules/uswds/build/components/render/#{@name}.html"
+      @fs_path = "node_modules/uswds/_site/components/render/#{@name}.html"
     end
 
     def get_from_server()

--- a/config/gulp/build.js
+++ b/config/gulp/build.js
@@ -64,7 +64,7 @@ function spawnP(cmd, args, opts) {
 gulp.task('build-uswds-if-needed', function () {
   const rootDir = path.normalize(path.join(__dirname, '..', '..'));
   const uswdsDir = path.join(rootDir, 'node_modules', 'uswds');
-  const fractalIndex = path.join(uswdsDir, 'build', 'index.html');
+  const fractalIndex = path.join(uswdsDir, '_site', 'index.html');
   const gulpfile = path.join(uswdsDir, 'gulpfile.js');
 
   if (fs.existsSync(fractalIndex)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "stylelint-config-recommended-scss": "^4.3.0",
         "stylelint-prettier": "^1.2.0",
         "stylelint-scss": "^3.21.0",
-        "uswds": "^2.13.1",
+        "uswds": "^2.13.2",
         "vinyl-buffer": "^1.0.1",
         "vinyl-source-stream": "^2.0.0",
         "yamljs": "^0.3.0"
@@ -3621,9 +3621,9 @@
       }
     },
     "node_modules/classlist-polyfill": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
-      "integrity": "sha1-k1vC39lFiodrJ5YXUUY4vKqWSi4=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.0.3.tgz",
+      "integrity": "sha1-fNWpIHyNaTL1kv3qprRTUu1xaQ0=",
       "dev": true
     },
     "node_modules/clean-stack": {
@@ -16154,9 +16154,9 @@
       }
     },
     "node_modules/uswds": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/uswds/-/uswds-2.13.1.tgz",
-      "integrity": "sha512-tl4bSB+0ejZw90gwqsbO5XA+1b9nnGdbvVhY4ARGKoTIJ7M8/vpUBoz+Tm327ATZI2LUWmoced5V986muq1Iew==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/uswds/-/uswds-2.13.2.tgz",
+      "integrity": "sha512-dhHH2SgFfZFQz7OckCig5oa/4AO0eYKWZM0pRLZUovbU5zwy1USsnjZkPhlVw9eKL6OG87mc1wuhj5Jbw28uvw==",
       "dev": true,
       "dependencies": {
         "classlist-polyfill": "^1.0.3",
@@ -19588,9 +19588,9 @@
       }
     },
     "classlist-polyfill": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
-      "integrity": "sha1-k1vC39lFiodrJ5YXUUY4vKqWSi4=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.0.3.tgz",
+      "integrity": "sha1-fNWpIHyNaTL1kv3qprRTUu1xaQ0=",
       "dev": true
     },
     "clean-stack": {
@@ -29522,9 +29522,9 @@
       "dev": true
     },
     "uswds": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/uswds/-/uswds-2.13.1.tgz",
-      "integrity": "sha512-tl4bSB+0ejZw90gwqsbO5XA+1b9nnGdbvVhY4ARGKoTIJ7M8/vpUBoz+Tm327ATZI2LUWmoced5V986muq1Iew==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/uswds/-/uswds-2.13.2.tgz",
+      "integrity": "sha512-dhHH2SgFfZFQz7OckCig5oa/4AO0eYKWZM0pRLZUovbU5zwy1USsnjZkPhlVw9eKL6OG87mc1wuhj5Jbw28uvw==",
       "dev": true,
       "requires": {
         "classlist-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "stylelint-config-recommended-scss": "^4.3.0",
     "stylelint-prettier": "^1.2.0",
     "stylelint-scss": "^3.21.0",
-    "uswds": "^2.13.1",
+    "uswds": "^2.13.2",
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0",
     "yamljs": "^0.3.0"

--- a/pages/documentation/maturity-model.md
+++ b/pages/documentation/maturity-model.md
@@ -118,15 +118,15 @@ Government websites include components that aren’t included in USWDS yet. Use 
 
 #### 1: Add USWDS code and adjust settings.
 
-- Add USWDS to your project [with NPM]({{ site.baseurl }}/documentation/developers/#install-using-npm) or by [downloading the source from Github]({{ site.baseurl }}/documentation/developers/#download-and-install).
+- Add USWDS to your project [with NPM]({{ site.baseurl }}/documentation/developers/#install-using-npm) or by [downloading the source from Github]({{ site.baseurl }}/documentation/developers/#download-and-install-without-npm).
 - Compile the Sass source code using the [guidelines in the documentation]({{ site.baseurl }}/documentation/developers/#sass-compilation-requirements) or by using [uswds-compile](https://github.com/uswds/uswds-compile) available via GitHub.
-- Compile the Javascript source code using the [guidelines in the documentation]({{ site.baseurl }}/documentation/developers/#js-customization) or [download a precompiled version]({{ site.baseurl }}/documentation/developers/#download-and-install).
+- Compile the Javascript source code using the [guidelines in the documentation]({{ site.baseurl }}/documentation/developers/#js-customization) or [download a precompiled version]({{ site.baseurl }}/documentation/developers/#download-and-install-without-npm).
 - Add USWDS Javascript to your page templates.
 - Add USWDS CSS to your page templates.
 
 #### 2: Use USWDS design tokens in all stylesheets.
 
-- Install USWDS source Sass files using [the instructions]({{ site.baseurl }}/documentation/developers/#download-and-install) on the USWDS website.
+- Install USWDS source Sass files using [the instructions]({{ site.baseurl }}/documentation/developers/#download-and-install-without-npm) on the USWDS website.
 - Include USWDS Sass before including existing project source files. See [Sass an theme settings]({{ site.baseurl }}/documentation/developers/#sass-and-theme-settings).
 - Convert existing values to tokenized values. Use [the conversion tables](/documentation/migration/#integrating-tokens) to convert existing values to USWDS tokens.
 - Use USWDS [tokens]({{ site.baseurl }}/design-tokens/), functions (see [font-family functions]({{ site.baseurl }}/design-tokens/typesetting/font-family/#using-family-tokens), for example), and utility mixins (see [font-family utility mixins]({{ site.baseurl }}/design-tokens/typesetting/font-family/#using-family-tokens), for example) in existing component code.

--- a/pages/documentation/maturity-model.md
+++ b/pages/documentation/maturity-model.md
@@ -118,15 +118,15 @@ Government websites include components that aren’t included in USWDS yet. Use 
 
 #### 1: Add USWDS code and adjust settings.
 
-- Add USWDS to your project [with NPM]({{ site.baseurl }}/documentation/developers/#install-using-npm) or by [downloading the source from Github]({{ site.baseurl }}/documentation/developers/#download-and-install-without-npm).
+- Add USWDS to your project [with NPM]({{ site.baseurl }}/documentation/developers/#install-using-npm) or by [downloading the source from Github]({{ site.baseurl }}/documentation/developers/#download-and-install).
 - Compile the Sass source code using the [guidelines in the documentation]({{ site.baseurl }}/documentation/developers/#sass-compilation-requirements) or by using [uswds-compile](https://github.com/uswds/uswds-compile) available via GitHub.
-- Compile the Javascript source code using the [guidelines in the documentation]({{ site.baseurl }}/documentation/developers/#js-customization) or [download a precompiled version]({{ site.baseurl }}/documentation/developers/#download-and-install-without-npm).
+- Compile the Javascript source code using the [guidelines in the documentation]({{ site.baseurl }}/documentation/developers/#js-customization) or [download a precompiled version]({{ site.baseurl }}/documentation/developers/#download-and-install).
 - Add USWDS Javascript to your page templates.
 - Add USWDS CSS to your page templates.
 
 #### 2: Use USWDS design tokens in all stylesheets.
 
-- Install USWDS source Sass files using [the instructions]({{ site.baseurl }}/documentation/developers/#download-and-install-without-npm) on the USWDS website.
+- Install USWDS source Sass files using [the instructions]({{ site.baseurl }}/documentation/developers/#download-and-install) on the USWDS website.
 - Include USWDS Sass before including existing project source files. See [Sass an theme settings]({{ site.baseurl }}/documentation/developers/#sass-and-theme-settings).
 - Convert existing values to tokenized values. Use [the conversion tables](/documentation/migration/#integrating-tokens) to convert existing values to USWDS tokens.
 - Use USWDS [tokens]({{ site.baseurl }}/design-tokens/), functions (see [font-family functions]({{ site.baseurl }}/design-tokens/typesetting/font-family/#using-family-tokens), for example), and utility mixins (see [font-family utility mixins]({{ site.baseurl }}/design-tokens/typesetting/font-family/#using-family-tokens), for example) in existing component code.


### PR DESCRIPTION
We updated USWDS Fractal to render to the `/_site` directory instead of `/build`. This PR updates the build and component scripts to use the new directory.