### PR TITLE
Update when-to-use for unclear text

### DIFF
--- a/_components/text-input/guidance/when-to-use.md
+++ b/_components/text-input/guidance/when-to-use.md
@@ -1,3 +1,3 @@
 - **Unpredictable or freeform responses.** If you can’t reasonably predict a user’s answer to a prompt and there might be wide variability in users’ answers.
-- **Input simplicity.** When using another type of input will make answering more difficult. For example, birthdays and other known dates are easier to type in than they are to select from a calendar picker.
+- **Input simplicity.** When using another type of input will make answering more difficult. For example, birthdays and other known dates are easier to type in than they are to select from a <a href="https://designsystem.digital.gov/components/date-picker/">date picker</a>.
 - **Pasted content.** When users want to be able to paste in a response.

--- a/_components/text-input/guidance/when-to-use.md
+++ b/_components/text-input/guidance/when-to-use.md
@@ -1,3 +1,3 @@
 - **Unpredictable or freeform responses.** If you can’t reasonably predict a user’s answer to a prompt and there might be wide variability in users’ answers.
-- **Input simplicity.** When using another type of input will make answering more difficult. For example, birthdays and other known dates are easier to type in than they are to select from a <a href="https://designsystem.digital.gov/components/date-picker/">date picker</a>.
+- **Input simplicity.** When using another type of input will make answering more difficult. For example, birthdays and other known dates are easier to type in than they are to select from a [date picker]({{ site.baseurl }}/components/date-picker).
 - **Pasted content.** When users want to be able to paste in a response.


### PR DESCRIPTION
-Response to a report that said the "calendar picker" was confusing wording, presumably since we typically use "date picker" language
-I updated the language from "calendar picker" to "date picker"
-I hyperlinked to the "date picker" page for further clarity

