### PR TITLE
Use uswds@develop branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "stylelint-config-recommended-scss": "^4.3.0",
         "stylelint-prettier": "^1.2.0",
         "stylelint-scss": "^3.21.0",
-        "uswds": "2.13.3",
+        "uswds": "github:uswds/uswds#develop",
         "vinyl-buffer": "^1.0.1",
         "vinyl-source-stream": "^2.0.0",
         "yamljs": "^0.3.0"
@@ -16155,9 +16155,9 @@
     },
     "node_modules/uswds": {
       "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/uswds/-/uswds-2.13.3.tgz",
-      "integrity": "sha512-qCblljeaRvS3+PrSxoHqQwmMnp746+Y1YZA34BkTzJknvo2bhhdzGE21yJaInumzIqV3glLD13TFdRwrwikMMQ==",
+      "resolved": "git+ssh://git@github.com/uswds/uswds.git#8f981344ca80c23a1db7c6a72a646692ce5dcfa3",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "classlist-polyfill": "1.0.3",
         "domready": "1.0.8",
@@ -29522,10 +29522,9 @@
       "dev": true
     },
     "uswds": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/uswds/-/uswds-2.13.3.tgz",
-      "integrity": "sha512-qCblljeaRvS3+PrSxoHqQwmMnp746+Y1YZA34BkTzJknvo2bhhdzGE21yJaInumzIqV3glLD13TFdRwrwikMMQ==",
+      "version": "git+ssh://git@github.com/uswds/uswds.git#8f981344ca80c23a1db7c6a72a646692ce5dcfa3",
       "dev": true,
+      "from": "uswds@uswds/uswds#develop",
       "requires": {
         "classlist-polyfill": "1.0.3",
         "domready": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "stylelint-config-recommended-scss": "^4.3.0",
     "stylelint-prettier": "^1.2.0",
     "stylelint-scss": "^3.21.0",
-    "uswds": "2.13.3",
+    "uswds": "github:uswds/uswds#develop",
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0",
     "yamljs": "^0.3.0"


### PR DESCRIPTION
Build from develop branch to incorporate new USWDS features. Specifically, this allows us to access the explicit `@frctl/mandelbrot` dependency that's causing our circle builds to fail.