### PR TITLE
Use USWDS 3.0.2 and update refs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 title: U.S. Web Design System (USWDS)
 description: USWDS makes it easier to build accessible, mobile-friendly government websites.
 google_analytics_ua: UA-48605964-43
-uswds_version: 3.0.1
+uswds_version: 3.0.2
 uswds_email: uswds@gsa.gov
 federalist_base: "https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds"
 federalist_component_preview: "iframe.html?id="
@@ -47,7 +47,7 @@ jekyll_get:
     json: "https://api.github.com/repos/uswds/uswds/contents/SECURITY.md"
     decode_content: true
   - data: hash
-    json: "https://api.github.com/repos/uswds/uswds/contents/security/uswds-3.0.1-zip-hash.txt?ref=main"
+    json: "https://api.github.com/repos/uswds/uswds/contents/security/uswds-3.0.2-zip-hash.txt?ref=main"
     decode_content: true
 
 repos:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@uswds/compile": "^1.0.0-beta.3",
-        "@uswds/uswds": "3.0.1"
+        "@uswds/uswds": "3.0.2"
       },
       "devDependencies": {
         "@18f/identity-stylelint-config": "^1.0.0",
@@ -489,9 +489,9 @@
       }
     },
     "node_modules/@uswds/uswds": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.0.1.tgz",
-      "integrity": "sha512-O2WHvWjKJwy10UJV9srimCBFMHenvnWDtP3LelMpTCV2AxgO1j/zYPn2SWpK116X/SuiIZk9hycbBroJQ6eH4w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.0.2.tgz",
+      "integrity": "sha512-I3as7QlcCN9hOya9P8mB/Z3HKZOOueT45fDmJ2r+LnkmhxCAkTLSsqmiFsXTcHNcbcllQSbGtpYsBf0/nOYlWw==",
       "dependencies": {
         "classlist-polyfill": "1.0.3",
         "domready": "1.0.8",
@@ -12633,9 +12633,9 @@
       }
     },
     "@uswds/uswds": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.0.1.tgz",
-      "integrity": "sha512-O2WHvWjKJwy10UJV9srimCBFMHenvnWDtP3LelMpTCV2AxgO1j/zYPn2SWpK116X/SuiIZk9hycbBroJQ6eH4w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.0.2.tgz",
+      "integrity": "sha512-I3as7QlcCN9hOya9P8mB/Z3HKZOOueT45fDmJ2r+LnkmhxCAkTLSsqmiFsXTcHNcbcllQSbGtpYsBf0/nOYlWw==",
       "requires": {
         "classlist-polyfill": "1.0.3",
         "domready": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,6 @@
   "snyk": true,
   "dependencies": {
     "@uswds/compile": "^1.0.0-beta.3",
-    "@uswds/uswds": "3.0.1"
+    "@uswds/uswds": "3.0.2"
   }
 }


### PR DESCRIPTION
Use USWDS `3.0.2` and update references to `3.0.2`

[Preview](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/use-3.0.2/) → 