### PR TITLE
USWDS - Site: Use USWDS 3.1.0

### DIFF
--- a/_components/accordion/guidance/accessibility.md
+++ b/_components/accordion/guidance/accessibility.md
@@ -1,4 +1,4 @@
-- **Code header areas in the accordion as buttons.** Using a `<button>` assures accordions are usable with both screen readers and keyboards.
+- **Code header areas in the accordion as buttons.** Using a `<button type="button">` assures accordions are usable with both screen readers and keyboards.
 - **Use `aria-expanded` on buttons to express an accordion’s default state.** Buttons should state if they are expanded by default with `aria-expanded="true"`. The `aria-expanded="false"` attribute will be added to other buttons when the accordion is initialized by the JavaScript.
 - **Use unique ids.** Each button has a unique name, `aria-controls="id"`, that associates the control with the appropriate region by referencing the controlled element’s `id`.
 - **Accordions use javascript to set the `hidden` values of their content areas.** Each content area will have its `hidden` attribute set by the component, depending on its corresponding button’s `aria-expanded` attribute. To ensure your content is accessible in the event that the JavaScript does not load or is disabled, you should not manually set `hidden` on any of your content areas.

--- a/_components/button-group/guidance/variants/segmented/accessibility.md
+++ b/_components/button-group/guidance/variants/segmented/accessibility.md
@@ -1,3 +1,3 @@
 - **Convey relationship.** If not using a list element, give the parent element `role="group"` in order to convey to screen readers that actions are part of a group. If using as part of a toolbar, use `role="toolbar"`.
 - **Use `aria-label` to give the buttons a useful name.** Some contexts may require additional context provided to screen readers.
-- **Use the `<button>` element.** Don't use `<a>` because it's a link. Don't use `<span>` because screen readers won't know it's a usable button.
+- **Use the `<button type="button">` element.** Don't use `<a>` because it's a link. Don't use `<span>` because screen readers won't know it's a usable button.

--- a/_components/link/guidance/usability-must.md
+++ b/_components/link/guidance/usability-must.md
@@ -10,7 +10,7 @@
 
     <div class="usa-accordion card-policy">
       <h3 class="usa-accordion__heading">
-      <button class="usa-accordion__button" title="View " aria-expanded="false" aria-controls="card-policy-6">
+      <button type="button" class="usa-accordion__button" title="View " aria-expanded="false" aria-controls="card-policy-6">
         <span class="scroll">
           <svg class="usa-icon square-4" aria-hidden="true" focusable="false" role="img"><use xlink:href="{{ site.baseurl }}/assets/img/sprite.svg#description"></use></svg>
         </span>

--- a/_components/modal/guidance/implementation.md
+++ b/_components/modal/guidance/implementation.md
@@ -1,7 +1,7 @@
 - **Use unique ids.** Each `.usa-modal` must have a unique id so that openers can associate them with their `aria-controls` attribute.
 
-- **Openers.** A single modal can have multiple openers. Each opener requires `data-open-modal` and `aria-controls=”MODAL_ID”` attributes. Openers can be coded either as `<button>` or `<a>`. Using `<a>` helps link to modals in the event javascript fails.
+- **Openers.** A single modal can have multiple openers. Each opener requires `data-open-modal` and `aria-controls=”MODAL_ID”` attributes. Openers can be coded either as `<button type="button">` or `<a>`. Using `<a>` helps link to modals in the event javascript fails.
 
-- **Closers.** Place a `data-close-modal` attribute on any button that will close a modal. Closers may have event listeners attached to them. Code closers as `<button>`.
+- **Closers.** Place a `data-close-modal` attribute on any button that will close a modal. Closers may have event listeners attached to them. Code closers as `<button type="button">`.
 
 - **Disabling close when an action is required.** In instances that a user must make a choice before continuing, you want to prevent them from closing the modal without taking action. Add `data-force-action` attribute to `.usa-modal` to prevent the user from closing the modal without taking an action.

