### PR TITLE
USWDS-Site: Instructions for migrating from USWDS 1.x

### DIFF
--- a/pages/documentation/migration-V3.md
+++ b/pages/documentation/migration-V3.md
@@ -25,7 +25,7 @@ subnav:
   href: '#6-optimize-your-installation'
 ---
 {: .site-note }
-**Note:** This guide provides instructions for upgrading from USWDS 2 to USWDS 3. If your project uses USWDS 1, you will need to update according to the [USWDS 2.0 migration guide]({{ site.baseurl }}/documentation/migration-v2) before proceeding with these steps. Not sure what version you're on? [Here's how to check](#1-check-your-current-uswds-code-and-settings-versions).
+**Note:** This guide provides instructions for upgrading from USWDS 2 to USWDS 3. If your project uses USWDS 1, you will need to update according to the [USWDS 2.0 migration guide]({{ site.baseurl }}/documentation/migration-v2) before proceeding with these steps. [Not sure which version of USWDS you're using? Here's how to check](#1-check-your-current-uswds-code-and-settings-versions).
 
 ## Why migrate to USWDS 3.0?
 

--- a/pages/documentation/migration-V3.md
+++ b/pages/documentation/migration-V3.md
@@ -25,7 +25,7 @@ subnav:
   href: '#6-optimize-your-installation'
 ---
 {: .site-note }
-**Note:** This guide provides instructions for upgrading from USWDS 2 to USWDS 3. If your project uses USWDS 1, you will need to update according to the [USWDS 2.0 migration guide]({{ site.baseurl }}/documentation/migration-v2) before proceeding with these steps.
+**Note:** This guide provides instructions for upgrading from USWDS 2 to USWDS 3. If your project uses USWDS 1, you will need to update according to the [USWDS 2.0 migration guide]({{ site.baseurl }}/documentation/migration-v2) before proceeding with these steps. Not sure what version you're on? [Here's how to check](#1-check-your-current-uswds-code-and-settings-versions).
 
 ## Why migrate to USWDS 3.0?
 

--- a/pages/documentation/migration-V3.md
+++ b/pages/documentation/migration-V3.md
@@ -24,6 +24,8 @@ subnav:
 - text: 6. Optimize your installation
   href: '#6-optimize-your-installation'
 ---
+{: .site-note }
+**Note:** This guide provides instructions for upgrading from USWDS 2 to USWDS 3. If your project uses USWDS 1, you will need to update according to the [USWDS 2.0 migration guide]({{ site.baseurl }}/documentation/migration-v2) before proceeding with these steps.
 
 ## Why migrate to USWDS 3.0?
 


### PR DESCRIPTION
## Summary
**Added clarity for users migrating from USWDS 1 to USWDS.** We included a note at the top of the 3.0 Migration guide explaining that users updating from 1.x should first update to version 2 via the 2.0 Migration guide. 

## Related issue
Closes #1733 

Related discussion: https://github.com/uswds/uswds/discussions/4895

## Preview link
Preview link: [Migrating to 3.0](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/al-migration-1x/documentation/migration/)

## Problem statement
Users should be able to easily find all the needed instructions for upgrading any version of USWDS to version 3. However, users who are upgrading from 1.x do not have clear instructions for all the steps they need to take to get to 3.x. 

## Solution
Providing instructions to 1.x users that they must first follow instructions in the 2.0 migration will help clarify the path to get to version 3. 

Possible additional solution not included in this PR: Add an additional note in [Section 4 of the 3.0 migration guide](https://designsystem.digital.gov/documentation/migration/#4-integrate-any-recent-uswds-changes). I left this out because the initial note clarifies that this is only for migrations from 2 to 3, and additional instructions felt unnecessary. Please let me know if you believe this would be a helpful addition. 

## Testing and review
To review:
1. Confirm that the instructions provided are clear and comprehensive enough that 1.x users can successfully upgrade to USWDS 3. 
1. Proof the copy for any errors

---

Before opening this PR, make sure you’ve done whichever of these applies to you:
- [x] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [x] Run `npm test` and confirm that all tests pass.
