### PR TITLE
USWDS-Site - Alert: Update ARIA role guidance

### DIFF
--- a/_components/alert/guidance/accessibility.md
+++ b/_components/alert/guidance/accessibility.md
@@ -2,7 +2,7 @@
 - **Use the proper ARIA role.** The ARIA `role` attribute can notify assistive technologies of time-sensitive and important messages. To elevate importance, add the appropriate `role` to the `.usa-alert` element, chosen from the following table:
 
 {% assign col1Title = 'Attribute' %}
-{% assign col2Title = 'Use case' %}
+{% assign col2Title = 'Use Case' %}
 
 <table class="usa-table--borderless site-table-responsive site-table-simple margin-top-2">
   <thead>
@@ -17,15 +17,7 @@
           <code>role="alert"</code>
         </td>
         <td data-title="{{ col2Title }}">
-          Important messages that demand the user's immediate attention. (Example: error alert)
-        </td>
-      </tr>
-      <tr>
-        <td data-title="{{ col1Title }}">
-          <code>role="alertdialog"</code>
-        </td>
-        <td data-title="{{ col2Title }}">
-          Important messages that demand the user's immediate attention <em>and</em> require user interaction. (Example: error alert that needs user confirmation)
+          Important messages that demand the user's immediate attention. <br/>Example: Error alert
         </td>
       </tr>
       <tr>
@@ -33,7 +25,15 @@
           <code>role="status"</code>
         </td>
         <td data-title="{{ col2Title }}">
-          Messages that provide advisory information, but do not have the same urgency as alerts. (Example: success alert)
+          Messages that provide advisory information, but do not have the same urgency as alerts. <br/>Example: Success alert
+        </td>
+      </tr>
+      <tr>
+        <td data-title="{{ col1Title }}">
+          <code>role="region"</code>
+        </td>
+        <td data-title="{{ col2Title }}">
+          Messages that are important enough to include in the landmarks of the page, but do not warrant interrupting the user's workflow. <br/>Example: Informative or warning alert
         </td>
       </tr>
     </tbody>

--- a/_components/alert/guidance/accessibility.md
+++ b/_components/alert/guidance/accessibility.md
@@ -37,7 +37,7 @@
         <td data-title="{{ col2Title }}">
           Messages that provide information the user would want to be able to easily find, but are not important enough to interrupt user workflow.
           <br/>Example: Informative or warning alert<br/>
-          Note: you must also add an appropriate `aria-label` or `aria-labelledby` attribute when using this role.
+          Note: you must add an appropriate <code>aria-label</code> or <code>aria-labelledby</code> attribute when using this role.
         </td>
       </tr>
     </tbody>

--- a/_components/alert/guidance/accessibility.md
+++ b/_components/alert/guidance/accessibility.md
@@ -17,7 +17,8 @@
           <code>role="alert"</code>
         </td>
         <td data-title="{{ col2Title }}">
-          Important messages that demand the user's immediate attention. <br/>Example: Error alert
+          Important messages that demand the user's immediate attention.
+          <br/>Example: Error alert
         </td>
       </tr>
       <tr>
@@ -25,7 +26,8 @@
           <code>role="status"</code>
         </td>
         <td data-title="{{ col2Title }}">
-          Messages that provide advisory information, but do not have the same urgency as alerts. <br/>Example: Success alert
+          Messages that provide advisory information but do not have the same urgency as alerts.
+          <br/>Example: Success alert
         </td>
       </tr>
       <tr>
@@ -33,7 +35,8 @@
           <code>role="region"</code>
         </td>
         <td data-title="{{ col2Title }}">
-          Messages that are important enough to include in the landmarks of the page, but do not warrant interrupting the user's workflow. <br/>Example: Informative or warning alert
+          Messages that are important enough to include in the landmarks of the page, but do not warrant interrupting the user's workflow.
+          <br/>Example: Informative or warning alert
         </td>
       </tr>
     </tbody>

--- a/_components/alert/guidance/accessibility.md
+++ b/_components/alert/guidance/accessibility.md
@@ -1,2 +1,43 @@
-- **Use the proper ARIA role.** If the message is not interactive, use the ARIA `role="alert"` to inform assistive technologies of a time-sensitive and important message. If the message is interactive, use the ARIA `role="alertdialog"` instead.
 - **Don’t visually hide alert messages and then make them visible when they are needed.** Users of older assistive technologies may still be able to perceive the alert messages even if they are not currently applicable.