--- a/_components/search/guidance/accessibility.md
+++ b/_components/search/guidance/accessibility.md
@@ -1,2 +1,2 @@
 - **Customize form controls accessibly.** If you customize this component, ensure that it continues to meet the [accessibility requirements that apply to all form controls]({{ site.baseurl }}/components/form).
-- **Include the word “Search” in the button.** Always include the word “search” inside the `<button>` element for screen readers. You can visually hide this text using the CSS class `usa-sr-only` or Sass mixin `@include sr-only`.
+- **Include the word “Search” in the button.** Always include the word “search” inside the `<button type="button">` element for screen readers. You can visually hide this text using the CSS class `usa-sr-only` or Sass mixin `@include sr-only`.

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 title: U.S. Web Design System (USWDS)
 description: USWDS makes it easier to build accessible, mobile-friendly government websites.
 google_analytics_ua: UA-48605964-43
-uswds_version: 3.0.2
+uswds_version: 3.1.0
 uswds_email: uswds@gsa.gov
 federalist_base: "https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds"
 federalist_component_preview: "iframe.html?id="
@@ -47,7 +47,7 @@ jekyll_get:
     json: "https://api.github.com/repos/uswds/uswds/contents/SECURITY.md"
     decode_content: true
   - data: hash
-    json: "https://api.github.com/repos/uswds/uswds/contents/security/uswds-3.0.2-zip-hash.txt?ref=main"
+    json: "https://api.github.com/repos/uswds/uswds/contents/security/uswds-3.1.0-zip-hash.txt?ref=main"
     decode_content: true
 
 repos:

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -9,8 +9,12 @@
           <p class="usa-banner__header-text">An official website of the United States government</p>
           <p class="usa-banner__header-action" aria-hidden="true">Here’s how you know</p>
         </div>
-        <button class="usa-accordion__button usa-banner__button"
-          aria-expanded="false" aria-controls="gov-banner">
+        <button
+          type="button"
+          class="usa-accordion__button usa-banner__button"
+          aria-expanded="false"
+          aria-controls="gov-banner"
+        >
           <span class="usa-banner__button-text">Here’s how you know</span>
         </button>
       </div>

--- a/_includes/code/accordion.html
+++ b/_includes/code/accordion.html
@@ -3,7 +3,7 @@
 <div class="usa-accordion usa-accordion--bordered site-accordion-code">
   {% assign _id = include.component | append: '-code' %}
   {% assign _content_id = include.component | append: '-code-content' %}
-  <button class="usa-accordion__button" aria-controls="{{ _content_id }}"><{{ level }} id="{{ _id }}">Component code</{{ level }}></button>
+  <button type="button" class="usa-accordion__button" aria-controls="{{ _content_id }}"><{{ level }} id="{{ _id }}">Component code</{{ level }}></button>
   <div id="{{ _content_id }}" class="usa-accordion__content">
     {% include code/syntax.html component=include.component %}
   </div>

--- a/_includes/code/preview.html
+++ b/_includes/code/preview.html
@@ -3,7 +3,7 @@
 <div class="usa-accordion usa-accordion--bordered site-accordion-code site-component-preview">
   {% assign _id = include.component | append: '-preview' %}
   {% assign _content_id = include.component | append: '-preview-content' %}
-  <button class="usa-accordion__button" aria-controls="{{ _content_id }}" aria-expanded="true"><{{ level }} id="{{ _id }}">Component preview</{{ level }}></button>
+  <button type="button" class="usa-accordion__button" aria-controls="{{ _content_id }}" aria-expanded="true"><{{ level }} id="{{ _id }}">Component preview</{{ level }}></button>
   <div id="{{ _content_id }}" class="usa-accordion__content">
 
     {% if include.image %}

--- a/_includes/nav/page-collapsible.html
+++ b/_includes/nav/page-collapsible.html
@@ -1,6 +1,6 @@
 {% assign _current = include.page.category | eq: page.category %}
 {% assign _id = include.page.title | slugify | prepend: 'nav-' %}
