### PR TITLE
USWDS-site: Repair prettier command

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "pa11y-ci:sitemap": "pa11y-ci --sitemap http://localhost:4000/sitemap.xml --sitemap-exclude '/*.pdf|next/'",
     "pa11y-ci:sitemap-mobile": "pa11y-ci --config .pa11yci--mobile --sitemap http://localhost:4000/sitemap.xml --sitemap-exclude '/*.pdf|next/'",
     "pa11y-ci:sitemap-json": "pa11y-ci --json > pa11y-results.json --sitemap http://localhost:4000/sitemap.xml --sitemap-exclude '/*.pdf|next/'",
-    "prettier:scss": "npx prettier --write ./css/**/*.scss"
+    "prettier:scss": "npx prettier --write './css/**/*.scss'"
   },
   "devDependencies": {
     "@babel/core": "^7.15.8",


### PR DESCRIPTION
<!-- Please feel free to remove whatever sections/lines in this aren’t relevant.

Use the title line as the title of your pull request, then delete these lines. 

## Title line template: [Title]: Brief description

UI components: For pull requests that impact the look, feel, or functionality of USWDS itself, please open a pull request on the web-design-standards repo (https://github.com/uswds/uswds-site). 

-->

## Description
The command `npm run prettier:scss` is returning different results than its paired npx command `npx prettier --write ./css/**/*.scss`. 

Running the command via `npm` causes it to only look at directories exactly one level deep inside `/css` while running it via `npx` brings results from multiple levels. See screenshot for differences:

![image](https://user-images.githubusercontent.com/93996430/165317963-b477c47c-0bab-4f9a-bd67-a9826dfd0931.png)

## Solution
Wrapping the path in single quotes returns intended results.
![image](https://user-images.githubusercontent.com/93996430/165317261-ddb9ec5c-ce1e-4685-b9b2-544f007866d4.png)