+- **Use the proper ARIA role.** The ARIA `role` attribute can notify assistive technologies of time-sensitive and important messages. To elevate importance, add the appropriate `role` to the `.usa-alert` element from the following table:
+
+{% assign col1Title = 'Attribute' %}
+{% assign col2Title = 'Use case' %}
+
+<table class="usa-table--borderless site-table-responsive site-table-simple margin-top-2">
+  <thead>
+      <tr>
+        <th scope="col">{{ col1Title }}</th>
+        <th scope="col">{{ col2Title }}</th>
+      </tr>
+    </thead>
+    <tbody class="font-lang-3xs">
+      <tr>
+        <td data-title="{{ col1Title }}">
+          <code>role="alert"</code>
+        </td>
+        <td data-title="{{ col2Title }}">
+          Important messages that demand the user's immediate attention.<br/>
+          Example: Error alert
+        </td>
+      </tr>
+      <tr>
+        <td data-title="{{ col1Title }}">
+          <code>role="alertdialog"</code>
+        </td>
+        <td data-title="{{ col2Title }}">
+          Important messages that demand the user's immediate attention <em>and</em> require user interaction.<br/>
+          Example: Error alert that need user confirmation
+        </td>
+      </tr>
+      <tr>
+        <td data-title="{{ col1Title }}">
+          <code>role="status"</code>
+        </td>
+        <td data-title="{{ col2Title }}">
+          Messages that provide advisory information, but do not have the same urgency as alerts.<br/>
+          Example: Success alert
+        </td>
+      </tr>
+    </tbody>
+</table>

--- a/_components/alert/guidance/accessibility.md
+++ b/_components/alert/guidance/accessibility.md
@@ -1,5 +1,5 @@
 - **Don’t visually hide alert messages and then make them visible when they are needed.** Users of older assistive technologies may still be able to perceive the alert messages even if they are not currently applicable.
-- **Use the proper ARIA role.** The ARIA `role` attribute can notify assistive technologies of time-sensitive and important messages. To elevate importance, add the appropriate `role` to the `.usa-alert` element from the following table:
+- **Use the proper ARIA role.** The ARIA `role` attribute can notify assistive technologies of time-sensitive and important messages. To elevate importance, add the appropriate `role` to the `.usa-alert` element, chosen from the following table:
 
 {% assign col1Title = 'Attribute' %}
 {% assign col2Title = 'Use case' %}
@@ -17,8 +17,7 @@
           <code>role="alert"</code>
         </td>
         <td data-title="{{ col2Title }}">
-          Important messages that demand the user's immediate attention.<br/>
-          Example: Error alert
+          Important messages that demand the user's immediate attention. (Example: error alert)
         </td>
       </tr>
       <tr>
@@ -26,8 +25,7 @@
           <code>role="alertdialog"</code>
         </td>
         <td data-title="{{ col2Title }}">
-          Important messages that demand the user's immediate attention <em>and</em> require user interaction.<br/>
-          Example: Error alert that need user confirmation
+          Important messages that demand the user's immediate attention <em>and</em> require user interaction. (Example: error alert that needs user confirmation)
         </td>
       </tr>
       <tr>
@@ -35,9 +33,11 @@
           <code>role="status"</code>
         </td>
         <td data-title="{{ col2Title }}">
-          Messages that provide advisory information, but do not have the same urgency as alerts.<br/>
-          Example: Success alert
+          Messages that provide advisory information, but do not have the same urgency as alerts. (Example: success alert)
         </td>
       </tr>
     </tbody>
 </table>
