### PR TITLE
Add changelog entry for Memorable Date updates

### DIFF
--- a/_data/changelogs/memorable-date.yml
+++ b/_data/changelogs/memorable-date.yml
@@ -2,6 +2,15 @@ title: Memorable date
 type: component
 changelogURL:
 items:
+- date: 2022-11-14
+  summary: Updated the month entry to a `select` from an `input`. 
+  summaryAdditional: Recent usability testing indicated that using a `select` for month entry was more clear and reduced mistakes. 
+  affectsMarkup: true
+  affectsStyles: true
+  affectsGuidance: true
+  githubRepo: uswds
+  githubPr: 4937
+  versionUswds: 3.3.0
 - date: 2022-04-28
   summary: Updated to Sass module syntax and new package structure.
   isBreaking: true


### PR DESCRIPTION
This adds a changelog entry to Memorable Date. We updated the month entry to a `select` from a numeric `input` because our pattern testing showed that a `select` was clearer and reduced confusion. 

Note that this is not a breaking change even though it affects styles and markup. We rewrote the styles to be backward compatible with the old markup