### PR TITLE
USWDS-Site: Resolve pa11y and html-proofer errors

### DIFF
--- a/_components/data-visualizations/data-visualizations.md
+++ b/_components/data-visualizations/data-visualizations.md
@@ -405,7 +405,7 @@ tags:
       </g>
     </g>
     </svg>
-    <table class="usa-sr-only" aria-describedby="source">
+    <table class="usa-sr-only" aria-describedby="source_bar">
       <caption>Top 5 most visited Nation Parks</caption>
       <thead>
         <tr>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@uswds/compile": "^1.0.0-beta.3",
-        "@uswds/uswds": "3.2.0"
+        "@uswds/uswds": "^3.2.0"
       },
       "devDependencies": {
         "@18f/identity-stylelint-config": "^1.0.0",
@@ -298,15 +298,15 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.6.tgz",
-      "integrity": "sha512-jJr+hPTJYKyDILJfhNSHsjiwXYf26Flsz8DvNndOsHs5pwSnpGUEy8yzF0JYhCEvTDdV2vuOK5tt8BVhwO5/hg==",
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
+      "integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
-        "minimatch": "^3.0.4"
+        "minimatch": "^3.0.5"
       },
       "engines": {
         "node": ">=10.10.0"
@@ -392,9 +392,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.11.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.7.tgz",
-      "integrity": "sha512-LhFTglglr63mNXUSRYD8A+ZAIu5sFqNJ4Y2fPuY7UlrySJH87rRRlhtVmMHplmfk5WkoJGmDjE9oiTfyX94CpQ=="
+      "version": "18.11.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.8.tgz",
+      "integrity": "sha512-uGwPWlE0Hj972KkHtCDVwZ8O39GmyjfMane1Z3GUBGGnkZ2USDq7SxLpVIiIHpweY9DS0QTDH0Nw7RNBsAAZ5A=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -2197,9 +2197,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001426",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001426.tgz",
-      "integrity": "sha512-n7cosrHLl8AWt0wwZw/PJZgUg3lV0gk9LMI7ikGJwhyhgsd2Nb65vKvmSexCqq/J7rbH3mFG6yZZiPR5dLPW5A==",
+      "version": "1.0.30001427",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001427.tgz",
+      "integrity": "sha512-lfXQ73oB9c8DP5Suxaszm+Ta2sr/4tf8+381GkIm1MLj/YdLf+rEDyDSRCzeltuyTVGm+/s18gdZ0q+Wmp8VsQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -3049,9 +3049,9 @@
       }
     },
     "node_modules/decamelize-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-      "integrity": "sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
+      "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
       "dev": true,
       "dependencies": {
         "decamelize": "^1.1.0",
@@ -3059,6 +3059,9 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/decode-uri-component": {
@@ -11902,9 +11905,9 @@
       }
     },
     "node_modules/snyk": {
-      "version": "1.1044.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1044.0.tgz",
-      "integrity": "sha512-mi9kF6tAPZFj1USYFJoAYxFUE4z/J2ZMJ0D8cXqlMIBewrR+r3RIBI3CNQfsOHvoWhfHZaVNh392TVAtIL2V2Q==",
+      "version": "1.1046.0",
+      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1046.0.tgz",
+      "integrity": "sha512-sr2tAsvs5X2ZO4ZPhnVomTg86w+zoUAldrYbFUnLZ79Xyy/GQjTmx0POfZAdd2OAIyfvskjVIxQqQCR6k0Kerg==",
       "dev": true,
       "bin": {
         "snyk": "bin/snyk"
@@ -14436,15 +14439,15 @@
       }
     },
     "@humanwhocodes/config-array": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.6.tgz",
-      "integrity": "sha512-jJr+hPTJYKyDILJfhNSHsjiwXYf26Flsz8DvNndOsHs5pwSnpGUEy8yzF0JYhCEvTDdV2vuOK5tt8BVhwO5/hg==",
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
+      "integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
       "dev": true,
       "peer": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
