### PR TITLE
Add note about initialization and theme files

### DIFF
--- a/pages/documentation/getting-started-developers/phase-two.md
+++ b/pages/documentation/getting-started-developers/phase-two.md
@@ -169,6 +169,10 @@ Function | Description
 For any function you defined as an `export` in your `gulpfile.js`, you can run `npx gulp [function]`.
 
 ## Step 5: Initialize your project
+
+{:.site-note}
+**Note:** Initialize with caution. The initialization task copies default settings and theme files, so if you've made any customizations to your local theme, `init` will overwrite them.
+
 Initialize your project to copy all the necessary image, font, and Javascript assets from the source code.
 
 Initialize your project and get started by running the following command:

--- a/pages/documentation/getting-started-developers/phase-two.md
+++ b/pages/documentation/getting-started-developers/phase-two.md
@@ -171,7 +171,7 @@ For any function you defined as an `export` in your `gulpfile.js`, you can run `
 ## Step 5: Initialize your project
 
 {:.site-note}
-**Note:** Initialize with caution. The initialization task copies default settings and theme files, so if you've made any customizations to your local theme, `init` will overwrite them.
+**Note:** Initialize with caution. The initialization task copies default settings and theme files, so if you've made any customizations to your local theme, `init` will overwrite them. You should only need to run `npx gulp init` once.
 
 Initialize your project to copy all the necessary image, font, and Javascript assets from the source code.
 


### PR DESCRIPTION
This PR adds a note to the `Getting started for developers` guide to be more clear that initialization risks overwriting existing theme files.

This relates to similar usage tips we're adding to the USWDS Compile docs: https://github.com/uswds/uswds-compile/pull/33

Fixes #1616 