### PR TITLE
V3 - update uswds_version in header button

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 title: U.S. Web Design System (USWDS)
 description: USWDS makes it easier to build accessible, mobile-friendly government websites.
 google_analytics_ua: UA-48605964-43
-uswds_version: 2.13.3
+uswds_version: 3.0
 uswds_email: uswds@gsa.gov
 federalist_base: "https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds"
 federalist_component_preview: "iframe.html?id="


### PR DESCRIPTION
## Description
Update the site uswds_version to 3.0. 

This update will be reflected in the header download button as well as in Phase 1 of `Getting started for developers` guide.

:warning: We will need to confirm that the download button works once USWDS 3.0 is released :warning: 

[Preview link ](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/al-v3-header-button/) 

Closes https://github.com/uswds/uswds-site/issues/1524