-        "minimatch": "^3.0.4"
+        "minimatch": "^3.0.5"
       }
     },
     "@humanwhocodes/module-importer": {
@@ -14508,9 +14511,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.11.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.7.tgz",
-      "integrity": "sha512-LhFTglglr63mNXUSRYD8A+ZAIu5sFqNJ4Y2fPuY7UlrySJH87rRRlhtVmMHplmfk5WkoJGmDjE9oiTfyX94CpQ=="
+      "version": "18.11.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.8.tgz",
+      "integrity": "sha512-uGwPWlE0Hj972KkHtCDVwZ8O39GmyjfMane1Z3GUBGGnkZ2USDq7SxLpVIiIHpweY9DS0QTDH0Nw7RNBsAAZ5A=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -15925,9 +15928,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001426",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001426.tgz",
-      "integrity": "sha512-n7cosrHLl8AWt0wwZw/PJZgUg3lV0gk9LMI7ikGJwhyhgsd2Nb65vKvmSexCqq/J7rbH3mFG6yZZiPR5dLPW5A=="
+      "version": "1.0.30001427",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001427.tgz",
+      "integrity": "sha512-lfXQ73oB9c8DP5Suxaszm+Ta2sr/4tf8+381GkIm1MLj/YdLf+rEDyDSRCzeltuyTVGm+/s18gdZ0q+Wmp8VsQ=="
     },
     "caw": {
       "version": "2.0.1",
@@ -16609,9 +16612,9 @@
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
     },
     "decamelize-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-      "integrity": "sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
+      "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
       "dev": true,
       "requires": {
         "decamelize": "^1.1.0",
@@ -23443,9 +23446,9 @@
       }
     },
     "snyk": {
-      "version": "1.1044.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1044.0.tgz",
-      "integrity": "sha512-mi9kF6tAPZFj1USYFJoAYxFUE4z/J2ZMJ0D8cXqlMIBewrR+r3RIBI3CNQfsOHvoWhfHZaVNh392TVAtIL2V2Q==",
+      "version": "1.1046.0",
+      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1046.0.tgz",
+      "integrity": "sha512-sr2tAsvs5X2ZO4ZPhnVomTg86w+zoUAldrYbFUnLZ79Xyy/GQjTmx0POfZAdd2OAIyfvskjVIxQqQCR6k0Kerg==",
       "dev": true
     },
     "sort-keys": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@uswds/compile": "^1.0.0-beta.3",