-<button class="usa-accordion__button usa-nav__link" aria-controls="{{ _id }}"
+<button type="button" class="usa-accordion__button usa-nav__link" aria-controls="{{ _id }}"
   {% if _current %}
   class="usa-current"
   aria-expanded="true"

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -10,7 +10,7 @@
         </a>
       </em>
     </div>
-    <button class="usa-menu-btn">Menu</button>
+    <button type="button" class="usa-menu-btn">Menu</button>
     <div class="navbar--container">
       <form
         id="search_form"
@@ -28,10 +28,10 @@
             name="query"
             type="search"
             autocomplete="off"/>
-          <button 
-            class="usa-button" 
+          <button
+            class="usa-button"
             type="submit"
-            name="commit">    
+            name="commit">
             <img src="{{ site.baseurl }}/assets/img/usa-icons-bg/search--white.svg" class="usa-search__submit-icon" alt="Search">
           </button>
         </div>
@@ -54,7 +54,7 @@
 <div class="usa-overlay"></div>
 
 <nav role="navigation" class="usa-nav site-nav sidenav-mobile">
-  <button class="usa-nav__close">
+  <button type="button" class="usa-nav__close">
     <img src="{{ site.baseurl }}/assets/img/usa-icons/close.svg" role="img" alt="Close">
   </button>
 

--- a/_utilities/clearfix.md
+++ b/_utilities/clearfix.md
@@ -38,7 +38,7 @@ utilities:
         <span class="float-right bg-secondary-light padding-2">.float-right</span>
       </div>
       <div class="usa-accordion usa-accordion--bordered site-accordion-code margin-top-4">
-        <button class="usa-accordion__button" aria-controls="code-clearfix" aria-expanded="true">Code</button>
+        <button type="button" class="usa-accordion__button" aria-controls="code-clearfix" aria-expanded="true">Code</button>
         <div id="code-clearfix" class="usa-accordion__content margin-bottom-1">
 <div markdown="1">
 {% highlight html linenos %}

--- a/_utilities/display.md
+++ b/_utilities/display.md
@@ -199,7 +199,7 @@ utilities:
         %}
       {% endfor %}
       <div class="usa-accordion usa-accordion--bordered site-accordion-code margin-top-4 margin-bottom-1">
-        <button class="usa-accordion__button" aria-controls="code-relative" aria-expanded="true">Code</button>
+        <button type="button" class="usa-accordion__button" aria-controls="code-relative" aria-expanded="true">Code</button>
         <div id="code-relative" class="usa-accordion__content">
 <div markdown="1" class="font-mono-xs">
 {% highlight html linenos %}
@@ -390,7 +390,7 @@ utilities:
         </div>
       </div>
       <div class="usa-accordion usa-accordion--bordered site-accordion-code margin-top-0">
-        <button class="usa-accordion__button" aria-controls="code-static-relative" aria-expanded="true">Code</button>
+        <button type="button" class="usa-accordion__button" aria-controls="code-static-relative" aria-expanded="true">Code</button>
         <div id="code-static-relative" class="usa-accordion__content">
 <div markdown="1">
 {% highlight html linenos %}
@@ -433,7 +433,7 @@ utilities:
         </div>
       </div>
       <div class="usa-accordion usa-accordion--bordered site-accordion-code margin-top-2">
-        <button class="usa-accordion__button" aria-controls="code-fixed" aria-expanded="true">Code</button>
+        <button type="button" class="usa-accordion__button" aria-controls="code-fixed" aria-expanded="true">Code</button>
         <div id="code-fixed" class="usa-accordion__content">
 <div markdown="1">
 {% highlight html linenos %}
@@ -475,7 +475,7 @@ utilities:
         </div>
       </div>
       <div class="usa-accordion usa-accordion--bordered site-accordion-code margin-top-2 margin-bottom-1">
