### PR TITLE
Add note about organization scope and installing

### DIFF
--- a/_posts/2022-04-28-introducing-uswds-3-0.md
+++ b/_posts/2022-04-28-introducing-uswds-3-0.md
@@ -23,6 +23,9 @@ If you have any questions or feedback let us know at the [USWDS Public Slack](ht
 
 If you aren't a member of the USWDS Public Slack, [sign up here](https://chat.18f.gov/) by "Joining a TTS Chat Room" — then select "U.S. Web Design System" as your chat topic.
 
+{:.site-note}
+Starting in USWDS 3.0, we're publishing our npm package to an `@uswds` organization scope. So now, when installing USWDS, use `npm install @uswds/uswds --save`.
+
 ## What's new in USWDS 3.0?
 USWDS 3.0 takes a modular, component-centered approach to the design system. We've rebuilt our codebase with a component focus so teams can more effectively integrate the design system incrementally and use only the USWDS components needed in their projects.
 


### PR DESCRIPTION
Adds a note to the intro about our new organization scope with an explicit instruction about how to install the new package

[Preview](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/dw-add-install-note/whats-new/updates/2022/04/28/introducing-uswds-3-0/) → 