### PR TITLE
USWDS-Site: Update snyk ignore

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1420,8 +1420,8 @@ ignore:
         expires: '2022-01-27T21:29:25.296Z'
     - '*':
         reason: No available upgrade or patch
-        expires: 2022-08-12T14:03:06.502Z
-        created: 2022-07-13T14:03:06.556Z
+        expires: 2022-09-14T17:25:17.790Z
+        created: 2022-08-15T17:25:17.843Z
   SNYK-JS-NODESASS-1059081:
     - gulp-sass > node-sass:
         reason: No available upgrade or patch.
@@ -2707,8 +2707,8 @@ ignore:
         expires: '2022-01-27T21:29:25.295Z'
     - '*':
         reason: No available upgrade or patch
-        expires: 2022-08-12T14:02:25.399Z
-        created: 2022-07-13T14:02:25.446Z
+        expires: 2022-09-14T17:25:23.695Z
+        created: 2022-08-15T17:25:23.742Z
   SNYK-JS-AXIOS-1579269:
     - uswds > @frctl/fractal > @frctl/web > browser-sync > localtunnel > axios:
         reason: None given
@@ -3498,8 +3498,8 @@ ignore:
   SNYK-JS-UNSETVALUE-2400660:
     - '*':
         reason: No available upgrade or patch
-        expires: 2022-08-12T14:03:23.030Z
-        created: 2022-07-13T14:03:23.075Z
+        expires: 2022-09-14T17:25:11.065Z
+        created: 2022-08-15T17:25:11.117Z
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   'npm:minimatch:20160620':


### PR DESCRIPTION
## Related issue
Closes https://github.com/uswds/uswds-site/issues/1742

## Problem statement
`npx snyk test` was throwing errors related to sub-dependencies inside Gulp 4.0.2. 

## Solution
Update the snyk policy to ignore these alerts for 30 days. 

## Testing and review
To test, run `npx snyk test` and check for errors.

## Reference
[Ignore vulnerabilities using Snyk CLI](https://docs.snyk.io/snyk-cli/test-for-vulnerabilities/ignore-vulnerabilities-using-snyk-cli)

---

Before opening this PR, make sure you’ve done whichever of these applies to you:
- [x] Run `npm test` and confirm that all tests pass.