-        <button class="usa-accordion__button" aria-controls="code-sticky" aria-expanded="true">Code</button>
+        <button type="button" class="usa-accordion__button" aria-controls="code-sticky" aria-expanded="true">Code</button>
         <div id="code-sticky" class="usa-accordion__content">
 <div markdown="1">
 {% highlight html linenos %}

--- a/_utilities/flex.md
+++ b/_utilities/flex.md
@@ -238,7 +238,7 @@ utilities:
       {% endfor %}
 
       <div class="usa-accordion usa-accordion--bordered site-accordion-code margin-top-4 margin-bottom-1">
-        <button class="usa-accordion__button" aria-controls="code-flex" aria-expanded="true">Code</button>
+        <button type="button" class="usa-accordion__button" aria-controls="code-flex" aria-expanded="true">Code</button>
         <div id="code-flex" class="usa-accordion__content">
 <div markdown="1" class="font-mono-xs">
 
@@ -342,7 +342,7 @@ utilities:
     {% endfor %}
 
     <div class="usa-accordion usa-accordion--bordered site-accordion-code margin-top-4 margin-bottom-1">
-      <button class="usa-accordion__button" aria-controls="code-flex-direction" aria-expanded="true">Code</button>
+      <button type="button" class="usa-accordion__button" aria-controls="code-flex-direction" aria-expanded="true">Code</button>
       <div id="code-flex-direction" class="usa-accordion__content">
 <div markdown="1" class="font-mono-xs">
 {% highlight html linenos %}
@@ -401,7 +401,7 @@ utilities:
     {% endfor %}
 
     <div class="usa-accordion usa-accordion--bordered site-accordion-code margin-top-4 margin-bottom-1">
-      <button class="usa-accordion__button" aria-controls="code-flex-wrap" aria-expanded="true">Code</button>
+      <button type="button" class="usa-accordion__button" aria-controls="code-flex-wrap" aria-expanded="true">Code</button>
       <div id="code-flex-wrap" class="usa-accordion__content">
 <div markdown="1" class="font-mono-xs">
 {% highlight html linenos %}
@@ -463,7 +463,7 @@ utilities:
     {% endfor %}
 
     <div class="usa-accordion usa-accordion--bordered site-accordion-code margin-top-4 margin-bottom-1">
-      <button class="usa-accordion__button" aria-controls="code-flex-align" aria-expanded="true">Code</button>
+      <button type="button" class="usa-accordion__button" aria-controls="code-flex-align" aria-expanded="true">Code</button>
       <div id="code-flex-align" class="usa-accordion__content">
 <div markdown="1" class="font-mono-xs">
 {% highlight html linenos %}
@@ -552,7 +552,7 @@ utilities:
         </div>
     {% endfor %}
     <div class="usa-accordion usa-accordion--bordered site-accordion-code margin-top-4 margin-bottom-1">
-      <button class="usa-accordion__button" aria-controls="code-flex-align" aria-expanded="true">Code</button>
+      <button type="button" class="usa-accordion__button" aria-controls="code-flex-align" aria-expanded="true">Code</button>
       <div id="code-flex-align-self" class="usa-accordion__content">
 <div markdown="1" class="font-mono-xs">
 {% highlight html linenos %}
@@ -614,7 +614,7 @@ utilities:
         </div>
 
     <div class="usa-accordion usa-accordion--bordered site-accordion-code margin-top-4 margin-bottom-1">
-      <button class="usa-accordion__button" aria-controls="code-flex-justify" aria-expanded="true">Code</button>
+      <button type="button" class="usa-accordion__button" aria-controls="code-flex-justify" aria-expanded="true">Code</button>
       <div id="code-flex-justify" class="usa-accordion__content">
 <div markdown="1" class="font-mono-xs">
 {% highlight html linenos %}
@@ -699,7 +699,7 @@ utilities:
     </div>
 
     <div class="usa-accordion usa-accordion--bordered site-accordion-code margin-top-4 margin-bottom-1">
