### PR TITLE
USWDS-Site - Site alert: Add aria-label information to accessibility docs

### DIFF
--- a/_components/site-alert/guidance/accessibility.md
+++ b/_components/site-alert/guidance/accessibility.md
@@ -1,1 +1,2 @@
+- **Include a descriptive ARIA label.** Add an `aria-label` or `aria-labelledby` attribute to the `.usa-site-alert` element to ensure that your site alert appears in the landmarks menu. A well-written label can help assistive technology users easily find and understand the top-level information of your site alert.
 - **Don’t visually hide alert messages and then make them visible when they are needed.** Users of older assistive technologies may still be able to perceive hidden alert messages. Fully remove alert messages when they’re not needed.

--- a/_components/site-alert/guidance/accessibility.md
+++ b/_components/site-alert/guidance/accessibility.md
@@ -1,6 +1,6 @@
 - **Don’t visually hide alert messages and then make them visible when they are needed.** Users of older assistive technologies may still be able to perceive hidden alert messages. Fully remove alert messages when they’re not needed.
 - **Include a descriptive ARIA label.** Add an `aria-label` or `aria-labelledby` attribute to the `.usa-site-alert` element to ensure that your site alert appears in the landmarks menu. A well-written label can help assistive technology users easily find and understand the top-level information of your site alert.
-- **Add an ARIA role to dynamically-updated site alerts.** For important, time-sensitive site alerts that will be dynamically updated mid-session, add an ARIA `role` attribute that will notify users of changes. To do this, choose the appropriate `role` from the [ARIA roles table](#site-alert-aria-roles) and add it to the `.usa-site-alert` element.
+- **Add an ARIA role to dynamically-updated site alerts.** For important, time-sensitive site alerts that will receive new content mid-session, for example if your site pushes out an updated emergency alert, add an ARIA `role` attribute that will notify users of changes. To do this, choose the appropriate `role` from the [ARIA roles table](#site-alert-aria-roles) and add it to the `.usa-site-alert` element.
 
 {% assign col1Title = 'Attribute' %}
 {% assign col2Title = 'Use Case' %}

--- a/_components/site-alert/guidance/accessibility.md
+++ b/_components/site-alert/guidance/accessibility.md
@@ -1,2 +1,37 @@
-- **Include a descriptive ARIA label.** Add an `aria-label` or `aria-labelledby` attribute to the `.usa-site-alert` element to ensure that your site alert appears in the landmarks menu. A well-written label can help assistive technology users easily find and understand the top-level information of your site alert.
 - **Don’t visually hide alert messages and then make them visible when they are needed.** Users of older assistive technologies may still be able to perceive hidden alert messages. Fully remove alert messages when they’re not needed.
+- **Include a descriptive ARIA label.** Add an `aria-label` or `aria-labelledby` attribute to the `.usa-site-alert` element to ensure that your site alert appears in the landmarks menu. A well-written label can help assistive technology users easily find and understand the top-level information of your site alert.
+- **Add an ARIA role to dynamically-updated site alerts.** If your site alert will be dynamically updated during a session, add an ARIA `role` attribute to notify assistive technologies users of important and time-sensitive changes. To elevate importance, add the appropriate `role` to the `.usa-site-alert` element, chosen from the following table:
+
+{% assign col1Title = 'Attribute' %}
+{% assign col2Title = 'Use Case' %}
+
+<table class="usa-table--borderless site-table-responsive site-table-simple margin-top-2">
+  <thead>
+      <tr>
+        <th scope="col">{{ col1Title }}</th>
+        <th scope="col">{{ col2Title }}</th>
+      </tr>
+    </thead>
+    <tbody class="font-lang-3xs">
+      <tr>
+        <td data-title="{{ col1Title }}">
+          <code>role="alert"</code>
+        </td>
+        <td data-title="{{ col2Title }}">
+          Important messages that demand the user's immediate attention. Use this role sparingly because it interrupts the user's workflow.
+        </td>
+      </tr>
+      <tr>
+        <td data-title="{{ col1Title }}">
+          <code>role="status"</code>
+        </td>
+        <td data-title="{{ col2Title }}">
+          Messages that provide advisory information but do not have the same urgency as alerts.
+        </td>
+      </tr>
+    </tbody>
+</table>
+
+{: .font-lang-3xs }
+Reference: [WAI-ARIA](https://www.w3.org/TR/wai-aria-1.1/#alert)
+

--- a/_components/site-alert/guidance/accessibility.md
+++ b/_components/site-alert/guidance/accessibility.md
@@ -1,9 +1,11 @@
 - **Don’t visually hide alert messages and then make them visible when they are needed.** Users of older assistive technologies may still be able to perceive hidden alert messages. Fully remove alert messages when they’re not needed.
 - **Include a descriptive ARIA label.** Add an `aria-label` or `aria-labelledby` attribute to the `.usa-site-alert` element to ensure that your site alert appears in the landmarks menu. A well-written label can help assistive technology users easily find and understand the top-level information of your site alert.
-- **Add an ARIA role to dynamically-updated site alerts.** If your site alert will be dynamically updated during a session, add an ARIA `role` attribute to notify assistive technologies users of important and time-sensitive changes. To elevate importance, add the appropriate `role` to the `.usa-site-alert` element, chosen from the following table:
+- **Add an ARIA role to dynamically-updated site alerts.** For important, time-sensitive site alerts that will be dynamically updated mid-session, add an ARIA `role` attribute that will notify users of changes. To do this, choose the appropriate `role` from the [ARIA roles table](#site-alert-aria-roles) and add it to the `.usa-site-alert` element.
 
 {% assign col1Title = 'Attribute' %}
 {% assign col2Title = 'Use Case' %}
+
+#### Site alert ARIA roles
 
 <table class="usa-table--borderless site-table-responsive site-table-simple margin-top-2">
   <thead>


### PR DESCRIPTION
## Summary
Added instruction for using descriptive ARIA labels to ensure that assistive technology users can find and understand the site alert from the landmarks menu.

Additionally, added instruction for using ARIA roles to announce content changes to assistive technology users.

## Related issue
Closes https://github.com/uswds/uswds/issues/4589

## Preview link
Preview link: [Site alert accessibility section](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/al-site-alert-aria/components/site-alert/#accessibility-site-alert)

## Problem statement
Site alerts should be included in the page landmarks so that users of assistive technologies can more easily find site alert content on the page. However, if a user excludes the ARIA label, the site alert will not appear in the landmarks menu. 

Additionally, some site alerts should be announced to assistive technologies users as new information is added to it. However, our docs do not explain ARIA roles for live regions.

## Solution
Providing instruction about for using ARIA labels will increase the likelihood that users will include helpful labels on their site alerts. 

Additionally, providing information about adding ARIA roles can help users understand how to announce changes to users of assistive technologies. 

Note: It is unclear if instructions for the ARIA roles is appropriate here because the component specifically speaks to static items. This update was written on the assumption that injecting static content based on site needs (rather than user action) fit the construct of a static message. If this is inappropriate, we can safely remove. 

From the [site alert component page](https://designsystem.digital.gov/components/site-alert/#when-to-use-the-site-alert):
> Use a site alert to deliver a static system status update, such as notices about unavailable services or content. Site alerts should appear by default and not in response to an action.

## Testing and review
Copyeditors:
- Proofread for errors and clarity

Developers:
- Confirm that the information solves the problem in [issue #4589](https://github.com/uswds/uswds/issues/4589)
