### PR TITLE
USWDS - Main nav: Update offset header class

### DIFF
--- a/css/custom-styles/_site-header.scss
+++ b/css/custom-styles/_site-header.scss
@@ -84,7 +84,6 @@ $site-secondary-nav-input-height: 38px;
 }
 
 .site-title {
-
   &--short {
     @include at-media("mobile-lg") {
       display: none;

--- a/js/calculate-anchor-position.js
+++ b/js/calculate-anchor-position.js
@@ -14,11 +14,11 @@ var calculateAnchorPosition = function (hash) {
   var navPadding = parseInt($(".sidenav").css("padding-top"), 10);
   var anchorPadding = parseInt(anchor.css("padding-top"), 10);
 
-  //start with the height of the header
-  topOffset = $(".usa-nav__primary--desktop").first().outerHeight();
+  //start with the height of the sticky nav
+  topOffset = $(".site-nav.sticky").first().outerHeight();
+
   //subtract the diffence in padding between nav top and anchor
   topOffset = topOffset - (anchorPadding - navPadding);
-  console.log(topOffset);
 
   //anchor should now align with first item inside nav
   return anchor.offset().top - topOffset;

--- a/js/calculate-anchor-position.js
+++ b/js/calculate-anchor-position.js
@@ -15,9 +15,10 @@ var calculateAnchorPosition = function (hash) {
   var anchorPadding = parseInt(anchor.css("padding-top"), 10);
 
   //start with the height of the header
-  topOffset = $(".site-nav-secondary").first().outerHeight();
+  topOffset = $(".usa-nav__primary--desktop").first().outerHeight();
   //subtract the diffence in padding between nav top and anchor
   topOffset = topOffset - (anchorPadding - navPadding);
+  console.log(topOffset);
 
   //anchor should now align with first item inside nav
   return anchor.offset().top - topOffset;


### PR DESCRIPTION
## Description

**Fixed inner links in sidenav.** Subnav links now smooth scroll to correct page section.  Closes #1793.

## Additional information

There's JS to smoothscroll sidenav links to relevant page sections _with_ the sticky nav offset included. Needed to update the `calculate-anchor-position.js` script to point to correct class. Now the offset is calculated correctly.

### JS changes

```diff
-  //start with the height of the header
-  topOffset = $(".usa-nav__primary--desktop").first().outerHeight();
+   //start with the height of the sticky nav
+  topOffset = $(".site-nav.sticky").first().outerHeight();
```
 
Issue was introduced in main nav update to recommended USWDS markup [PR #1730]. The desktop class for sticky nav `.site-nav-secondary → .site-nav` was changed to more accurately describe it.

### #1730 nav changes

```diff
- <nav class="site-nav-secondary sticky">
+ <nav aria-label="Primary navigation" class="usa-nav site-nav sticky">
```


Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [ ] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