+
+{: .font-lang-3xs }
+Reference: [WAI-ARIA](https://www.w3.org/TR/wai-aria-1.1/#alert)

--- a/_components/alert/guidance/accessibility.md
+++ b/_components/alert/guidance/accessibility.md
@@ -35,8 +35,9 @@
           <code>role="region"</code>
         </td>
         <td data-title="{{ col2Title }}">
-          Messages that are important enough to include in the landmarks of the page, but do not warrant interrupting the user's workflow.
-          <br/>Example: Informative or warning alert
+          Messages that provide information the user would want to be able to easily find, but are not important enough to interrupt user workflow.
+          <br/>Example: Informative or warning alert<br/>
+          Note: you must also add an appropriate `aria-label` or `aria-labelledby` attribute when using this role.
         </td>
       </tr>
     </tbody>

--- a/_components/alert/guidance/accessibility.md
+++ b/_components/alert/guidance/accessibility.md
@@ -1,8 +1,9 @@
 - **Don’t visually hide alert messages and then make them visible when they are needed.** Users of older assistive technologies may still be able to perceive the alert messages even if they are not currently applicable.
-- **Use the proper ARIA role.** The ARIA `role` attribute can notify assistive technologies of time-sensitive and important messages. To elevate importance, add the appropriate `role` to the `.usa-alert` element, chosen from the following table:
+- **Use the proper ARIA role.** The ARIA `role` attribute can notify assistive technologies of time-sensitive and important messages. To elevate the importance of the alert, choose the appropriate `role` from the [ARIA roles table](#alert-aria-roles) and add it to the `.usa-alert` element.
 
 {% assign col1Title = 'Attribute' %}
 {% assign col2Title = 'Use Case' %}
+#### Alert ARIA roles
 
 <table class="usa-table--borderless site-table-responsive site-table-simple margin-top-2">
   <thead>


### PR DESCRIPTION
## Summary
Updated accessibility documentation for the alert component to give clearer instructions for adding the appropriate ARIA role. 

## Related issue
Closes https://github.com/uswds/uswds/issues/3832

## Preview link
Preview link: [Alert component page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/al-alert-aria-update/components/alert/#accessibility-alert)

## Problem statement
It is important that users are informed of the attributes the alert component needs to make it accessible. However, our current documentation provides information on only some of the available roles and does not give a clear indication of exactly how and where these attributes should be used.

## Solution
ARIA provides several `role` attributes that can be added to the alert component to make content more readily available to users of assistive technologies. Each role generates a different behavior and should be chosen based on the urgency and importance of the message. 

- The alert role is a live region with implicit values of `aria-live="assertive"` and `aria-atomic="true"`  [W3C Alert role](https://www.w3.org/TR/wai-aria-1.1/#alert)
- The status role is a live region with implicit values of `aria-live="polite"` and `aria-atomic="true"` [status role](https://www.w3.org/TR/wai-aria-1.1/#status)
- The region role is a landmark and does not have implicit `aria-live` or `aria-atomic` values. However, it does make the component appear in the landmarks menu, which can make finding that content easier. This role does require the addition of `aria-labelledby` or `aria-label`. [Region role](https://www.w3.org/TR/wai-aria-1.1/#region)

The proposed solution in this PR creates a table that shows a list of available ARIA roles, use cases for each, and examples chosen from our component variants. 

Note: I added the `region` role because it gives the option to add the alert as a page landmark so that users can more easily find it via rotor, etc.  It is debatable to me if our alerts should be included as landmarks &mdash; the site alert component is a clearer candidate for a landmark role &mdash; but I included the information here because it might be useful in certain cases. If we decide the alert should be a landmark by default, we can change the wrapping `div` in this component to a `section`, which is automatically added to the landmarks menu.

Note: I removed recommendations for `alertdialog` because the specs indicate that using this role should also involve adding a behavior that moves and traps user focus on the `alertdialog` element. Because this did not fit the pattern of the existing alert component, I removed it from the list of recommended roles.

> Content authors SHOULD make alert dialogs modal by ensuring that, while the alertdialog is shown, keyboard and mouse interactions only operate within the dialog. ([W3C Alertdialog](https://w3c.github.io/aria/#alertdialog))


## Possible next steps:
If we move forward with these examples and recommendations, we should consider adding these roles to the component code. It also might be worth considering converting the outer `<div>` to be a `<section>` instead so that it is automatically included in page landmarks and `role="region"` would no longer be needed. 

## Testing and review
- Proofread the copy for errors and clarity
- Confirm that the provided roles are the ones we want to recommend
- Confirm at all the information a user needs for quick reference is made available

---

Before opening this PR, make sure you’ve done whichever of these applies to you:

- [x] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [x] Run `npm test` and confirm that all tests pass.