-      <button class="usa-accordion__button" aria-controls="code-order" aria-expanded="true">Code</button>
+      <button type="button" class="usa-accordion__button" aria-controls="code-order" aria-expanded="true">Code</button>
       <div id="code-order" class="usa-accordion__content">
 <div markdown="1" class="font-mono-xs">
 {% highlight html linenos %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@uswds/compile": "^1.0.0-beta.3",
-        "@uswds/uswds": "github:uswds/uswds#develop"
+        "@uswds/uswds": "^3.1.0"
       },
       "devDependencies": {
         "@18f/identity-stylelint-config": "^1.0.0",
@@ -494,12 +494,9 @@
       }
     },
     "node_modules/@uswds/uswds": {
-      "version": "3.0.2",
-      "resolved": "git+ssh://git@github.com/uswds/uswds.git#60fa5d7de65ff72d0f68fb9431fe74e74fb222ea",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "workspaces": [
-        "packages/uswds-core"
-      ],
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.1.0.tgz",
+      "integrity": "sha512-6XTeaQD/ipc3x4713mud4Rrr+lRc4nJ1Qw5Oy35dbVEXuKr7DjN4EBoAkbze9OoV0UdmAIvoxolBF/UcpFVKOg==",
       "dependencies": {
         "classlist-polyfill": "1.0.3",
         "domready": "1.0.8",
@@ -14580,8 +14577,9 @@
       }
     },
     "@uswds/uswds": {
-      "version": "git+ssh://git@github.com/uswds/uswds.git#60fa5d7de65ff72d0f68fb9431fe74e74fb222ea",
-      "from": "@uswds/uswds@github:uswds/uswds#develop",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.1.0.tgz",
+      "integrity": "sha512-6XTeaQD/ipc3x4713mud4Rrr+lRc4nJ1Qw5Oy35dbVEXuKr7DjN4EBoAkbze9OoV0UdmAIvoxolBF/UcpFVKOg==",
       "requires": {
         "classlist-polyfill": "1.0.3",
         "domready": "1.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@uswds/compile": "^1.0.0-beta.3",
-        "@uswds/uswds": "3.0.2"
+        "@uswds/uswds": "github:uswds/uswds#develop"
       },
       "devDependencies": {
         "@18f/identity-stylelint-config": "^1.0.0",
@@ -495,8 +495,11 @@
     },
     "node_modules/@uswds/uswds": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.0.2.tgz",
-      "integrity": "sha512-I3as7QlcCN9hOya9P8mB/Z3HKZOOueT45fDmJ2r+LnkmhxCAkTLSsqmiFsXTcHNcbcllQSbGtpYsBf0/nOYlWw==",
+      "resolved": "git+ssh://git@github.com/uswds/uswds.git#7b3cb679fb79d0be2f0db82f22d7dd9802abc98f",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "workspaces": [
+        "packages/uswds-core"
+      ],
       "dependencies": {
         "classlist-polyfill": "1.0.3",
         "domready": "1.0.8",
@@ -14577,9 +14580,8 @@
       }
     },
     "@uswds/uswds": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.0.2.tgz",
