### PR TITLE
Circleci: Create install, build, and test jobs for faster builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,15 +3,16 @@ version: 2.1
 orbs:
   snyk: snyk/snyk@1.1.2
 
-jobs:
-  build:
+executors:
+  my-executor:
     docker:
       - image: cimg/ruby:3.0.4-browsers
+
+jobs:
+  install_ruby_deps:
+    executor: my-executor
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - npm-cache-{{ checksum "package-lock.json" }}
       - restore_cache:
           keys:
             - gem-cache-{{ checksum "Gemfile.lock" }}
@@ -30,23 +31,107 @@ jobs:
           key: gem-cache-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
+      - persist_to_workspace:
+          root: ~/project
+          paths:
+            - "vendor/bundle"
+  install_node_deps:
+    executor: my-executor
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - npm-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Install node dependencies
           command: npm install
-      - run:
-          name: Build USWDS if needed
-          command: npm run build-uswds
       - save_cache:
           key: npm-cache-{{ checksum "package-lock.json" }}
           paths:
             - node_modules
+  build:
+    executor: my-executor
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/project
+      - restore_cache:
+          keys:
+            - npm-cache-{{ checksum "package-lock.json" }}
+      - restore_cache:
+          keys:
+            - gem-cache-{{ checksum "Gemfile.lock" }}
+            - gem-cache
+      - run:
+          name: Build USWDS if needed
+          command: npm run build-uswds
+      - run:
+          name: Build site assets
+          command: npm run build-all-assets
+      - persist_to_workspace:
+          root: ~/project
+          paths:
+            - "_site"
+            - "assets"
+            - "node_modules"
+  test_build:
+    executor: my-executor
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/project
+      - run:
+          name: Run rspec
+          command: |
+            bundle config set --local path '~/project/vendor/bundle'
+            bundle exec rspec
+      - run:
+          name: Run HTML proofer
+          command: npm run proof
       - snyk/scan:
           organization: uswds
+  test_a11y_desktop:
+    executor: my-executor
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/project
       - run:
-          name: Run test
-          command: npm run test:ci
+          name: Link bundler
+          command: |
+            bundle config set --local path '~/project/vendor/bundle'
+      - run:
+          name: Run pa11y-ci desktop
+          command: npm run start-detached && npm run pa11y-ci:sitemap
+  test_a11y_mobile:
+    executor: my-executor
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/project
+      - run:
+          name: Link bundler
+          command: |
+            bundle config set --local path '~/project/vendor/bundle'
+      - run:
+          name: Run pa11y-ci mobile
+          command: npm run start-detached && npm run pa11y-ci:sitemap-mobile
 
 workflows:
   circle-uswds-site:
     jobs:
-      - build
+      - install_ruby_deps
+      - install_node_deps
+      - build:
+          requires:
+            - install_ruby_deps
+            - install_node_deps
+      - test_build:
+          requires:
+            - build
+      - test_a11y_desktop:
+          requires:
+            - build
+      - test_a11y_mobile:
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,6 @@ jobs:
           command: npm run test:ci
 
 workflows:
-  version: 2
   circle-uswds-site:
     jobs:
       - build


### PR DESCRIPTION
## Description

This PR attempts to improve CircleCI builds to be faster and more reliable. 

⚠️We still need to update to pa11y 3 to avoid those jekyll page crashing issues that have been bothering us.

## Additional information

The previous `build` job is now split into 3 separate "phases". It uses the `persist_to_workspace` and `attach_workspace` features to re-use the same build per workflow.

1. **Install dependencies ⬇️**
   1. Install Ruby deps
   1. Install Node deps 
1. **Build the site 🏗️**
   1. Jekyll Build
   1. Build assets 
1. **Run tests 🧪**
   1. Run ruby unit tests & HTML proofer
   1. Test pa11y desktop
   3. Test pa11y mobile

This changes to workflow so the sub-steps can run at the same time, speeding up builds/rebuilds, and clarity on what exactly failed.

**Before**
![image](https://user-images.githubusercontent.com/3385219/167208816-f7268d07-c837-453d-af0c-dfc4072ffff5.png)


**After**
![image](https://user-images.githubusercontent.com/3385219/167208834-7828587d-0600-4cba-bb8e-a317fdabf01c.png)

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [ ] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
