### PR TITLE
USWDS-Site - Changelog: Add group 3 changelog items

### DIFF
--- a/_components/sidenav/sidenav.md
+++ b/_components/sidenav/sidenav.md
@@ -18,6 +18,8 @@ subnav:
   href: '#side-navigation-guidance'
 - text: Package
   href: '#side-navigation-package'
+- text: Latest updates
+  href: '#side-navigation-changelog'
 tags:
   - sidenav
   - nav

--- a/_components/site-alert/site-alert.md
+++ b/_components/site-alert/site-alert.md
@@ -20,6 +20,8 @@ subnav:
   href: '#site-alert-guidance'
 - text: Package
   href: '#site-alert-package'
+- text: Latest updates
+  href: '#site-alert-changelog'
 tags:
   - warning
   - bar

--- a/_components/step-indicator/step-indicator.md
+++ b/_components/step-indicator/step-indicator.md
@@ -26,6 +26,8 @@ subnav:
   href: '#step-indicator-guidance'
 - text: Package
   href: '#step-indicator-package'
+- text: Latest updates
+  href: '#step-indicator-changelog'
 tags:
   - stepper
   - step by step

--- a/_components/summary-box/summary-box.md
+++ b/_components/summary-box/summary-box.md
@@ -15,6 +15,8 @@ subnav:
   href: '#summary-box-guidance'
 - text: Package
   href: '#summary-box-package'
+- text: Latest updates
+  href: '#summary-box-changelog'
 tags:
   - tldr
   - tl;dr

--- a/_components/table/table.md
+++ b/_components/table/table.md
@@ -23,6 +23,8 @@ subnav:
   href: '#table-guidance'
 - text: Package
   href: '#table-package'
+- text: Latest updates
+  href: '#table-changelog'
 tags:
   - table
   - zebra stripes

--- a/_components/tag/tag.md
+++ b/_components/tag/tag.md
@@ -20,6 +20,8 @@ subnav:
   href: '#tag-guidance'
 - text: Package
   href: '#tag-package'
+- text: Latest updates
+  href: '#tag-changelog'
 tags:
   - label
   - lable
@@ -28,4 +30,3 @@ variants:
   - variant: "`usa-tag--big`"
     description: A tag with increased padding and font size.
 ---
-

--- a/_components/text-input/text-input.md
+++ b/_components/text-input/text-input.md
@@ -19,6 +19,8 @@ subnav:
   href: '#text-input-guidance'
 - text: Package
   href: '#text-input-package'
+- text: Latest updates
+  href: '#text-input-changelog'
 tags:
   - input
   - box
@@ -31,4 +33,3 @@ variants:
   - variant: "`usa-input--[width]`"
     description: Displays an input at a specific width. Accepts `2xs` (4ex), `xs` (7ex), `sm` or `small` (10ex), `md` or `medium` (20ex), `lg` (30ex), `xl` (40ex), and `2xl` (50ex).
 ---
-

--- a/_components/time-picker/time-picker.md
+++ b/_components/time-picker/time-picker.md
@@ -44,6 +44,8 @@ subnav:
   href: '#time-picker-guidance'
 - text: Package
   href: '#time-picker-package'
+- text: Latest updates
+  href: '#time-picker-changelog'
 tags:
   - input
   - box

--- a/_components/tooltip/tooltip.md
+++ b/_components/tooltip/tooltip.md
@@ -17,4 +17,6 @@ subnav:
   href: '#tooltip-guidance'
 - text: Package
   href: '#tooltip-package'
+- text: Latest updates
+  href: '#tooltip-changelog'
 ---

--- a/_components/typography/typography.md
+++ b/_components/typography/typography.md
@@ -15,6 +15,8 @@ subnav:
     href: '#typesetting-with-uswds'
   - text: Included typefaces
     href: '#included-typefaces'
+  - text: Latest updates
+    href: '#typography-changelog'
 tags:
   - type
   - typesetting

--- a/_components/validation/validation.md
+++ b/_components/validation/validation.md
@@ -17,6 +17,8 @@ subnav:
     href: '#validation-guidance'
   - text: Package
     href: '#validation-package'
+  - text: Latest updates
+    href: '#validation-changelog'
 tags:
   - forms
   - error

--- a/_data/changelogs/side-navigation.yml
+++ b/_data/changelogs/side-navigation.yml
@@ -41,6 +41,7 @@ items:
 - date: 2022-04-28
   summary: USWDS 3.0.0 released.
   summaryAdditional: USWDS 3.0 allows teams to update their projects to modern Sass syntax, improve performance, and reduce the size of project CSS.
+  isBreaking: false
   affectsAccessibility: true
   affectsAssets: true
   affectsGuidance: true

--- a/_data/changelogs/side-navigation.yml
+++ b/_data/changelogs/side-navigation.yml
@@ -19,4 +19,48 @@ changelogURL:
   #   githubPr:
   #   githubRepo:
   #   versionUswds:
