### PR TITLE
Idp staging in-page nav fix which removes in-page nav from landing pages

### DIFF
--- a/_components/button-group/button-group.md
+++ b/_components/button-group/button-group.md
@@ -4,7 +4,7 @@ component:
   name: button-group
   status: ready
   package: usa-button-group
-layout: styleguide
+layout: in-page-nav
 lead: A button group collects similar or related actions.
 permalink: /components/button-group/
 redirect_from:

--- a/_components/data-visualizations/data-visualizations.md
+++ b/_components/data-visualizations/data-visualizations.md
@@ -4,7 +4,7 @@ component:
   package:
   dependencies:
 permalink: /components/data-visualizations/
-layout: styleguide
+layout: in-page-nav
 type: component
 title: Data visualizations
 category: Components

--- a/_components/form/form.md
+++ b/_components/form/form.md
@@ -7,7 +7,7 @@ permalink: /components/form/
 redirect_from:
 - /form-controls/
 - /components/form-controls/
-layout: styleguide
+layout: in-page-nav
 type: component
 title: Form
 category: Components

--- a/_components/header/header.html
+++ b/_components/header/header.html
@@ -7,7 +7,7 @@ permalink: /components/header/
 redirect_from:
   - /headers/
   - /components/headers/
-layout: styleguide
+layout: in-page-nav
 title: Header
 type: component
 category: Components

--- a/_components/table/table.md
+++ b/_components/table/table.md
@@ -9,7 +9,7 @@ permalink: /components/table/
 redirect_from:
 - /tables/
 - /components/tables/
-layout: styleguide
+layout: in-page-nav
 subnav:
 - text: Borderless table
   href: '#borderless-table'

--- a/_components/typography/typography.md
+++ b/_components/typography/typography.md
@@ -6,7 +6,7 @@ component:
 permalink: /components/typography/
 redirect_from:
 - /typography/
-layout: styleguide
+layout: in-page-nav
 title: Typography
 category: Components
 lead: "Government websites need clear and consistent headings, highly legible body paragraphs, clear labels, and easy-to-use input fields. Our default typefaces are designed for legibility and can adapt to a variety of visual tones."

--- a/_layouts/component.html
+++ b/_layouts/component.html
@@ -1,5 +1,5 @@
 ---
-layout: styleguide
+layout: in-page-nav
 type: component
 ---
 

--- a/_layouts/in-page-nav.html
+++ b/_layouts/in-page-nav.html
@@ -1,0 +1,33 @@
+---
+layout: default
+---
+<div class="default-container">
+  <aside class="sidenav" id="page-side-navigation" aria-label="Section navigation">
+    {% assign sidenav = site.data.nav[page.category] %}
+    {% if sidenav %}
+    <ul class="site-sidenav usa-sidenav">
+      {% include nav/list.html links=sidenav %}
+    </ul>
+    {% endif %}
+  </aside>
+
+  <div class="usa-in-page-nav-container">
+    <aside class="usa-in-page-nav" aria-label="Page navigation"></aside>
+    <main id="main-content" class="main-content">
+      <div class="styleguide-content{% unless page.category == 'Utilities' and page.type != 'docs' %} usa-prose site-prose{% endunless %}">
+        <header>
+          {% if page.category != null %}
+            {% unless page.path contains 'overview' and page.permalink != '/design-tokens/color/overview/' %}
+              <p class="site-subheading">{{ page.category }}</p>
+            {% endunless %}
+          {% endif %}
+          <h1 id="{{ page.title | slugify }}" class="site-page-title">{{ page.title }}</h1>
+        </header>
+
+        {% include lead.html text=page.lead %}
+
+        {{ content }}
+      </div>
+    </main>
+  </div>
+</div>

--- a/_layouts/styleguide.html
+++ b/_layouts/styleguide.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 <div class="default-container">
-  <aside class="sidenav" id="page-side-navigation" aria-label="Section navigation">
+  <aside class="sidenav" id="page-side-navigation">
     {% assign sidenav = site.data.nav[page.category] %}
     {% if sidenav %}
     <ul class="site-sidenav usa-sidenav">
@@ -11,23 +11,21 @@ layout: default
     {% endif %}
   </aside>
 
-  <div class="usa-in-page-nav-container">
-    <aside class="usa-in-page-nav" aria-label="Page navigation"></aside>
-    <main id="main-content" class="main-content">
-      <div class="styleguide-content{% unless page.category == 'Utilities' and page.type != 'docs' %} usa-prose site-prose{% endunless %}">
-        <header>
-          {% if page.category != null %}
-            {% unless page.path contains 'overview' and page.permalink != '/design-tokens/color/overview/' %}
-              <p class="site-subheading">{{ page.category }}</p>
-            {% endunless %}
-          {% endif %}
-          <h1 id="{{ page.title | slugify }}" class="site-page-title">{{ page.title }}</h1>
-        </header>
+  <main id="main-content" class="main-content">
 
-        {% include lead.html text=page.lead %}
+    <div class="styleguide-content{% unless page.category == 'Utilities' and page.type != 'docs' %} usa-prose site-prose{% endunless %}">
+      <header>
+        {% if page.category != null %}
+          {% unless page.path contains 'overview' and page.permalink != '/design-tokens/color/overview/' %}
+            <p class="site-subheading">{{ page.category }}</p>
+          {% endunless %}
+        {% endif %}
+        <h1 id="{{ page.title | slugify }}" class="site-page-title">{{ page.title }}</h1>
+      </header>
 
-        {{ content }}
-      </div>
-    </main>
-  </div>
+      {% include lead.html text=page.lead %}
+
+      {{ content }}
+    </div>
+  </main>
 </div>


### PR DESCRIPTION
I created a new layout called in-page-nav that has the code for in-page nav and REMOVED the in-page nav code from the styleguide layout. Then I changed component.html to call `layout: in-page-nav`.

The result is landing pages don't have in-page nav. 

Why? Team consensus was that the landing pages don't need it. There were multiple issues, including three card layouts with h3 tags on the same row, and three links in the nav which would all point to the same vertical scroll-to position.

I went through the patterns pages too, and basically **any page that has a card layout (e.g. n number of rows with three cards per row) I used the standard styleguide layout.

