### PR TITLE
USWDS-Site: Update snyk ignore (November, round 2)

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -3500,6 +3500,11 @@ ignore:
         reason: No available upgrade or patch
         expires: 2022-12-18T14:18:47.166Z
         created: 2022-11-18T14:18:47.221Z
+  SNYK-JS-DECODEURICOMPONENT-3149970:
+    - '*':
+        reason: No available upgrade or patch
+        expires: 2022-12-28T19:04:33.799Z
+        created: 2022-11-28T19:04:33.852Z
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   'npm:minimatch:20160620':


### PR DESCRIPTION
## Related issue
Closes #1924

## Problem statement
`npx snyk test` was throwing errors related to sub-dependencies of `gulp-sourcemaps@3.0.0`

More details: [Circle CI failure report](https://app.circleci.com/pipelines/github/uswds/uswds-site/4380/workflows/850e896e-9237-47d0-ba34-812c9adf8899/jobs/14887)

## Solution
Update the snyk policy to ignore these alerts for 30 days. 

Ran the following in the command line:
```
npx snyk ignore --id="SNYK-JS-DECODEURICOMPONENT-3149970" --reason="No available upgrade or patch"
```

## Testing and review
To test, run `npx snyk test` and check for errors.

## Reference
[Ignore vulnerabilities using Snyk CLI](https://docs.snyk.io/snyk-cli/test-for-vulnerabilities/ignore-vulnerabilities-using-snyk-cli)