-# end changelog item
+
+items:
+  # 3.1.0 release
+- date: 2022-08-05
+  summary: |-
+    Non-form buttons inside of usa-sidenav require `type="button"` to prevent default `submit` behaviors.
+  summaryAdditional: |-
+    This allowed us to remove `preventDefault()` to relevant components.
+  isBreaking: true
+  affectsAccessibility: true
+  affectsAssets: false
+  affectsGuidance: true
+  affectsJavascript: true
+  affectsMarkup: true
+  affectsStyles: false
+  githubPr: 4695
+  githubRepo: uswds
+  versionUswds: 3.1.0
+  # 3.0 release
+- date: 2022-04-28
+  summary: USWDS 3.0.0 released.
+  summaryAdditional: USWDS 3.0 allows teams to update their projects to modern Sass syntax, improve performance, and reduce the size of project CSS.
+  affectsAccessibility: true
+  affectsAssets: true
+  affectsGuidance: true
+  affectsJavascript: true
+  affectsMarkup: true
+  affectsStyles: true
+  githubPr: 4656
+  githubRepo: uswds
+  versionUswds: 3.0.0
+  # 2.11.2 release
+- date: 2021-04-28
+  summary: Fixed color of active parents in side navigation.
+  summaryAdditional: Fixed a regression where parent items in usa-sidenav no longer receive `primary` color.
+  isBreaking: false
+  affectsAccessibility: false
+  affectsAssets: false
+  affectsGuidance: false
+  affectsJavascript: false
+  affectsMarkup: false
+  affectsStyles: true
+  githubPr: 4163
+  githubRepo: uswds
+  versionUswds: 2.11.2

--- a/_data/changelogs/side-navigation.yml
+++ b/_data/changelogs/side-navigation.yml
@@ -39,9 +39,9 @@ items:
   versionUswds: 3.1.0
   # 3.0 release
 - date: 2022-04-28
-  summary: USWDS 3.0.0 released.
+  summary: Released USWDS 3.0.
   summaryAdditional: USWDS 3.0 allows teams to update their projects to modern Sass syntax, improve performance, and reduce the size of project CSS.
-  isBreaking: false
+  isBreaking: true
   affectsAccessibility: true
   affectsAssets: true
   affectsGuidance: true

--- a/_data/changelogs/site-alert.yml
+++ b/_data/changelogs/site-alert.yml
@@ -33,3 +33,37 @@ items:
     githubPr: 4656
     githubRepo: uswds
     versionUswds: 3.0.0
+  # 2.11.1
+  - date: 2021-03-17
+    summary: Restored missing white icons.
+    summaryAdditional: Restored <code>error--white</code>, <code>info--white</code>, and <code>warning--white</code> icons.
+    affectsAssets: true
+    githubPr: 4106
+    githubRepo: uswds
+    versionUswds: 2.11.1
+  # 2.11.0
+  - date: 2021-03-17
+    summary: Provided better support for color icons that adapt to theme settings.
+    summaryAdditional: Now the color of the alert icon will update automatically to adapt to the alert background, or to the color of the alert text.
+    affectsAccessibility: false
+    affectsAssets: true
+    affectsGuidance: false
+    affectsJavascript: false
+    affectsMarkup: false
+    affectsStyles: true
+    githubPr: 4079
+    githubRepo: uswds
+    versionUswds: 2.11.0
+  # 2.11.0
+  - date: 2021-03-17
+    summary: Added the <code>$theme-alert-padding-y</code> setting.
+    summaryAdditional:
+    affectsAccessibility: false
+    affectsAssets: false
+    affectsGuidance: false
+    affectsJavascript: false
+    affectsMarkup: false
+    affectsStyles: true
+    githubPr: 4079
+    githubRepo: uswds
+    versionUswds: 2.11.0

--- a/_data/changelogs/site-alert.yml
+++ b/_data/changelogs/site-alert.yml
@@ -21,9 +21,9 @@ items:
     versionUswds: 3.2.0
   # 3.0 release
   - date: 2022-04-28
-    summary: USWDS 3.0.0 released.
+    summary: Released USWDS 3.0.
     summaryAdditional: USWDS 3.0 allows teams to update their projects to modern Sass syntax, improve performance, and reduce the size of project CSS.
-    isBreaking: false
+    isBreaking: true
     affectsAccessibility: true
     affectsAssets: true
     affectsGuidance: true

--- a/_data/changelogs/site-alert.yml
+++ b/_data/changelogs/site-alert.yml
@@ -21,7 +21,7 @@ changelogURL:
   #   versionUswds:
 
 items:
-  # 3.1.0 release
+  # 3.2.0 release
   - date: 2022-10-19
     summary: Updated the alignment of site alert content to visually match alignment with banner content.
     summaryAdditional: The alert component was also updated to match banner content alignment.
@@ -34,7 +34,7 @@ items:
     affectsStyles: true
     githubPr: 4922
     githubRepo: uswds
-    versionUswds: 3.1.0
+    versionUswds: 3.2.0
   # 3.0 release
   - date: 2022-04-28
     summary: USWDS 3.0.0 released.

--- a/_data/changelogs/site-alert.yml
+++ b/_data/changelogs/site-alert.yml
@@ -39,6 +39,7 @@ items:
   - date: 2022-04-28
     summary: USWDS 3.0.0 released.
     summaryAdditional: USWDS 3.0 allows teams to update their projects to modern Sass syntax, improve performance, and reduce the size of project CSS.
+    isBreaking: false
     affectsAccessibility: true
     affectsAssets: true
     affectsGuidance: true

--- a/_data/changelogs/site-alert.yml
+++ b/_data/changelogs/site-alert.yml
@@ -3,22 +3,6 @@ title: Site alert
 type: component
 # Provide url for the package CHANGELOG.md. Note: Not all pages will have a related CHANGELOG.md file.
 changelogURL:
-# Add a list of changelog items with newest items first. Uncomment the 'items' data field when adding the first item.
-# Start changelog item. Copy this section to create a new changelog item.
-# items:
-  # - date:
-  #   summary:
-  #   summaryAdditional:
-  #   isBreaking:
-  #   affectsAccessibility:
-  #   affectsAssets:
-  #   affectsGuidance:
-  #   affectsJavascript:
-  #   affectsMarkup:
-  #   affectsStyles:
-  #   githubPr:
-  #   githubRepo:
-  #   versionUswds:
 
 items:
   # 3.2.0 release

