### PR TITLE
USWDS-Site- accordion: Update multiselectable docs 

### DIFF
--- a/_components/accordion/guidance/implementation.md
+++ b/_components/accordion/guidance/implementation.md
@@ -1,2 +1,2 @@
-- **Multiselectable accordion groups.** Add the `aria-multiselectable="true"` attribute to any usa-accordion to create a multiselectable accordion group.
+- **Multiselectable accordion groups.** Add the `data-allow-multiple` attribute to any usa-accordion to create a multiselectable accordion group.
 - **Default an accordion button to open.** Add the `aria-expanded="true"` attribute to any `usa-accordion__button` to have that section open by default at page load.


### PR DESCRIPTION
## Summary
Update accordion documentation to use the correct multi-select attribute.

Our current accordion documentation tells users to add the `aria-multiselectable="true"` attribute to trigger a multi-select accordion group, but the attribute is actually `data-allow-multiple`. 

Correcting this will make sure that users are able to successfully trigger the multi-select variant, while also preventing accessibility errors. 

## Related issue
Closes https://github.com/uswds/uswds/issues/4865

## Preview link
Preview link: [Accordion component page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/al-accordion-multi/components/accordion/#using-the-accordion-)

## To confirm:
1. Open the [accordion twig file in USWDS](https://github.com/uswds/uswds/blob/develop/packages/usa-accordion/src/usa-accordion.twig#L1)
2. Confirm that our templates use `data-allow-multiple` instead of `aria-multiselectable="true"` (In fact, there is no reference to `aria-multiselectable` in the USWDS code base.)

---

Before opening this PR, make sure you’ve done whichever of these applies to you:

- [x] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [x] Run `npm test` and confirm that all tests pass.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.