-      "integrity": "sha512-I3as7QlcCN9hOya9P8mB/Z3HKZOOueT45fDmJ2r+LnkmhxCAkTLSsqmiFsXTcHNcbcllQSbGtpYsBf0/nOYlWw==",
+      "version": "git+ssh://git@github.com/uswds/uswds.git#7b3cb679fb79d0be2f0db82f22d7dd9802abc98f",
+      "from": "@uswds/uswds@github:uswds/uswds#develop",
       "requires": {
         "classlist-polyfill": "1.0.3",
         "domready": "1.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -495,7 +495,7 @@
     },
     "node_modules/@uswds/uswds": {
       "version": "3.0.2",
-      "resolved": "git+ssh://git@github.com/uswds/uswds.git#7b3cb679fb79d0be2f0db82f22d7dd9802abc98f",
+      "resolved": "git+ssh://git@github.com/uswds/uswds.git#60fa5d7de65ff72d0f68fb9431fe74e74fb222ea",
       "license": "SEE LICENSE IN LICENSE.md",
       "workspaces": [
         "packages/uswds-core"
@@ -14580,7 +14580,7 @@
       }
     },
     "@uswds/uswds": {
-      "version": "git+ssh://git@github.com/uswds/uswds.git#7b3cb679fb79d0be2f0db82f22d7dd9802abc98f",
+      "version": "git+ssh://git@github.com/uswds/uswds.git#60fa5d7de65ff72d0f68fb9431fe74e74fb222ea",
       "from": "@uswds/uswds@github:uswds/uswds#develop",
       "requires": {
         "classlist-polyfill": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,6 @@
   "snyk": true,
   "dependencies": {
     "@uswds/compile": "^1.0.0-beta.3",
-    "@uswds/uswds": "3.0.2"
+    "@uswds/uswds": "github:uswds/uswds#develop"
   }
 }

--- a/package.json
+++ b/package.json
@@ -97,6 +97,6 @@
   "snyk": true,
   "dependencies": {
     "@uswds/compile": "^1.0.0-beta.3",
-    "@uswds/uswds": "github:uswds/uswds#develop"
+    "@uswds/uswds": "^3.1.0"
   }
 }

--- a/pages/documentation/migration-V3.md
+++ b/pages/documentation/migration-V3.md
@@ -173,7 +173,7 @@ Add this load path to your compiler settings, or update any old paths if your co
 
 <!-- Start USWDS Gulp section -->
 <h4 class="usa-accordion__heading">
-  <button class="usa-accordion__button" aria-controls="m-a6">
+  <button type="button" class="usa-accordion__button" aria-controls="m-a6">
     If you're using USWDS Gulp
   </button>
 </h4>
