### PR TITLE
Simplify and update community guidelines

### DIFF
--- a/pages/about/community.md
+++ b/pages/about/community.md
@@ -27,7 +27,7 @@ There are several ways to contribute to USWDS. Participating in the community is
 </p>
 
 ## Community Conduct
-By voluntarily participating in this community, you are agreeing to abide by the  [Digital.gov Community Guidelines](https://digital.gov/communities/manage-your-subscription/) and the [TTS Code of Conduct](https://handbook.tts.gsa.gov/code-of-conduct/). Respect your peers, use plain language, be patient, practice constructive criticism, and stay organized.
+By voluntarily participating in this community, you are agreeing to abide by the  [Digital.gov Community Guidelines](https://digital.gov/communities/community-guidelines/) and the [TTS Code of Conduct](https://handbook.tts.gsa.gov/code-of-conduct/). Respect your peers, use plain language, be patient, practice constructive criticism, and stay organized.
 
 ## Community Managers
 

--- a/pages/about/community.md
+++ b/pages/about/community.md
@@ -27,7 +27,7 @@ There are several ways to contribute to USWDS. Participating in the community is
 </p>
 
 ## Community Conduct
-When participating in this community, you must follow [Digital.gov Etiquette Guidelines](https://digital.gov/communities/manage-your-subscription/). Respect your peers, use plain language, be patient, practice constructive criticism, and stay organized. By participating in the community, you agree to abide by the [TTS Code of Conduct](https://handbook.tts.gsa.gov/code-of-conduct/).
+By voluntarily participating in this community, you agree to follow the [Digital.gov Community Guidelines](https://digital.gov/communities/manage-your-subscription/) and the [TTS Code of Conduct](https://handbook.tts.gsa.gov/code-of-conduct/). Respect your peers, use plain language, be patient, practice constructive criticism, and stay organized.
 
 ## Community Managers
 

--- a/pages/about/community.md
+++ b/pages/about/community.md
@@ -27,7 +27,7 @@ There are several ways to contribute to USWDS. Participating in the community is
 </p>
 
 ## Community Conduct
-By voluntarily participating in this community, you agree to follow the [Digital.gov Community Guidelines](https://digital.gov/communities/manage-your-subscription/) and the [TTS Code of Conduct](https://handbook.tts.gsa.gov/code-of-conduct/). Respect your peers, use plain language, be patient, practice constructive criticism, and stay organized.
+By voluntarily participating in this community, you are agreeing to abide by the  [Digital.gov Community Guidelines](https://digital.gov/communities/manage-your-subscription/) and the [TTS Code of Conduct](https://handbook.tts.gsa.gov/code-of-conduct/). Respect your peers, use plain language, be patient, practice constructive criticism, and stay organized.
 
 ## Community Managers
 


### PR DESCRIPTION
This PR makes some small edits to our community page:

- Use the new DG Community Guidelines name. (It's no longer "Etiquette Guidelines")
- Connect DGCG and TTS CoC into one sentence. (Since participating in the community means following both the DG Guidelines and the TTS Code of Conduct.)
- Clarify that community participation is voluntary. (Be clear that folks who join our community are free _not_ to join our community.)
- Use the new URL for the DG Community Guidelines, since the old URL forwards to it.