### PR TITLE
Fix possible typo in packages.yml

### DIFF
--- a/_data/packages.yml
+++ b/_data/packages.yml
@@ -278,7 +278,7 @@
   dependencies:
     - "uswds-fonts"
     - "usa-fieldset"
-    - "usa-legent"
+    - "usa-legend"
 - name: "usa-range"
   fullSize: 8
   sourceSize: 2


### PR DESCRIPTION
<!-- Please feel free to remove whatever sections/lines in this aren’t relevant.

Use the title line as the title of your pull request, then delete these lines. 

## Title line template: Fix typo in packages.yml

-->

## Description

I noticed a dependency for usa-radio was "usa-legent".  Its possible it should be "usa-legend"

<img width="1223" alt="image" src="https://user-images.githubusercontent.com/6232068/171664884-baa96cba-7f8c-443a-a25c-fcf6407db304.png">
