### PR TITLE
Docs: add $theme-footer-max-width variable

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -811,6 +811,12 @@
       var: $theme-footer-font-family
       default: "'body'"
       kind: family
+    - name: Footer
+      subsection: Footer max width
+      usage: Maximum width of footer container.
+      var: $theme-footer-max-width
+      default: "'desktop'"
+      kind: units
 
     - name: Checkbox
       section: true

--- a/_data/settings/components/footer.yml
+++ b/_data/settings/components/footer.yml
@@ -5,3 +5,8 @@ contents:
     var: $theme-footer-font-family
     default: '"body"'
     type: family
+  - name: Max width
+    description: Maximum width of footer container.
+    var: $theme-footer-max-width
+    default: '"desktop"'
+    type: units


### PR DESCRIPTION
## Description

This PR adds $theme-footer-max-width to the documentation. Closes #1696.

## Additional information

Seen on pages

- [documentation/settings/#footer](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/jm-footer-docs/documentation/settings/#footer)
- [components/footer/#component-settings-footer](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/jm-footer-docs/components/footer/#component-settings-footer)


---

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
