### PR TITLE
USWDS-Site - Search: Remove button type

### DIFF
--- a/_components/search/guidance/accessibility.md
+++ b/_components/search/guidance/accessibility.md
@@ -1,2 +1,2 @@
 - **Customize form controls accessibly.** If you customize this component, ensure that it continues to meet the [accessibility requirements that apply to all form controls]({{ site.baseurl }}/components/form).
-- **Include the word “Search” in the button.** Always include the word “search” inside the `<button type="button">` element for screen readers. You can visually hide this text using the CSS class `usa-sr-only` or Sass mixin `@include sr-only`.
+- **Include the word “Search” in the button.** Always include the word “search” inside the `<button>` element for screen readers. You can visually hide this text using the CSS class `usa-sr-only` or Sass mixin `@include sr-only`.


### PR DESCRIPTION
## Summary
Removed `type="button"` from the button example in the accessibility guidance.

It is not necessary to include the type in the example because the meaning can be derived without it. Plus, our component code shows `type="submit"`. 

## Related issue
Closes #1903 

## Preview link
Preview link: Search page

---

Before opening this PR, make sure you’ve done whichever of these applies to you:

- [x] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [x] Run `npm test` and confirm that all tests pass.