-        "@uswds/uswds": "github:uswds/uswds#al-pa11y3-errors"
+        "@uswds/uswds": "3.2.0"
       },
       "devDependencies": {
         "@18f/identity-stylelint-config": "^1.0.0",
@@ -485,11 +485,8 @@
     },
     "node_modules/@uswds/uswds": {
       "version": "3.2.0",
-      "resolved": "git+ssh://git@github.com/uswds/uswds.git#112d77861b24fa691b9f51058f8ce2c32581a902",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "workspaces": [
-        "packages/uswds-core"
-      ],
+      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.2.0.tgz",
+      "integrity": "sha512-Lk3qCkeDVR6I8tFuiK3fsb3ewC6lhttiXL9ZPDDnVVclAXlAE0SFfPIBw5aYdyKU3xq3KEjkQTS2tmC8/nBrmw==",
       "dependencies": {
         "classlist-polyfill": "1.0.3",
         "object-assign": "4.1.1",
@@ -14592,8 +14589,9 @@
       }
     },
     "@uswds/uswds": {
-      "version": "git+ssh://git@github.com/uswds/uswds.git#112d77861b24fa691b9f51058f8ce2c32581a902",
-      "from": "@uswds/uswds@github:uswds/uswds#al-pa11y3-errors",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.2.0.tgz",
+      "integrity": "sha512-Lk3qCkeDVR6I8tFuiK3fsb3ewC6lhttiXL9ZPDDnVVclAXlAE0SFfPIBw5aYdyKU3xq3KEjkQTS2tmC8/nBrmw==",
       "requires": {
         "classlist-polyfill": "1.0.3",
         "object-assign": "4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@uswds/compile": "^1.0.0-beta.3",
-        "@uswds/uswds": "^3.2.0"
+        "@uswds/uswds": "github:uswds/uswds#al-pa11y3-errors"
       },
       "devDependencies": {
         "@18f/identity-stylelint-config": "^1.0.0",
@@ -298,9 +298,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.7.tgz",
-      "integrity": "sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==",
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.6.tgz",
+      "integrity": "sha512-jJr+hPTJYKyDILJfhNSHsjiwXYf26Flsz8DvNndOsHs5pwSnpGUEy8yzF0JYhCEvTDdV2vuOK5tt8BVhwO5/hg==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -392,9 +392,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.11.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.2.tgz",
-      "integrity": "sha512-BWN3M23gLO2jVG8g/XHIRFWiiV4/GckeFIqbU/C4V3xpoBBWSMk4OZomouN0wCkfQFPqgZikyLr7DOYDysIkkw=="
+      "version": "18.11.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.7.tgz",
+      "integrity": "sha512-LhFTglglr63mNXUSRYD8A+ZAIu5sFqNJ4Y2fPuY7UlrySJH87rRRlhtVmMHplmfk5WkoJGmDjE9oiTfyX94CpQ=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -485,8 +485,11 @@
     },
     "node_modules/@uswds/uswds": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.2.0.tgz",
-      "integrity": "sha512-Lk3qCkeDVR6I8tFuiK3fsb3ewC6lhttiXL9ZPDDnVVclAXlAE0SFfPIBw5aYdyKU3xq3KEjkQTS2tmC8/nBrmw==",
+      "resolved": "git+ssh://git@github.com/uswds/uswds.git#112d77861b24fa691b9f51058f8ce2c32581a902",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "workspaces": [
+        "packages/uswds-core"
+      ],
       "dependencies": {
         "classlist-polyfill": "1.0.3",
         "object-assign": "4.1.1",
@@ -511,9 +514,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -1239,9 +1242,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
-      "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.5.0.tgz",
+      "integrity": "sha512-4+rr8eQ7+XXS5nZrKcMO/AikHL0hVqy+lHWAnE3xdHl+aguag8SOQ6eEqLexwLNWgXIMfunGuD3ON1/6Kyet0A==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -2197,9 +2200,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001422",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001422.tgz",
-      "integrity": "sha512-hSesn02u1QacQHhaxl/kNMZwqVG35Sz/8DgvmgedxSH8z9UUpcDYSPYgsj3x5dQNRcNp6BwpSfQfVzYUTm+fog==",
+      "version": "1.0.30001426",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001426.tgz",
+      "integrity": "sha512-n7cosrHLl8AWt0wwZw/PJZgUg3lV0gk9LMI7ikGJwhyhgsd2Nb65vKvmSexCqq/J7rbH3mFG6yZZiPR5dLPW5A==",
       "funding": [
         {
           "type": "opencollective",
@@ -2606,9 +2609,9 @@
       }
     },
     "node_modules/concurrently": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-7.4.0.tgz",
-      "integrity": "sha512-M6AfrueDt/GEna/Vg9BqQ+93yuvzkSKmoTixnwEJkH0LlcGrRC2eCmjeG1tLLHIYfpYJABokqSGyMcXjm96AFA==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-7.5.0.tgz",
+      "integrity": "sha512-5E3mwiS+i2JYBzr5BpXkFxOnleZTMsG+WnE/dCG4/P+oiVXrbmrBwJ2ozn4SxwB2EZDrKR568X+puVohxz3/Mg==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0",
@@ -3773,15 +3776,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.25.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.25.0.tgz",
-      "integrity": "sha512-DVlJOZ4Pn50zcKW5bYH7GQK/9MsoQG2d5eDH0ebEkE8PbgzTTmtt/VTH9GGJ4BfeZCpBLqFfvsjX35UacUL83A==",
+      "version": "8.26.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.26.0.tgz",
+      "integrity": "sha512-kzJkpaw1Bfwheq4VXUezFriD1GxszX6dUekM7Z3aC2o4hju+tsR/XyTC3RcoSD7jmy9VkPU3+N6YjVU2e96Oyg==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.3.3",
-        "@humanwhocodes/config-array": "^0.10.5",
+        "@humanwhocodes/config-array": "^0.11.6",
         "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -3797,14 +3801,14 @@
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
-        "glob-parent": "^6.0.1",
+        "glob-parent": "^6.0.2",
         "globals": "^13.15.0",
-        "globby": "^11.1.0",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
         "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
@@ -6188,9 +6192,9 @@
       }
     },
     "node_modules/gulp-replace/node_modules/@types/node": {
-      "version": "14.18.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.32.tgz",
-      "integrity": "sha512-Y6S38pFr04yb13qqHf8uk1nHE3lXgQ30WZbv1mLliV9pt0NjvqdWttLcrOYLnXbOafknVYRHZGoMSpR9UwfYow=="
+      "version": "14.18.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.33.tgz",
+      "integrity": "sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg=="
     },
     "node_modules/gulp-sass": {
       "version": "5.1.0",
@@ -11901,9 +11905,9 @@
       }
     },
     "node_modules/snyk": {
-      "version": "1.1035.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1035.0.tgz",
-      "integrity": "sha512-EE6mguhgPZnT06eHn8F7nwLjQcwfx7p+ovuJicOD7DkVAanpeoYso6gKDJbLtBUihgT3urGQFKRNoBo1tKoWiw==",
+      "version": "1.1044.0",
+      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1044.0.tgz",
+      "integrity": "sha512-mi9kF6tAPZFj1USYFJoAYxFUE4z/J2ZMJ0D8cXqlMIBewrR+r3RIBI3CNQfsOHvoWhfHZaVNh392TVAtIL2V2Q==",
       "dev": true,
       "bin": {
         "snyk": "bin/snyk"
@@ -13522,9 +13526,9 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "node_modules/uglify-js": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.3.tgz",
-      "integrity": "sha512-JmMFDME3iufZnBpyKL+uS78LRiC+mK55zWfM5f/pWBJfpOttXAqYfdDGRukYhJuyRinvPVAtUhvy7rlDybNtFg==",
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
       "dev": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
@@ -14435,9 +14439,9 @@
       }
     },
     "@humanwhocodes/config-array": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.7.tgz",