--- a/_data/changelogs/site-alert.yml
+++ b/_data/changelogs/site-alert.yml
@@ -19,4 +19,32 @@ changelogURL:
   #   githubPr:
   #   githubRepo:
   #   versionUswds:
-# end changelog item
+
+items:
+  # 3.1.0 release
+  - date: 2022-10-19
+    summary: Updated the alignment of site alert content to visually match alignment with banner content.
+    summaryAdditional: The alert component was also updated to match banner content alignment.
+    isBreaking: false
+    affectsAccessibility: false
+    affectsAssets: false
+    affectsGuidance: false
+    affectsJavascript: false
+    affectsMarkup: false
+    affectsStyles: true
+    githubPr: 4922
+    githubRepo: uswds
+    versionUswds: 3.1.0
+  # 3.0 release
+  - date: 2022-04-28
+    summary: USWDS 3.0.0 released.
+    summaryAdditional: USWDS 3.0 allows teams to update their projects to modern Sass syntax, improve performance, and reduce the size of project CSS.
+    affectsAccessibility: true
+    affectsAssets: true
+    affectsGuidance: true
+    affectsJavascript: true
+    affectsMarkup: true
+    affectsStyles: true
+    githubPr: 4656
+    githubRepo: uswds
+    versionUswds: 3.0.0

--- a/_data/changelogs/step-indicator.yml
+++ b/_data/changelogs/step-indicator.yml
@@ -3,22 +3,6 @@ title: Step indicator
 type: component
 # Provide url for the package CHANGELOG.md. Note: Not all pages will have a related CHANGELOG.md file.
 changelogURL:
-# Add a list of changelog items with newest items first. Uncomment the 'items' data field when adding the first item.
-# Start changelog item. Copy this section to create a new changelog item.
-# items:
-  # - date:
-  #   summary:
-  #   summaryAdditional:
-  #   isBreaking:
-  #   affectsAccessibility:
-  #   affectsAssets:
-  #   affectsGuidance:
-  #   affectsJavascript:
-  #   affectsMarkup:
-  #   affectsStyles:
-  #   githubPr:
-  #   githubRepo:
-  #   versionUswds:
 
 items:
   # 3.0 release

--- a/_data/changelogs/step-indicator.yml
+++ b/_data/changelogs/step-indicator.yml
@@ -7,9 +7,9 @@ changelogURL:
 items:
   # 3.0 release
   - date: 2022-04-28
-    summary: USWDS 3.0.0 released.
+    summary: Released USWDS 3.0.
     summaryAdditional: USWDS 3.0 allows teams to update their projects to modern Sass syntax, improve performance, and reduce the size of project CSS.
-    isBreaking: false
+    isBreaking: true
     affectsAccessibility: true
     affectsAssets: true
     affectsGuidance: true

--- a/_data/changelogs/step-indicator.yml
+++ b/_data/changelogs/step-indicator.yml
@@ -19,4 +19,18 @@ changelogURL:
   #   githubPr:
   #   githubRepo:
   #   versionUswds:
-# end changelog item
+
+items:
+  # 3.0 release
+  - date: 2022-04-28
+    summary: USWDS 3.0.0 released.
+    summaryAdditional: USWDS 3.0 allows teams to update their projects to modern Sass syntax, improve performance, and reduce the size of project CSS.
+    affectsAccessibility: true
+    affectsAssets: true
+    affectsGuidance: true
+    affectsJavascript: true
+    affectsMarkup: true
+    affectsStyles: true
+    githubPr: 4656
+    githubRepo: uswds
+    versionUswds: 3.0.0

--- a/_data/changelogs/step-indicator.yml
+++ b/_data/changelogs/step-indicator.yml
@@ -25,6 +25,7 @@ items:
   - date: 2022-04-28
     summary: USWDS 3.0.0 released.
     summaryAdditional: USWDS 3.0 allows teams to update their projects to modern Sass syntax, improve performance, and reduce the size of project CSS.
+    isBreaking: false
     affectsAccessibility: true
     affectsAssets: true
     affectsGuidance: true

--- a/_data/changelogs/summary-box.yml
+++ b/_data/changelogs/summary-box.yml
@@ -20,3 +20,31 @@ changelogURL:
   #   githubRepo:
   #   versionUswds:
 # end changelog item
+
+items:
+  # 3.0 release
+  - date: 2022-04-28
+    summary: USWDS 3.0.0 released.
+    summaryAdditional: USWDS 3.0 allows teams to update their projects to modern Sass syntax, improve performance, and reduce the size of project CSS.
+    affectsAccessibility: true
+    affectsAssets: true
+    affectsGuidance: true
+    affectsJavascript: true
+    affectsMarkup: true
+    affectsStyles: true
+    githubPr: 4656
+    githubRepo: uswds
+    versionUswds: 3.0.0
+  # 2.11.2 release
+  - date: 2021-04-28
+    summary: Added missing Summary box SASS package.
+    summaryAdditional:
+    affectsAccessibility: false
+    affectsAssets: true
+    affectsGuidance: true
+    affectsJavascript: false
+    affectsMarkup: false
+    affectsStyles: false
+    githubPr: 4162
+    githubRepo: uswds
+    versionUswds: 2.11.2

