### PR TITLE
USWDS-Site: Button: add instructions for type attribute

### DIFF
--- a/_components/button/guidance/implementation.md
+++ b/_components/button/guidance/implementation.md
@@ -1,3 +1,4 @@
 - The component preview and component code demonstrate how to use button elements. To use a button style on a link, add the `usa-button` class to your link.
 - To use a different style button on your link, add button variant classes in addition to `usa-button`.
 - Use the browser-native `disabled` attribute for any disabled button. Don't use `usa-button--disabled`, which is intended only for debugging and prototyping.
+- Always set the `type` attribute to define the purpose of the button. The type attribute can accept three values: `submit`, `button`, and `reset`. If no type attribute is defined, the button will behave as a `submit` button.


### PR DESCRIPTION
<!-- Please feel free to remove whatever sections/lines in this aren’t relevant.

Use the title line as the title of your pull request, then delete these lines. 

## Title line template: [Title]: Brief description

UI components: For pull requests that impact the look, feel, or functionality of USWDS itself, please open a pull request on the web-design-standards repo (https://github.com/uswds/uswds-site). 

-->

## Description
Closes https://github.com/uswds/uswds-site/issues/1609

Update button component page to include guidance on button `type` attribute.

This is part of the resolution of issue https://github.com/uswds/uswds/issues/3563. Related PR: https://github.com/uswds/uswds/pull/4695

Preview link: [Button component page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/al-button-type/components/button/#using-the-button-component)

## Additional information
Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