-      "integrity": "sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==",
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.6.tgz",
+      "integrity": "sha512-jJr+hPTJYKyDILJfhNSHsjiwXYf26Flsz8DvNndOsHs5pwSnpGUEy8yzF0JYhCEvTDdV2vuOK5tt8BVhwO5/hg==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -14507,9 +14511,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.11.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.2.tgz",
-      "integrity": "sha512-BWN3M23gLO2jVG8g/XHIRFWiiV4/GckeFIqbU/C4V3xpoBBWSMk4OZomouN0wCkfQFPqgZikyLr7DOYDysIkkw=="
+      "version": "18.11.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.7.tgz",
+      "integrity": "sha512-LhFTglglr63mNXUSRYD8A+ZAIu5sFqNJ4Y2fPuY7UlrySJH87rRRlhtVmMHplmfk5WkoJGmDjE9oiTfyX94CpQ=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -14588,9 +14592,8 @@
       }
     },
     "@uswds/uswds": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.2.0.tgz",
-      "integrity": "sha512-Lk3qCkeDVR6I8tFuiK3fsb3ewC6lhttiXL9ZPDDnVVclAXlAE0SFfPIBw5aYdyKU3xq3KEjkQTS2tmC8/nBrmw==",
+      "version": "git+ssh://git@github.com/uswds/uswds.git#112d77861b24fa691b9f51058f8ce2c32581a902",
+      "from": "@uswds/uswds@github:uswds/uswds#al-pa11y3-errors",
       "requires": {
         "classlist-polyfill": "1.0.3",
         "object-assign": "4.1.1",
@@ -14609,9 +14612,9 @@
       }
     },
     "acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
       "dev": true,
       "peer": true
     },
