### PR TITLE
USWDS-Site: Update synk ignore

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1420,8 +1420,8 @@ ignore:
         expires: '2022-01-27T21:29:25.296Z'
     - '*':
         reason: No available upgrade or patch
-        expires: 2022-10-14T20:00:26.279Z
-        created: 2022-09-14T20:00:26.333Z
+        expires: 2022-11-18T13:56:03.336Z
+        created: 2022-10-19T13:56:03.390Z
   SNYK-JS-NODESASS-1059081:
     - gulp-sass > node-sass:
         reason: No available upgrade or patch.
@@ -2707,8 +2707,8 @@ ignore:
         expires: '2022-01-27T21:29:25.295Z'
     - '*':
         reason: No available upgrade or patch
-        expires: 2022-10-14T19:54:44.913Z
-        created: 2022-09-14T19:54:44.967Z
+        expires: 2022-11-18T13:55:45.748Z
+        created: 2022-10-19T13:55:45.804Z
   SNYK-JS-AXIOS-1579269:
     - uswds > @frctl/fractal > @frctl/web > browser-sync > localtunnel > axios:
         reason: None given
@@ -3498,8 +3498,8 @@ ignore:
   SNYK-JS-UNSETVALUE-2400660:
     - '*':
         reason: No available upgrade or patch
-        expires: 2022-10-14T20:00:14.827Z
-        created: 2022-09-14T20:00:14.880Z
+        expires: 2022-11-18T13:56:10.299Z
+        created: 2022-10-19T13:56:10.352Z
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   'npm:minimatch:20160620':


### PR DESCRIPTION
## Related issue
Closes https://github.com/uswds/uswds-site/issues/1842

## Problem statement
`npx snyk test` was throwing errors related to sub-dependencies inside Gulp 4.0.2. 

## Solution
Update the snyk policy to ignore these alerts for 30 days. 

Run the following in the command line:
```
npx snyk ignore --id="SNYK-JS-ANSIREGEX-1583908" --reason="No available upgrade or patch" && npx snyk ignore --id="SNYK-JS-GLOBPARENT-1016905" --reason="No available upgrade or patch" && npx snyk ignore --id="SNYK-JS-UNSETVALUE-2400660" --reason="No available upgrade or patch"
```

## Testing and review
To test, run `npx snyk test` and check for errors.

## Reference
[Ignore vulnerabilities using Snyk CLI](https://docs.snyk.io/snyk-cli/test-for-vulnerabilities/ignore-vulnerabilities-using-snyk-cli)