### PR TITLE
Add Touchpoints key to site data

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ federalist_component_preview: "iframe.html?id="
 federalist_release_prefix: "release-"
 meta:
   og:image: /img/uswds-logo/lg-black.png
-
+touchpoints: false
 # this is for pages that don't have a permalink (primarily posts)
 permalink: /whats-new/updates/:year/:month/:day/:title/
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,4 @@
-{% if page.touchpoints_survey | default: false %}
+{% if site.touchpoints and page.touchpoints_survey | default: false %}
   {% include touchpoint-survey-script.html %}
 {% endif %}
 


### PR DESCRIPTION
This PR adds a `touchpoints` key to `_config.yml` that controls whether touchpoints js will be output on the site. I've set it to `false`. Perhaps later this might be connected to an environment variable, and values in `_config.yml` may be set by Federalist for specific branches. 

But, for now, this functionally disables touchpoints until we can troubleshoot what's causing problems between it and out pa11y tests.