@@ -15137,9 +15140,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
-      "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.5.0.tgz",
+      "integrity": "sha512-4+rr8eQ7+XXS5nZrKcMO/AikHL0hVqy+lHWAnE3xdHl+aguag8SOQ6eEqLexwLNWgXIMfunGuD3ON1/6Kyet0A==",
       "dev": true
     },
     "bach": {
@@ -15924,9 +15927,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001422",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001422.tgz",
-      "integrity": "sha512-hSesn02u1QacQHhaxl/kNMZwqVG35Sz/8DgvmgedxSH8z9UUpcDYSPYgsj3x5dQNRcNp6BwpSfQfVzYUTm+fog=="
+      "version": "1.0.30001426",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001426.tgz",
+      "integrity": "sha512-n7cosrHLl8AWt0wwZw/PJZgUg3lV0gk9LMI7ikGJwhyhgsd2Nb65vKvmSexCqq/J7rbH3mFG6yZZiPR5dLPW5A=="
     },
     "caw": {
       "version": "2.0.1",
@@ -16254,9 +16257,9 @@
       }
     },
     "concurrently": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-7.4.0.tgz",
-      "integrity": "sha512-M6AfrueDt/GEna/Vg9BqQ+93yuvzkSKmoTixnwEJkH0LlcGrRC2eCmjeG1tLLHIYfpYJABokqSGyMcXjm96AFA==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-7.5.0.tgz",
+      "integrity": "sha512-5E3mwiS+i2JYBzr5BpXkFxOnleZTMsG+WnE/dCG4/P+oiVXrbmrBwJ2ozn4SxwB2EZDrKR568X+puVohxz3/Mg==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",
@@ -17187,15 +17190,16 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.25.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.25.0.tgz",
-      "integrity": "sha512-DVlJOZ4Pn50zcKW5bYH7GQK/9MsoQG2d5eDH0ebEkE8PbgzTTmtt/VTH9GGJ4BfeZCpBLqFfvsjX35UacUL83A==",
+      "version": "8.26.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.26.0.tgz",
+      "integrity": "sha512-kzJkpaw1Bfwheq4VXUezFriD1GxszX6dUekM7Z3aC2o4hju+tsR/XyTC3RcoSD7jmy9VkPU3+N6YjVU2e96Oyg==",
       "dev": true,
       "peer": true,
       "requires": {
         "@eslint/eslintrc": "^1.3.3",
-        "@humanwhocodes/config-array": "^0.10.5",
+        "@humanwhocodes/config-array": "^0.11.6",
         "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -17211,14 +17215,14 @@
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
-        "glob-parent": "^6.0.1",
+        "glob-parent": "^6.0.2",
         "globals": "^13.15.0",
-        "globby": "^11.1.0",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
         "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
@@ -19115,9 +19119,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.18.32",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.32.tgz",
-          "integrity": "sha512-Y6S38pFr04yb13qqHf8uk1nHE3lXgQ30WZbv1mLliV9pt0NjvqdWttLcrOYLnXbOafknVYRHZGoMSpR9UwfYow=="
+          "version": "14.18.33",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.33.tgz",
+          "integrity": "sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg=="
         }
       }
     },
