### PR TITLE
[uswds-site] - [Header documentation]: Fix external blog post link to usertesting.com

### DIFF
--- a/_components/header/header.html
+++ b/_components/header/header.html
@@ -163,8 +163,8 @@ subnav:
   </li>
   <li>
     <a
-      href="https://www.usertesting.com/blog/2015/03/19/site-navigation-tree-testing/"
-      >https://www.usertesting.com/blog/2015/03/19/site-navigation-tree-testing/</a
+      href="https://www.usertesting.com/blog/site-navigation-tree-testing"
+      >https://www.usertesting.com/blog/site-navigation-tree-testing</a
     >
   </li>
 </ul>


### PR DESCRIPTION
## Description

I noticed the usertesting.com link under Further Reading for the Header component was no longer redirecting to the actual post, but to the blog home page instead. It looks like they've redone their url structure, so I updated the page with the current link for that post.

## Additional information

This closes #1381 

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed. (I can't run this because it requires `snyk auth`.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