--- a/_data/changelogs/summary-box.yml
+++ b/_data/changelogs/summary-box.yml
@@ -4,22 +4,6 @@ type: component
 # Provide url for the package CHANGELOG.md. Note: Not all pages will have a related CHANGELOG.md file.
 changelogURL:
 # Add a list of changelog items with newest items first. Uncomment the 'items' data field when adding the first item.
-# Start changelog item. Copy this section to create a new changelog item.
-# items:
-  # - date:
-  #   summary:
-  #   summaryAdditional:
-  #   isBreaking:
-  #   affectsAccessibility:
-  #   affectsAssets:
-  #   affectsGuidance:
-  #   affectsJavascript:
-  #   affectsMarkup:
-  #   affectsStyles:
-  #   githubPr:
-  #   githubRepo:
-  #   versionUswds:
-# end changelog item
 
 items:
   # 3.0 release

--- a/_data/changelogs/summary-box.yml
+++ b/_data/changelogs/summary-box.yml
@@ -26,6 +26,7 @@ items:
   - date: 2022-04-28
     summary: USWDS 3.0.0 released.
     summaryAdditional: USWDS 3.0 allows teams to update their projects to modern Sass syntax, improve performance, and reduce the size of project CSS.
+    isBreaking: false
     affectsAccessibility: true
     affectsAssets: true
     affectsGuidance: true
@@ -39,6 +40,7 @@ items:
   - date: 2021-04-28
     summary: Added missing Summary box SASS package.
     summaryAdditional:
+    isBreaking: false
     affectsAccessibility: false
     affectsAssets: true
     affectsGuidance: true

--- a/_data/changelogs/summary-box.yml
+++ b/_data/changelogs/summary-box.yml
@@ -8,9 +8,9 @@ changelogURL:
 items:
   # 3.0 release
   - date: 2022-04-28
-    summary: USWDS 3.0.0 released.
+    summary: Released USWDS 3.0.
     summaryAdditional: USWDS 3.0 allows teams to update their projects to modern Sass syntax, improve performance, and reduce the size of project CSS.
-    isBreaking: false
+    isBreaking: true
     affectsAccessibility: true
     affectsAssets: true
     affectsGuidance: true

--- a/_data/changelogs/table.yml
+++ b/_data/changelogs/table.yml
@@ -21,9 +21,9 @@ items:
     versionUswds: 3.0.2
   # 3.0 release
   - date: 2022-04-28
-    summary: USWDS 3.0.0 released.
+    summary: Released USWDS 3.0.
     summaryAdditional: USWDS 3.0 allows teams to update their projects to modern Sass syntax, improve performance, and reduce the size of project CSS.
-    isBreaking: false
+    isBreaking: true
     affectsAccessibility: true
     affectsAssets: true
     affectsGuidance: true

--- a/_data/changelogs/table.yml
+++ b/_data/changelogs/table.yml
@@ -47,3 +47,17 @@ items:
     githubPr: 3950
     githubRepo: uswds
     versionUswds: 2.11.0
+  - date: 2021-03-17
+    summary: Updated default values for table settings.
+    summaryAdditional: Changed values of <code>$theme-table-border-color</code>, <code>$theme-table-header-text-color</code>, <code>$theme-table-stripe-text-color</code>, and <code>$theme-table-text-color</code> from <code>default</code> to <code>"ink"</code>.
+    affectsStyles: true
+    githubPr: 3950
+    githubRepo: uswds
+    versionUswds: 2.11.0
+  - date: 2021-03-17
+    summary: Added new table settings. 
+    summaryAdditional: Added <code>$theme-table-sorted-header-background-color</code>, <code>$theme-table-sorted-background-color</code>, <code>$theme-table-sorted-stripe-background-color</code>, and <code>$theme-table-sorted-icon-color</code>, and <code>$theme-table-unsorted-icon-color</code> .
+    affectsStyles: true
+    githubPr: 3950
+    githubRepo: uswds
+    versionUswds: 2.11.0

--- a/_data/changelogs/table.yml
+++ b/_data/changelogs/table.yml
@@ -39,6 +39,7 @@ items:
   - date: 2022-04-28
     summary: USWDS 3.0.0 released.
     summaryAdditional: USWDS 3.0 allows teams to update their projects to modern Sass syntax, improve performance, and reduce the size of project CSS.
+    isBreaking: false
     affectsAccessibility: true
     affectsAssets: true
     affectsGuidance: true
@@ -52,6 +53,7 @@ items:
   - date: 2021-03-17
     summary: Sortable table is released.
     summaryAdditional: A sorted column changes the row ordering based on alphabetical or numeric cell values.
+    isBreaking: false
     affectsAccessibility: false
     affectsAssets: false
     affectsGuidance: true

--- a/_data/changelogs/table.yml
+++ b/_data/changelogs/table.yml
@@ -19,4 +19,45 @@ changelogURL:
   #   githubPr:
   #   githubRepo:
   #   versionUswds:
