### PR TITLE
USWDS - CI: HTMLProofer fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,11 @@ jobs:
       - run:
           name: Build site assets
           command: npm run build:all-assets
+      - run:
+          name: Build static site
+          command: |
+            bundle config set --local path '~/project/vendor/bundle'
+            bundle exec jekyll build
       - persist_to_workspace:
           root: ~/project
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
             - gem-cache-{{ checksum "Gemfile.lock" }}
             - gem-cache
       - run:
-          name: Build USWDS if needed
+          name: Build USWDS components if needed
           command: npm run build:uswds
       - run:
           name: Build site assets

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "federalist": "npx gulp build",
     "lint": "gulp lintJS lintSass && npm run prettier:scss",
     "prestart": "npx gulp build",
-    "proof": "bundle exec htmlproofer --allow-hash-href=true --enforce-https=false --allow-missing-href=true --ignore-empty-alt=true --ignore-files '/_site/whats-new/updates/2017/'  --ignore-status-codes 403,429 ./_site",
+    "proof": "bundle exec htmlproofer --allow-hash-href=true --enforce-https=false --allow-missing-href=true --ignore-empty-alt=true --ignore-files '/_site/whats-new/updates/2017/' --ignore-status-codes 0,403,429,503 ./_site",
     "serve": "npm run build:all-assets && bundle exec jekyll serve --drafts --future --incremental --livereload --host=localhost",
     "serve:package": "npm run build:uswds && npm run serve",
     "serve:local": "export LIBRARY_BASE_URL=\"http://localhost:3000\" && npm run serve",

--- a/pages/documentation/guidance/performance/why.md
+++ b/pages/documentation/guidance/performance/why.md
@@ -19,7 +19,6 @@ Conversion is the rate at which customers of a website product take a desired ac
 
 Performance has been known to be an influencing factor when it comes to the conversion rate for a site. Regardless of the user interface and its purpose, multiple studies have shown that improving performance consistently improves conversion rates over a wide range of applications. There are real-world examples of how performance can affect conversion, such as:
 
-- [Getelastic.com notes, Google found out that slowing search results by just 4/10ths of a second would reduce the number of searches by 8,000,000 per day](http://www.getelastic.com/site-speed-infographic/).
 - [Amazon calculated that a page load slowdown of just one second could cost it $1.6 billion in sales each year](https://www.fastcompany.com/1825005/how-one-second-could-cost-amazon-16-billion-sales).
 
 How fast a site loads is often the first indication of what a web experience will be for a user, and a slow loading site can cause a user to quickly lose trust and patience with a website.


### PR DESCRIPTION
## Description

Created a separate Jekyll build step to ensure `_site/` builds properly for HTMLProofer test. Fixes #1799.

## Additional information

CircleCI was returning 5 failures, three of them false positives.

```bash
Running 3 checks (Images, Links, Scripts) in ["./_site"] on *.html files...


Checking 648 external links
Checking 853 internal links
Ran on 282 files!


For the Links > External check, the following failures were found:

* At ./_site/getting-started/showcase/all/index.html:2611:

  External link https://lincs.ed.gov/ failed with something very wrong.
It's possible libcurl couldn't connect to the server, or perhaps the request timed out.
Sometimes, making too many requests at once also breaks things. (status code 0)

* At ./_site/getting-started/showcase/all/index.html:2673:

  External link https://www.flra.gov/ failed with something very wrong.
It's possible libcurl couldn't connect to the server, or perhaps the request timed out.
Sometimes, making too many requests at once also breaks things. (status code 0)

* At ./_site/performance/why/index.html:2712:

  External link http://www.getelastic.com/site-speed-infographic/ failed (status code 404)

* At ./_site/performance/why/index.html:2713:

  External link https://www.fastcompany.com/1825005/how-one-second-could-cost-amazon-16-billion-sales failed (status code 503)

* At ./_site/website-standards/index.html:2488:

  External link https://www.congress.gov/bill/115th-congress/house-bill/5759/text failed (status code 503)


HTML-Proofer found 5 failures!

Exited with code exit status 1

```

### Valid errors

#### Performance page

* ~http://www.getelastic.com/site-speed-infographic/
  Domain has changed from getelastic to elasticpath and the URL for the infographic is gone. I've tried to search for alternatives, but not having luck finding the one mentioned in our page.~ Removed in [[080d69a]](https://github.com/uswds/uswds-site/pull/1800/commits/080d69ae9989f37005ae973a89199a57ccc7ad58)
* https://www.fastcompany.com/1825005/how-one-second-could-cost-amazon-16-billion-sales
  The entire site is down as their site was breached. It now redirects to that breach message.

#### False positives

- https://lincs.ed.gov/ (timeout)
- https://www.congress.gov/bill/115th-congress/house-bill/5759/text (503)


### Next steps
- [x] I've added status codes `0` and `503` to ignore [[019afc9]](https://github.com/uswds/uswds-site/pull/1800/commits/019afc9e3910d7e91b3bb0c18c1a0e1b0adc1d84)
- [x] **REMOVED** ~Find alternate link or remove site speed infographic from getelastic on [performance page](https://designsystem.digital.gov/performance/why/#conversion-rate)~

## How to test

- `test_build` should **not** report 0 links
- HTML proof step should pass

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
