### PR TITLE
Add Vue USWDS to implementations page

### DIFF
--- a/_data/implementations.yml
+++ b/_data/implementations.yml
@@ -167,3 +167,13 @@
     name: Brian Hurst
     url: https://github.com/hursey013
   notes: "A Tailwind CSS plugin for adding U.S. Web Design System design tokens to supported Tailwind utilities."
+  
+- name: Vue USWDS
+  distribution: Vue.js
+  id: vue-uswds
+  url: https://github.com/patrickcate/vue-uswds
+  author:
+    name: Patrick Cate
+    url: https://github.com/patrickcate
+  version:
+  notes: "A Vue.js implementation of the U.S. Web Design System."


### PR DESCRIPTION
Per #1877, this adds the Vue USWDS project to the implementations page.