-# end changelog item
+
+items:
+  # 3.0.2 release
+  - date: 2022-06-17
+    summary: Table border settings work as expected.
+    summaryAdditional: Theme table settings are now consistently applied to table styles.
+    isBreaking: false
+    affectsAccessibility: false
+    affectsAssets: false
+    affectsGuidance: false
+    affectsJavascript: false
+    affectsMarkup: false
+    affectsStyles: true
+    githubPr: 4712
+    githubRepo: uswds
+    versionUswds: 3.0.2
+  # 3.0 release
+  - date: 2022-04-28
+    summary: USWDS 3.0.0 released.
+    summaryAdditional: USWDS 3.0 allows teams to update their projects to modern Sass syntax, improve performance, and reduce the size of project CSS.
+    affectsAccessibility: true
+    affectsAssets: true
+    affectsGuidance: true
+    affectsJavascript: true
+    affectsMarkup: true
+    affectsStyles: true
+    githubPr: 4656
+    githubRepo: uswds
+    versionUswds: 3.0.0
+  # 2.11.0 release
+  - date: 2021-03-17
+    summary: Sortable table is released.
+    summaryAdditional: A sorted column changes the row ordering based on alphabetical or numeric cell values.
+    affectsAccessibility: false
+    affectsAssets: false
+    affectsGuidance: true
+    affectsJavascript: true
+    affectsMarkup: true
+    affectsStyles: true
+    githubPr: 3950
+    githubRepo: uswds
+    versionUswds: 2.11.0

--- a/_data/changelogs/table.yml
+++ b/_data/changelogs/table.yml
@@ -3,22 +3,6 @@ title: Table
 type: component
 # Provide url for the package CHANGELOG.md. Note: Not all pages will have a related CHANGELOG.md file.
 changelogURL:
-# Add a list of changelog items with newest items first. Uncomment the 'items' data field when adding the first item.
-# Start changelog item. Copy this section to create a new changelog item.
-# items:
-  # - date:
-  #   summary:
-  #   summaryAdditional:
-  #   isBreaking:
-  #   affectsAccessibility:
-  #   affectsAssets:
-  #   affectsGuidance:
-  #   affectsJavascript:
-  #   affectsMarkup:
-  #   affectsStyles:
-  #   githubPr:
-  #   githubRepo:
-  #   versionUswds:
 
 items:
   # 3.0.2 release

--- a/_data/changelogs/tag.yml
+++ b/_data/changelogs/tag.yml
@@ -3,22 +3,6 @@ title: Tag
 type: component
 # Provide url for the package CHANGELOG.md. Note: Not all pages will have a related CHANGELOG.md file.
 changelogURL:
-# Add a list of changelog items with newest items first. Uncomment the 'items' data field when adding the first item.
-# Start changelog item. Copy this section to create a new changelog item.
-# items:
-  # - date:
-  #   summary:
-  #   summaryAdditional:
-  #   isBreaking:
-  #   affectsAccessibility:
-  #   affectsAssets:
-  #   affectsGuidance:
-  #   affectsJavascript:
-  #   affectsMarkup:
-  #   affectsStyles:
-  #   githubPr:
-  #   githubRepo:
-  #   versionUswds:
 
 items:
   # 3.0 release

--- a/_data/changelogs/tag.yml
+++ b/_data/changelogs/tag.yml
@@ -7,9 +7,9 @@ changelogURL:
 items:
   # 3.0 release
   - date: 2022-04-28
-    summary: USWDS 3.0.0 released.
+    summary: Released USWDS 3.0.
     summaryAdditional: USWDS 3.0 allows teams to update their projects to modern Sass syntax, improve performance, and reduce the size of project CSS.
-    isBreaking: false
+    isBreaking: true
     affectsAccessibility: true
     affectsAssets: true
     affectsGuidance: true

--- a/_data/changelogs/tag.yml
+++ b/_data/changelogs/tag.yml
@@ -19,4 +19,19 @@ changelogURL:
   #   githubPr:
   #   githubRepo:
   #   versionUswds:
-# end changelog item
+
+items:
+  # 3.0 release
+  - date: 2022-04-28
+    summary: USWDS 3.0.0 released.
+    summaryAdditional: USWDS 3.0 allows teams to update their projects to modern Sass syntax, improve performance, and reduce the size of project CSS.
+    isBreaking: false
+    affectsAccessibility: true
+    affectsAssets: true
+    affectsGuidance: true
+    affectsJavascript: true
+    affectsMarkup: true
+    affectsStyles: true
+    githubPr: 4656
+    githubRepo: uswds
+    versionUswds: 3.0.0

--- a/_data/changelogs/text-input.yml
+++ b/_data/changelogs/text-input.yml
@@ -21,8 +21,9 @@ items:
     versionUswds: 3.0.2
   # 3.0 release
   - date: 2022-04-28
-    summary: USWDS 3.0.0 released.
+    summary: Released USWDS 3.0.
     summaryAdditional: USWDS 3.0 allows teams to update their projects to modern Sass syntax, improve performance, and reduce the size of project CSS.
+    isBreaking: true
     affectsAccessibility: true
     affectsAssets: true
     affectsGuidance: true

--- a/_data/changelogs/text-input.yml
+++ b/_data/changelogs/text-input.yml
@@ -3,22 +3,6 @@ title: Text input
 type: component
 # Provide url for the package CHANGELOG.md. Note: Not all pages will have a related CHANGELOG.md file.
 changelogURL:
-# Add a list of changelog items with newest items first. Uncomment the 'items' data field when adding the first item.
-# Start changelog item. Copy this section to create a new changelog item.
-# items:
-  # - date:
-  #   summary:
-  #   summaryAdditional:
-  #   isBreaking:
-  #   affectsAccessibility:
-  #   affectsAssets:
-  #   affectsGuidance:
-  #   affectsJavascript:
-  #   affectsMarkup:
-  #   affectsStyles:
-  #   githubPr:
-  #   githubRepo:
-  #   versionUswds:
 
 items:
   # 3.0.2 release

--- a/_data/changelogs/text-input.yml
+++ b/_data/changelogs/text-input.yml
@@ -19,4 +19,32 @@ changelogURL:
   #   githubPr:
   #   githubRepo:
   #   versionUswds:
