### PR TITLE
USWDS-Site - Compile: Update settings example

### DIFF
--- a/pages/documentation/getting-started-developers/phase-two.md
+++ b/pages/documentation/getting-started-developers/phase-two.md
@@ -61,7 +61,6 @@ In plain language, this code says:
   @use "uswds-core" with (
     $theme-image-path: "../uswds/img",
     $theme-show-compile-warnings: true,
-    $theme-show-compile-warnings: false,
     $theme-banner-background-color: "ink",
     $theme-banner-link-color: "primary-light",
     $theme-banner-max-width: "none",

--- a/pages/documentation/getting-started-developers/phase-two.md
+++ b/pages/documentation/getting-started-developers/phase-two.md
@@ -58,14 +58,14 @@ In plain language, this code says:
 
   {:.site-terminal}
   ```scss
- @use "uswds-core" with (
-  $theme-image-path: "../uswds/img",
-  $theme-show-compile-warnings: true,
-  $theme-show-notifications: false,
-  $theme-banner-background-color: "ink",
-  $theme-banner-link-color: "primary-light",
-  $theme-banner-max-width: "none",
-)
+  @use "uswds-core" with (
+    $theme-image-path: "../uswds/img",
+    $theme-show-compile-warnings: true,
+    $theme-show-compile-warnings: false,
+    $theme-banner-background-color: "ink",
+    $theme-banner-link-color: "primary-light",
+    $theme-banner-max-width: "none",
+  )
   ```
 
 - **Create the foundation**: Build all USWDS styles from these settings.

--- a/pages/documentation/getting-started-developers/phase-two.md
+++ b/pages/documentation/getting-started-developers/phase-two.md
@@ -58,21 +58,14 @@ In plain language, this code says:
 
   {:.site-terminal}
   ```scss
-  @use "uswds-core" with (
-    $theme-image-path: "../uswds/img",
-    $theme-show-compile-warnings: false,
-    $theme-color-primary-lightest: "green-warm-10",
-    $theme-color-primary-lighter: "green-warm-20",
-    $theme-color-primary-light: "green-warm-30",
-    $theme-color-primary: "green-warm-50",
-    $theme-color-primary-vivid: "green-warm-50v",
-    $theme-color-primary-dark: "green-warm-60v",
-    $theme-color-primary-darker: "green-warm-70v",
-    $theme-color-primary-darkest: "green-warm-80",
-    $theme-banner-background-color: "ink",
-    $theme-banner-link-color: "primary-light",
-    $theme-banner-max-width: "none",
-  )
+ @use "uswds-core" with (
+  $theme-image-path: "../uswds/img",
+  $theme-show-compile-warnings: true,
+  $theme-show-notifications: false,
+  $theme-banner-background-color: "ink",
+  $theme-banner-link-color: "primary-light",
+  $theme-banner-max-width: "none",
+)
   ```
 
 - **Create the foundation**: Build all USWDS styles from these settings.


### PR DESCRIPTION
<!-- Please feel free to remove whatever sections/lines in this aren’t relevant.

Use the title line as the title of your pull request, then delete these lines. 

## Title line template: [Title]: Brief description

UI components: For pull requests that impact the look, feel, or functionality of USWDS itself, please open a pull request on the web-design-standards repo (https://github.com/uswds/uswds-site). 

-->

## Description
Closes https://github.com/uswds/uswds-site/issues/1590
Preview link: [Getting started for developers - Phase 2 ](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/al-compilation-settings/documentation/getting-started/developers/phase-two-compile/)

### Problem
From the related issue: "The settings file example in docs would generate a warning for insufficient contrast, if the warnings hadn't been disabled. Since it's typical for people getting started to copy/paste examples, it would be better to have an initial file that didn't disable warnings and had contrasting colors."

### Solution

Updated the example compile settings in Phase 2 of the Getting Started for Developers guide to include values that compile without warnings. 

### Testing
To test, open a sample project and use the current code sample from our docs but turn `$theme-show-compile-warnings` to `true`. Note the compile warnings. 

```scss
@use "uswds-core" with (
  $theme-image-path: "../uswds/img",
  $theme-show-compile-warnings: true,
  $theme-color-primary-lightest: "green-warm-10",
  $theme-color-primary-lighter: "green-warm-20",
  $theme-color-primary-light: "green-warm-30",
  $theme-color-primary: "green-warm-50",
  $theme-color-primary-vivid: "green-warm-50v",
  $theme-color-primary-dark: "green-warm-60v",
  $theme-color-primary-darker: "green-warm-70v",
  $theme-color-primary-darkest: "green-warm-80",
  $theme-banner-background-color: "ink",
  $theme-banner-link-color: "primary-light",
  $theme-banner-max-width: "none",
)
```

Then compile  using the updated code sample. You should receive no compile warnings or errors. 
```scss
@use "uswds-core" with (
  $theme-image-path: "../uswds/img",
  $theme-show-compile-warnings: true,
  $theme-show-compile-warnings: false,
  $theme-banner-background-color: "ink",
  $theme-banner-link-color: "primary-light",
  $theme-banner-max-width: "none",
)
```

## Additional information

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