@@ -23441,9 +23445,9 @@
       }
     },
     "snyk": {
-      "version": "1.1035.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1035.0.tgz",
-      "integrity": "sha512-EE6mguhgPZnT06eHn8F7nwLjQcwfx7p+ovuJicOD7DkVAanpeoYso6gKDJbLtBUihgT3urGQFKRNoBo1tKoWiw==",
+      "version": "1.1044.0",
+      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1044.0.tgz",
+      "integrity": "sha512-mi9kF6tAPZFj1USYFJoAYxFUE4z/J2ZMJ0D8cXqlMIBewrR+r3RIBI3CNQfsOHvoWhfHZaVNh392TVAtIL2V2Q==",
       "dev": true
     },
     "sort-keys": {
@@ -24700,9 +24704,9 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "uglify-js": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.3.tgz",
-      "integrity": "sha512-JmMFDME3iufZnBpyKL+uS78LRiC+mK55zWfM5f/pWBJfpOttXAqYfdDGRukYhJuyRinvPVAtUhvy7rlDybNtFg==",
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
       "dev": true
     },
     "umd": {

--- a/package.json
+++ b/package.json
@@ -99,6 +99,6 @@
   "snyk": true,
   "dependencies": {
     "@uswds/compile": "^1.0.0-beta.3",
-    "@uswds/uswds": "^3.2.0"
+    "@uswds/uswds": "github:uswds/uswds#al-pa11y3-errors"
   }
 }

--- a/package.json
+++ b/package.json
@@ -99,6 +99,6 @@
   "snyk": true,
   "dependencies": {
     "@uswds/compile": "^1.0.0-beta.3",
-    "@uswds/uswds": "github:uswds/uswds#al-pa11y3-errors"
+    "@uswds/uswds": "3.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -99,6 +99,6 @@
   "snyk": true,
   "dependencies": {
     "@uswds/compile": "^1.0.0-beta.3",
-    "@uswds/uswds": "3.2.0"
+    "@uswds/uswds": "^3.2.0"
   }
 }

--- a/pages/whats-new/overview.md
+++ b/pages/whats-new/overview.md
@@ -32,7 +32,7 @@ You can read some older posts on the [18F Blog](https://18f.gsa.gov/tags/web-des
 
 Interested in seeing who else is using USWDS? We
 maintain a list of sites in our GitHub repo. Feel free to
-[open an issue](https://github.com/uswds/uswds-assets/issues/new) using GitHub
+[open an issue](https://github.com/uswds/uswds/issues/new) using GitHub
 or [email us](mailto:{{ site.uswds_email }}) if you’d like to add your
 project to our list.
 


### PR DESCRIPTION
## Summary
Resolved a couple of errors that appeared in `html-proofer` and after the test upgrade to pa11y-ci v3.0 (This upgrade has not been included in this PR). 

## Related issue
Closes [#1860](https://github.com/uswds/uswds-site/issues/1860)

## Preview link
Preview links:
- [Data Visualizations - Bar charts](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-fix-pa11y3-errors/components/data-visualizations/#bar-charts)
- [What's New ](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-fix-pa11y3-errors/about/whats-new/)

## Problem statement
Tests to upgrade to pa11y-ci 3 revealed a new valid aria error:
![image](https://user-images.githubusercontent.com/93996430/198736345-290a8e1c-7c5f-40ac-93d8-64241468ecbd.png)

html-proofer returned the error:
```
For the Links > External check, the following failures were found:
* At ./_site/about/whats-new/index.html:2440:
 External link https://github.com/uswds/uswds-assets/issues/new failed (status code 404)
HTML-Proofer found 1 failure!
```

## Solution
- On [Data Visualizations](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-fix-pa11y3-errors/components/data-visualizations/#bar-charts) page, connected `aria-describedby` to the appropriate related `id`.
- On [What's new](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-fix-pa11y3-errors/about/whats-new/) page, updated a broken link.

## Testing and review
Confirm that the updated items continue to work as expected and that tests complete without error. 