-# end changelog item
+
+items:
+  # 3.0.2 release
+  - date: 2022-06-17
+    summary: Improved form group error display.
+    summaryAdditional: Form group margins are the same whether or not the form group is in an error state.
+    isBreaking: false
+    affectsAccessibility: false
+    affectsAssets: false
+    affectsGuidance: false
+    affectsJavascript: false
+    affectsMarkup: false
+    affectsStyles: true
+    githubPr: 4751
+    githubRepo: uswds
+    versionUswds: 3.0.2
+  # 3.0 release
+  - date: 2022-04-28
+    summary: USWDS 3.0.0 released.
+    summaryAdditional: USWDS 3.0 allows teams to update their projects to modern Sass syntax, improve performance, and reduce the size of project CSS.
+    affectsAccessibility: true
+    affectsAssets: true
+    affectsGuidance: true
+    affectsJavascript: true
+    affectsMarkup: true
+    affectsStyles: true
+    githubPr: 4656
+    githubRepo: uswds
+    versionUswds: 3.0.0

--- a/_data/changelogs/time-picker.yml
+++ b/_data/changelogs/time-picker.yml
@@ -3,22 +3,6 @@ title: Time picker
 type: component
 # Provide url for the package CHANGELOG.md. Note: Not all pages will have a related CHANGELOG.md file.
 changelogURL:
-# Add a list of changelog items with newest items first. Uncomment the 'items' data field when adding the first item.
-# Start changelog item. Copy this section to create a new changelog item.
-# items:
-  # - date:
-  #   summary:
-  #   summaryAdditional:
-  #   isBreaking:
-  #   affectsAccessibility:
-  #   affectsAssets:
-  #   affectsGuidance:
-  #   affectsJavascript:
-  #   affectsMarkup:
-  #   affectsStyles:
-  #   githubPr:
-  #   githubRepo:
-  #   versionUswds:
 
 items:
   # 3.0 release

--- a/_data/changelogs/time-picker.yml
+++ b/_data/changelogs/time-picker.yml
@@ -19,4 +19,32 @@ changelogURL:
   #   githubPr:
   #   githubRepo:
   #   versionUswds:
-# end changelog item
+
+items:
+  # 3.0 release
+  - date: 2022-04-28
+    summary: USWDS 3.0.0 released.
+    summaryAdditional: USWDS 3.0 allows teams to update their projects to modern Sass syntax, improve performance, and reduce the size of project CSS.
+    affectsAccessibility: true
+    affectsAssets: true
+    affectsGuidance: true
+    affectsJavascript: true
+    affectsMarkup: true
+    affectsStyles: true
+    githubPr: 4656
+    githubRepo: uswds
+    versionUswds: 3.0.0
+  # 2.13.3
+  - date: 2022-04-11
+    summary: Allow default `value` in Time picker.
+    summaryAdditional: The input `value` is now used on initialization if set.
+    isBreaking: false
+    affectsAccessibility: false
+    affectsAssets: false
+    affectsGuidance: true
+    affectsJavascript: true
+    affectsMarkup: true
+    affectsStyles: false
+    githubPr: 4488
+    githubRepo: uswds
+    versionUswds: 2.13.3

--- a/_data/changelogs/time-picker.yml
+++ b/_data/changelogs/time-picker.yml
@@ -7,8 +7,9 @@ changelogURL:
 items:
   # 3.0 release
   - date: 2022-04-28
-    summary: USWDS 3.0.0 released.
+    summary: Released USWDS 3.0.
     summaryAdditional: USWDS 3.0 allows teams to update their projects to modern Sass syntax, improve performance, and reduce the size of project CSS.
+    isBreaking: true
     affectsAccessibility: true
     affectsAssets: true
     affectsGuidance: true

--- a/_data/changelogs/tooltip.yml
+++ b/_data/changelogs/tooltip.yml
@@ -3,22 +3,6 @@ title: Tooltip
 type: component
 # Provide url for the package CHANGELOG.md. Note: Not all pages will have a related CHANGELOG.md file.
 changelogURL:
-# Add a list of changelog items with newest items first. Uncomment the 'items' data field when adding the first item.
-# Start changelog item. Copy this section to create a new changelog item.
-# items:
-  # - date:
-  #   summary:
-  #   summaryAdditional:
-  #   isBreaking:
-  #   affectsAccessibility:
-  #   affectsAssets:
-  #   affectsGuidance:
-  #   affectsJavascript:
-  #   affectsMarkup:
-  #   affectsStyles:
-  #   githubPr:
-  #   githubRepo:
-  #   versionUswds:
 
 items:
   # 3.2.0 release

--- a/_data/changelogs/tooltip.yml
+++ b/_data/changelogs/tooltip.yml
@@ -19,4 +19,31 @@ changelogURL:
   #   githubPr:
   #   githubRepo:
   #   versionUswds:
-# end changelog item
+
+items:
+  # 3.2.0 release
+  - date: 2022-10-19
+    summary: Tooltip allows for dynamic initialization.
+    summaryAdditional: Tooltip initializes on first interaction and checks if component has been initialized before toggling. If it hasn't initialized properly it will call a setup attributes function.
+    affectsAccessibility: false
+    affectsAssets: false
+    affectsGuidance: false
+    affectsJavascript: true
+    affectsMarkup: false
+    affectsStyles: true
+    githubPr: 4955
+    githubRepo: uswds
+    versionUswds: 3.2.0
+  # 3.0 release
+  - date: 2022-04-28
+    summary: USWDS 3.0.0 released.
+    summaryAdditional: USWDS 3.0 allows teams to update their projects to modern Sass syntax, improve performance, and reduce the size of project CSS.
+    affectsAccessibility: true
+    affectsAssets: true
+    affectsGuidance: true
+    affectsJavascript: true
+    affectsMarkup: true
+    affectsStyles: true
+    githubPr: 4656
+    githubRepo: uswds
+    versionUswds: 3.0.0