@@ -249,7 +249,7 @@ includePaths: [
 
 <!-- Start USWDS Compile section -->
 <h4 class="usa-accordion__heading">
-  <button class="usa-accordion__button" aria-controls="m-a7">
+  <button type="button" class="usa-accordion__button" aria-controls="m-a7">
     If you're using USWDS Compile
   </button>
 </h4>
@@ -271,7 +271,7 @@ const uswds = require("@uswds/compile");
 
 <!-- Start custom gulp workflow section -->
 <h4 class="usa-accordion__heading">
-  <button class="usa-accordion__button" aria-controls="m-a8">
+  <button type="button" class="usa-accordion__button" aria-controls="m-a8">
     If you're using a custom gulp workflow
   </button>
 </h4>
@@ -303,7 +303,7 @@ const uswds = require("@uswds/compile");
 
 <!-- Start custom gulp workflow section -->
 <h4 class="usa-accordion__heading">
-  <button class="usa-accordion__button" aria-controls="m-a9">
+  <button type="button" class="usa-accordion__button" aria-controls="m-a9">
     If you're using webpack
   </button>
 </h4>
@@ -342,6 +342,7 @@ Follow the instructions in each section that applies to either your USWDS versio
 <!-- Start All section -->
 <h4 class="usa-accordion__heading">
   <button
+    type="button"
     class="usa-accordion__button"
     aria-controls="m-all"
   >
@@ -365,6 +366,7 @@ We've removed the `$output-all-utilities` settings and replaced it with `$output
 <!-- Start 2.13.0 section -->
 <h4 class="usa-accordion__heading">
   <button
+    type="button"
     class="usa-accordion__button"
     aria-controls="m-a1"
   >
@@ -385,7 +387,7 @@ You'll need to update any instances of the small search button on your site. We'
 ###### Old code
 
 ```html
-<button class="usa-button" type="submit">
+<button type="button" class="usa-button" type="submit">
   <span class="usa-sr-only">Search</span>
 <button>
 ```
@@ -394,7 +396,7 @@ You'll need to update any instances of the small search button on your site. We'
 ###### New code
 
 ```html
-<button class="usa-button" type="submit">
+<button type="button" class="usa-button" type="submit">
   <img
     src="{% raw %}{{ uswds image path }}{% endraw %}/usa-icons-bg/search--white.svg"
     class="usa-search__submit-icon"
@@ -479,6 +481,7 @@ You'll need to update social media icons in the USWDS footer. We're now using ex
 <!-- Start 2.12.0 section -->
 <h4 class="usa-accordion__heading">
   <button
+    type="button"
     class="usa-accordion__button"
     aria-controls="m-a2"
   >
@@ -520,6 +523,7 @@ Setting | Old default | New default
 <!-- Start 2.11.2 section -->
 <h4 class="usa-accordion__heading">
   <button
+    type="button"
     class="usa-accordion__button"
     aria-controls="m-a3"
   >
@@ -549,6 +553,7 @@ We replaced the `thumb_down_off_alt` icon with `thumb_down_alt` in our default i
 <!-- Start 2.11.0 section -->
 <h4 class="usa-accordion__heading">
   <button
+    type="button"
     class="usa-accordion__button"
     aria-controls="m-a4"
   >
@@ -579,6 +584,7 @@ Setting | Old default | New default
 <!-- Start 2.10.1 section -->
 <h4 class="usa-accordion__heading">
   <button
+    type="button"
     class="usa-accordion__button"
     aria-controls="m-a5"
   >

--- a/pages/documentation/sample-contract-language.md
+++ b/pages/documentation/sample-contract-language.md
@@ -38,7 +38,9 @@ In new solicitations, you can include requirements for 21st Century IDEA in the 
 
 <div class="usa-accordion site-accordion usa-accordion--bordered measure-5">
   <h4 class="usa-accordion__heading">
-    <button class="usa-accordion__button font-lang-sm radius-top-md"
+    <button
+      type="button"
+      class="usa-accordion__button font-lang-sm radius-top-md"
       aria-expanded="true"
       aria-controls="example-1">
       Draft language for new solicitations
@@ -56,7 +58,9 @@ You can ask your CO to amend open solicitations to include requirements for 21st
 
 <div class="usa-accordion site-accordion usa-accordion--bordered measure-5">
   <h4 class="usa-accordion__heading font-lang-sm">
-    <button class="usa-accordion__button radius-top-md"
+    <button
+      type="button"
+      class="usa-accordion__button radius-top-md"
       aria-expanded="true"
       aria-controls="example-2">
       Draft language for open solicitations
@@ -77,7 +81,9 @@ You can use evaluation factors to select the best vendor by evaluating their abi
 
 <div class="usa-accordion site-accordion usa-accordion--bordered measure-5">
   <h3 class="usa-accordion__heading radius-top-md">
-    <button class="usa-accordion__button font-lang-sm"
+    <button
+      type="button"
+      class="usa-accordion__button font-lang-sm"
       aria-expanded="true"
       aria-controls="example-3">
       Draft 1: Modern website or digital service evaluation factor
@@ -133,7 +139,9 @@ You can use evaluation factors to select the best vendor by evaluating their abi
 
 <div class="usa-accordion site-accordion usa-accordion--bordered measure-5">
   <h3 class="usa-accordion__heading font-lang-sm">
-    <button class="usa-accordion__button radius-top-md line-height-sans-4"
+    <button
+      type="button"
+      class="usa-accordion__button radius-top-md line-height-sans-4"
       aria-expanded="true"
       aria-controls="example-4">
       Draft 2 (scenario): Modern website or digital service scenario evaluation factor


### PR DESCRIPTION
## Description

Updates USWDS to 3.1.0. Closes #1736.

[Preview link →](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/use-3.1.0/)

## Additional information

- Adds `type="button"` to non-submit buttons
  - Added attribute to guidance pages
  - Site banner
  - Site accordions

---

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [ ] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
