### PR TITLE
Remove snyk protect from develop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "prettier": "^2.4.1",
         "sass": "^1.43.4",
         "simplecrawler": "^1.1.8",
-        "snyk": "^1.811.0",
+        "snyk": "^1.913.0",
         "stylelint": "^13.13.1",
         "stylelint-config-prettier": "^9.0.2",
         "stylelint-config-recommended-scss": "^4.3.0",
@@ -14563,9 +14563,9 @@
       }
     },
     "node_modules/snyk": {
-      "version": "1.906.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.906.0.tgz",
-      "integrity": "sha512-BqHGSWBVx7LuiM9BuPE2zXRCQyAN7wJch4IEm0LFibZcLaoJ+4QWcn6X2ZynRzMCX7UJOntQUQj3q7lTmSaiug==",
+      "version": "1.913.0",
+      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.913.0.tgz",
+      "integrity": "sha512-CtmoL99ZQBmTJnexeE8NqtBz3IxXzny1000S0z78s0/Il+ox4wRU+BGFwvG37ObTJzF7iwwizcFtZITuOU9vPA==",
       "dev": true,
       "bin": {
         "snyk": "bin/snyk"
@@ -28802,9 +28802,9 @@
       }
     },
     "snyk": {
-      "version": "1.906.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.906.0.tgz",
-      "integrity": "sha512-BqHGSWBVx7LuiM9BuPE2zXRCQyAN7wJch4IEm0LFibZcLaoJ+4QWcn6X2ZynRzMCX7UJOntQUQj3q7lTmSaiug==",
+      "version": "1.913.0",
+      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.913.0.tgz",
+      "integrity": "sha512-CtmoL99ZQBmTJnexeE8NqtBz3IxXzny1000S0z78s0/Il+ox4wRU+BGFwvG37ObTJzF7iwwizcFtZITuOU9vPA==",
       "dev": true
     },
     "source-map": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "prettier": "^2.4.1",
     "sass": "^1.43.4",
     "simplecrawler": "^1.1.8",
-    "snyk": "^1.811.0",
+    "snyk": "^1.913.0",
     "stylelint": "^13.13.1",
     "stylelint-config-prettier": "^9.0.2",
     "stylelint-config-recommended-scss": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -62,8 +62,6 @@
     "test:full": "npm run startup && npm run test:detached && npm run test:stop",
     "test:stop": "pkill -f jekyll",
     "watch": "NODE_ENV=development nswatch",
-    "snyk-protect": "snyk protect",
-    "prepare": "npm run snyk-protect",
     "start-detached": "bundle exec jekyll serve --detach --host=localhost",
     "startup": "npm install && bundle install && npm run build-uswds && npm run build-all-assets",
     "pa11y-ci:sitemap": "pa11y-ci --sitemap http://localhost:4000/sitemap.xml --sitemap-exclude '/*.pdf|next/'",


### PR DESCRIPTION
## Description

Removes `snyk protect` from package.json. Updates to Snyk have caused this warning to popup:

```bash
⚠ WARNING: Snyk protect was removed at 31 March 2022.
Please use '@snyk/protect' package instead: https://updates.snyk.io/snyk-wizard-and-snyk-protect-removal-224137 
```

Work was done in snyk and github settings to get the same functionality using the new standard.

## Additional information

The `snyk wizard` command is also deprecated and we'll now need to use `snyk ignore`. See documentation [here →](https://docs.snyk.io/snyk-cli/fix-vulnerabilities-from-the-cli/ignore-vulnerabilities-using-snyk-cli)

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [ ] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
