### PR TITLE
USWDS-Site - Fix typo in phase 2 dev guide 

### DIFF
--- a/pages/documentation/getting-started-developers/phase-two.md
+++ b/pages/documentation/getting-started-developers/phase-two.md
@@ -71,7 +71,7 @@ In plain language, this code says:
 
   The USWDS source code is the core of the design system. It contains all the styles for USWDS components as well as the design language of Sass tokens and functions used to build those components. USWDS source code has its own Sass entry point, which lives in the `node_modules` directory when you install USWDS with npm.
 
-  This is called `uswds` (or, more accurately, `uswds/_index.scss`), and it’s found in the `/packages` directory of the USWDS npm package. When you install with npm, the complete path is typically `./node_modules/@uswds/uswds/packages/uswds/_index.html`.
+  This is called `uswds` (or, more accurately, `uswds/_index.scss`), and it’s found in the `/packages` directory of the USWDS npm package. When you install with npm, the complete path is typically `./node_modules/@uswds/uswds/packages/uswds/_index.scss`.
 
 - **Build new work on top of that foundation**: Finally, add any custom project styles built from design system code.
 


### PR DESCRIPTION
# Summary
Updated typo that pointed users to `index.html` when it should be `index.scss`.

## Related issue
Closes #1711 

## Preview link
Preview link: [Phase 2 - Compile](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/al-phase2-typo/documentation/getting-started/developers/phase-two-compile/#step-1-set-up-your-projects-sass-entry-point)

---

Before opening this PR, make sure you’ve done whichever of these applies to you:

- [x] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [x] Run `npm test` and confirm that all tests pass.