### PR TITLE
Deleted the what's on this page navigation in the body of the page

### DIFF
--- a/pages/about/contribute.md
+++ b/pages/about/contribute.md
@@ -8,24 +8,6 @@ category: About
 lead: Your contribution helps make the Design System better for the next team that uses it.
 
 ---
-
-## What's on this page
-
-- [What's on this page](#whats-on-this-page)
-- [Get started](#get-started)
-- [Report bugs and issues](#report-bugs-and-issues)
-- [Propose a feature request or enhancement](#propose-a-feature-request-or-enhancement)
-- [Submit a pull request](#submit-a-pull-request)
-  - [If it's a bug fix:](#if-its-a-bug-fix)
-  - [If it's a feature request or enhancement:](#if-its-a-feature-request-or-enhancement)
-  - [Want to propose something else?](#want-to-propose-something-else)
-- [How we prioritize](#how-we-prioritize)
-- [Code of Conduct](#code-of-conduct)
-- [Licenses and attribution](#licenses-and-attribution)
-  - [A few parts of this project are not in the public domain](#a-few-parts-of-this-project-are-not-in-the-public-domain)
-  - [The rest of this project is in the public domain](#the-rest-of-this-project-is-in-the-public-domain)
-  - [Contributions will be released into the public domain](#contributions-will-be-released-into-the-public-domain)
-
 ## Get started
 
 Anyone can contribute to the U.S. Web Design System (USWDS). Whether it's submitting a bug or proposing a new component, we welcome your ideas on how to improve the Design System.


### PR DESCRIPTION
<!-- Please feel free to remove whatever sections/lines in this aren’t relevant.

Use the title line as the title of your pull request, then delete these lines. 

## Title line template: [Title]: Brief description

UI components: For pull requests that impact the look, feel, or functionality of USWDS itself, please open a pull request on the web-design-standards repo (https://github.com/uswds/uswds-site). 

-->

## Description

This issue affects the Contribute page as described in #1935 . I've removed the section "What's on this page" and all of the anchor links beneath it. 

## Additional information

This is a result of a recent change to uswds-site that added the side-nav component to our documentation. The end result for the Contribute page was that there were 3 navigations on a single document. This change will lighten the visual load and make the remaining page navigation more meaningful. 

![B35AFC49-F613-4A94-A79C-CE03721EC372](https://user-images.githubusercontent.com/96838068/206546220-dfa12da2-4e0a-4fab-a2ca-6a60ea4a6c13.jpeg)


Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [ ] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
