### PR TITLE
USWDS-Site: Update OMB Memo M-17-06 links

### DIFF
--- a/_components/link/guidance/additional-information.md
+++ b/_components/link/guidance/additional-information.md
@@ -1,2 +1,2 @@
-- [OMB M-17-06: Policies for Federal Agency Public Websites and Digital Services [PDF, 18 pages]](https://www.whitehouse.gov/sites/whitehouse.gov/files/omb/memoranda/2017/m-17-06.pdf)
+- [OMB M-17-06: Policies for Federal Agency Public Websites and Digital Services [PDF, 18 pages]](https://www.whitehouse.gov/wp-content/uploads/legacy_drupal_files/omb/memoranda/2017/m-17-06.pdf)
 - [OMB M-10-23: Guidance for Agency Use of Third-Party Websites and Applications [PDF, 9 pages]](https://obamawhitehouse.archives.gov/sites/default/files/omb/assets/memoranda_2010/m10-23.pdf)

--- a/_components/link/guidance/usability-must.md
+++ b/_components/link/guidance/usability-must.md
@@ -1,5 +1,5 @@
-- **Clearly identify external links.** [OMB’s Policies for Federal Agency Public Websites and Digital Services [PDF, 1.2 MB]](https://www.whitehouse.gov/sites/whitehouse.gov/files/omb/memoranda/2017/m-17-06.pdf) states that agencies “must clearly identify external links from their websites" and that they "should choose the best approach to identify external links to users in a way that minimizes the impact on the usability of their websites and digital services.”
-- **Provide required notification for non-federal external links.** [OMB’s Policies for Federal Agency Public Websites and Digital Services [PDF, 1.2 MB]](https://www.whitehouse.gov/sites/whitehouse.gov/files/omb/memoranda/2017/m-17-06.pdf) states that you “must clearly state that the content of external links to non-federal agency websites is not endorsed by the federal government.”
+- **Clearly identify external links.** [OMB’s Policies for Federal Agency Public Websites and Digital Services [PDF, 1.2 MB]](https://www.whitehouse.gov/wp-content/uploads/legacy_drupal_files/omb/memoranda/2017/m-17-06.pdf) states that agencies “must clearly identify external links from their websites" and that they "should choose the best approach to identify external links to users in a way that minimizes the impact on the usability of their websites and digital services.”
+- **Provide required notification for non-federal external links.** [OMB’s Policies for Federal Agency Public Websites and Digital Services [PDF, 1.2 MB]](https://www.whitehouse.gov/wp-content/uploads/legacy_drupal_files/omb/memoranda/2017/m-17-06.pdf) states that you “must clearly state that the content of external links to non-federal agency websites is not endorsed by the federal government.”
 
     This requirement has two aspects:
 
@@ -29,6 +29,6 @@
           <li><span class="text-highlight">Agency websites must clearly state that the content of external links to non-Federal Agency websites is not endorsed by the Federal Government and is not subject to Federal information quality, privacy, security, and related guidelines.</span></li>
           <li><span class="text-highlight">Agencies should choose the best approach to identify external links to users in a way that minimizes the impact on the usability of their websites and digital services.</span></li>
         </ol>
-        <a class="src" href="https://www.whitehouse.gov/sites/whitehouse.gov/files/omb/memoranda/2017/m-17-06.pdf" title="View ">View the full text of M-17-06 [PDF, 1.2 MB]</a>
+        <a class="src" href="https://www.whitehouse.gov/wp-content/uploads/legacy_drupal_files/omb/memoranda/2017/m-17-06.pdf" title="View ">View the full text of M-17-06 [PDF, 1.2 MB]</a>
       </div>
     </div>


### PR DESCRIPTION
<!-- Please feel free to remove whatever sections/lines in this aren’t relevant.

Use the title line as the title of your pull request, then delete these lines. 

## Title line template: [Title]: Brief description

UI components: For pull requests that impact the look, feel, or functionality of USWDS itself, please open a pull request on the web-design-standards repo (https://github.com/uswds/uswds-site). 

-->

## Description

Resolves #1513 

Links to OMB Memo M-17-06 were resulting in a 404 page. This was corrected by updating the anchors to the correct URL: [https://www.whitehouse.gov/wp-content/uploads/legacy_drupal_files/omb/memoranda/2017/m-17-06.pdf](https://www.whitehouse.gov/wp-content/uploads/legacy_drupal_files/omb/memoranda/2017/m-17-06.pdf)

I found four instances of the broken link, all of which were on the [link component page](https://designsystem.digital.gov/components/link/)

## Additional information

The old URL was `https://www.whitehouse.gov/sites/whitehouse.gov/files/omb/memoranda/2017/m-17-06.pdf`