--- a/_data/changelogs/tooltip.yml
+++ b/_data/changelogs/tooltip.yml
@@ -20,8 +20,9 @@ items:
     versionUswds: 3.2.0
   # 3.0 release
   - date: 2022-04-28
-    summary: USWDS 3.0.0 released.
+    summary: Released USWDS 3.0.
     summaryAdditional: USWDS 3.0 allows teams to update their projects to modern Sass syntax, improve performance, and reduce the size of project CSS.
+    isBreaking: true
     affectsAccessibility: true
     affectsAssets: true
     affectsGuidance: true

--- a/_data/changelogs/tooltip.yml
+++ b/_data/changelogs/tooltip.yml
@@ -47,3 +47,20 @@ items:
     githubPr: 4656
     githubRepo: uswds
     versionUswds: 3.0.0
+  # 2.12.2
+  - date: 2021-11-01
+    summary: Added automatic sanitizing.
+    summaryAdditional: The design system now automatically sanitizes content in elements we compose with JavaScript. This means that components like Combobox, Tooltip, File Input, and Date Picker will sanitize any content passed to them. This helps protect any design system implementation against malicious XSS attacks through these components.
+    affectsJavascript: true
+    githubPr: 4329
+    githubRepo: uswds
+    versionUswds: 2.12.2
+  # 2.11.0
+  - date: 2021-03-17
+    summary: Fixed tooltip positioning.
+    summaryAdditional: We fixed an issue that prevented some longer tooltips in some positions to display incorrectly.
+    affectsJavascript: true
+    affectsStyles: true
+    githubPr: 4062
+    githubRepo: uswds
+    versionUswds: 2.11.0

--- a/_data/changelogs/tooltip.yml
+++ b/_data/changelogs/tooltip.yml
@@ -30,7 +30,7 @@ items:
     affectsGuidance: false
     affectsJavascript: true
     affectsMarkup: false
-    affectsStyles: true
+    affectsStyles: false
     githubPr: 4955
     githubRepo: uswds
     versionUswds: 3.2.0

--- a/_data/changelogs/typography.yml
+++ b/_data/changelogs/typography.yml
@@ -2,22 +2,6 @@ title: Typography
 type: component
 # Provide url for the package CHANGELOG.md. Note: Not all pages will have a related CHANGELOG.md file.
 changelogURL:
-# Add a list of changelog items with newest items first. Uncomment the 'items' data field when adding the first item.
-# Start changelog item. Copy this section to create a new changelog item.
-# items:
-  # - date:
-  #   summary:
-  #   summaryAdditional:
-  #   isBreaking:
-  #   affectsAccessibility:
-  #   affectsAssets:
-  #   affectsGuidance:
-  #   affectsJavascript:
-  #   affectsMarkup:
-  #   affectsStyles:
-  #   githubPr:
-  #   githubRepo:
-  #   versionUswds:
 
 items:
   # 3.0 release

--- a/_data/changelogs/typography.yml
+++ b/_data/changelogs/typography.yml
@@ -1,0 +1,35 @@
+title: Typography
+type: component
+# Provide url for the package CHANGELOG.md. Note: Not all pages will have a related CHANGELOG.md file.
+changelogURL:
+# Add a list of changelog items with newest items first. Uncomment the 'items' data field when adding the first item.
+# Start changelog item. Copy this section to create a new changelog item.
+# items:
+  # - date:
+  #   summary:
+  #   summaryAdditional:
+  #   isBreaking:
+  #   affectsAccessibility:
+  #   affectsAssets:
+  #   affectsGuidance:
+  #   affectsJavascript:
+  #   affectsMarkup:
+  #   affectsStyles:
+  #   githubPr:
+  #   githubRepo:
+  #   versionUswds:
+
+items:
+  # 3.0 release
+  - date: 2022-04-28
+    summary: USWDS 3.0.0 released.
+    summaryAdditional: USWDS 3.0 allows teams to update their projects to modern Sass syntax, improve performance, and reduce the size of project CSS.
+    affectsAccessibility: true
+    affectsAssets: true
+    affectsGuidance: true
+    affectsJavascript: true
+    affectsMarkup: true
+    affectsStyles: true
+    githubPr: 4656
+    githubRepo: uswds
+    versionUswds: 3.0.0

--- a/_data/changelogs/typography.yml
+++ b/_data/changelogs/typography.yml
@@ -6,8 +6,9 @@ changelogURL:
 items:
   # 3.0 release
   - date: 2022-04-28
-    summary: USWDS 3.0.0 released.
+    summary: Released USWDS 3.0.
     summaryAdditional: USWDS 3.0 allows teams to update their projects to modern Sass syntax, improve performance, and reduce the size of project CSS.
+    isBreaking: true
     affectsAccessibility: true
     affectsAssets: true
     affectsGuidance: true

--- a/_data/changelogs/validation.yml
+++ b/_data/changelogs/validation.yml
@@ -2,22 +2,6 @@ title: Validation
 type: component
 # Provide url for the package CHANGELOG.md. Note: Not all pages will have a related CHANGELOG.md file.
 changelogURL:
-# Add a list of changelog items with newest items first. Uncomment the 'items' data field when adding the first item.
-# Start changelog item. Copy this section to create a new changelog item.
-# items:
-  # - date:
-  #   summary:
-  #   summaryAdditional:
-  #   isBreaking:
-  #   affectsAccessibility:
-  #   affectsAssets:
-  #   affectsGuidance:
-  #   affectsJavascript:
-  #   affectsMarkup:
-  #   affectsStyles:
-  #   githubPr:
-  #   githubRepo:
-  #   versionUswds:
 
 items:
   # 3.2.0 release

--- a/_data/changelogs/validation.yml
+++ b/_data/changelogs/validation.yml
@@ -20,9 +20,9 @@ items:
     versionUswds: 3.2.0
   # 3.0 release
   - date: 2022-04-28
-    summary: USWDS 3.0.0 released.
+    summary: Released USWDS 3.0.
     summaryAdditional: USWDS 3.0 allows teams to update their projects to modern Sass syntax, improve performance, and reduce the size of project CSS.
-    isBreaking: false
+    isBreaking: true
     affectsAccessibility: true
     affectsAssets: true
     affectsGuidance: true

--- a/_data/changelogs/validation.yml
+++ b/_data/changelogs/validation.yml
@@ -1,0 +1,50 @@
+title: Validation
+type: component
+# Provide url for the package CHANGELOG.md. Note: Not all pages will have a related CHANGELOG.md file.
+changelogURL:
+# Add a list of changelog items with newest items first. Uncomment the 'items' data field when adding the first item.
+# Start changelog item. Copy this section to create a new changelog item.
+# items:
+  # - date:
+  #   summary:
+  #   summaryAdditional:
+  #   isBreaking:
+  #   affectsAccessibility:
+  #   affectsAssets:
+  #   affectsGuidance:
+  #   affectsJavascript:
+  #   affectsMarkup:
+  #   affectsStyles:
+  #   githubPr:
+  #   githubRepo:
+  #   versionUswds:
+
+items:
+  # 3.2.0 release
+  - date: 2022-10-19
+    summary: Improved status updates about the completion of validation requirements for users of assistive technologies.
+    summaryAdditional: Component JavaScript generates the appropriate elements and ARIA attributes that help improve the experience of receiving status updates.
+    isBreaking: false
+    affectsAccessibility: true
+    affectsAssets: false
+    affectsGuidance: true
+    affectsJavascript: true
+    affectsMarkup: true
+    affectsStyles: false
+    githubPr: 4914
+    githubRepo: uswds
+    versionUswds: 3.2.0
+  # 3.0 release
+  - date: 2022-04-28
+    summary: USWDS 3.0.0 released.
+    summaryAdditional: USWDS 3.0 allows teams to update their projects to modern Sass syntax, improve performance, and reduce the size of project CSS.
+    isBreaking: false
+    affectsAccessibility: true
+    affectsAssets: true
+    affectsGuidance: true
+    affectsJavascript: true
+    affectsMarkup: true
+    affectsStyles: true
+    githubPr: 4656
+    githubRepo: uswds
+    versionUswds: 3.0.0

--- a/_includes/changelog-table.html
+++ b/_includes/changelog-table.html
@@ -84,11 +84,11 @@
               {% if item.isBreaking %}
                 <span class="display-none tablet:display-inline desktop-lg:display-none output-false">Breaking</span>
               {% endif %}
-              {% if item.summary %}
-              <strong>{{ item.summary }}</strong>
-              {% endif %}
+              <strong>
+                {{ item.summary | markdownify | remove: '<p>' | remove: '</p>' }}
+              </strong>
               {% if item.summaryAdditional %}
-                {{ item.summaryAdditional}}
+                {{ item.summaryAdditional | markdownify | remove: '<p>' | remove: '</p>' }}
               {% endif %}
             </p>
           {% endif %}


### PR DESCRIPTION
## Description

**Added data for group 3 components.** This adds release data to component changelogs from release `3.2.0 → 2.11.0`. Closes #1864.

![image](https://user-images.githubusercontent.com/3385219/199808413-78297f9a-ffb6-48a7-9995-a57ec1a22780.png)

## Additional information

**Group 3 components**
- [Side navigation](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/jm-changelog-group-3/components/side-navigation/)
- [Site alert](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/jm-changelog-group-3/components/site-alert/)
- [Step indicator](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/jm-changelog-group-3/components/step-indicator/)
- [Summary box](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/jm-changelog-group-3/components/summary-box/)
- [Table](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/jm-changelog-group-3/components/table/)
- [Text input](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/jm-changelog-group-3/components/text-input/)
- [Time picker](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/jm-changelog-group-3/components/time-picker/)
- [Tooltip](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/jm-changelog-group-3/components/tooltip/)
- [Typography](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/jm-changelog-group-3/components/typography/)
- [Validation](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/jm-changelog-group-3/components/validation/)

I didn't see [Tag](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/jm-changelog-group-3/components/tag/) listed, but I've added the general release note for 3.0.0

[See all groups in spreadsheet 🔒](https://docs.google.com/spreadsheets/d/16W0IO8gTW3yv47Dy9sUBAkEAkvVzpOYQpg2R9C6CM5s/edit#gid=0)


## How to test
1. Visit component pages above
2. Scroll to end of page
3. Verify new **Latest updates** section is listed
4. Verify **Latest updates** section is visible in component subnav
5. Validate accuracy of data
   1. Release dates should be correct
   2. Versions should be correct
   3. Affected tags are relevant
   4. Breaking changes are documented correctly
   6. Descriptions are unique and free of typo's
   7. Links to PRs are correct

---

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
