### PR TITLE
USWDS-Site: Update snyk ignore

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1420,8 +1420,8 @@ ignore:
         expires: '2022-01-27T21:29:25.296Z'
     - '*':
         reason: No available upgrade or patch
-        expires: 2022-12-18T14:18:42.899Z
-        created: 2022-11-18T14:18:42.949Z
+        expires: 2023-01-18T23:30:13.009Z
+        created: 2022-12-19T23:30:13.064Z
   SNYK-JS-NODESASS-1059081:
     - gulp-sass > node-sass:
         reason: No available upgrade or patch.
@@ -2707,8 +2707,8 @@ ignore:
         expires: '2022-01-27T21:29:25.295Z'
     - '*':
         reason: No available upgrade or patch
-        expires: 2022-12-18T14:18:38.141Z
-        created: 2022-11-18T14:18:38.196Z
+        expires: 2023-01-18T23:30:10.990Z
+        created: 2022-12-19T23:30:11.047Z
   SNYK-JS-AXIOS-1579269:
     - uswds > @frctl/fractal > @frctl/web > browser-sync > localtunnel > axios:
         reason: None given
@@ -3498,13 +3498,13 @@ ignore:
   SNYK-JS-UNSETVALUE-2400660:
     - '*':
         reason: No available upgrade or patch
-        expires: 2022-12-18T14:18:47.166Z
-        created: 2022-11-18T14:18:47.221Z
+        expires: 2023-01-18T23:30:14.882Z
+        created: 2022-12-19T23:30:14.935Z
   SNYK-JS-DECODEURICOMPONENT-3149970:
     - '*':
         reason: No available upgrade or patch
-        expires: 2022-12-28T19:04:33.799Z
-        created: 2022-11-28T19:04:33.852Z
+        expires: 2023-01-18T23:30:33.040Z
+        created: 2022-12-19T23:30:33.094Z
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   'npm:minimatch:20160620':


### PR DESCRIPTION
## Related issue
Closes #1956

## Problem statement
`npx snyk test` was throwing errors related to sub-dependencies inside Gulp 4.0.2. 

## Solution
Update the snyk policy to ignore these alerts for 30 days. 

Run the following in the command line:
```
npx snyk ignore --id="SNYK-JS-ANSIREGEX-1583908" --reason="No available upgrade or patch" && npx snyk ignore --id="SNYK-JS-GLOBPARENT-1016905" --reason="No available upgrade or patch" && npx snyk ignore --id="SNYK-JS-UNSETVALUE-2400660" --reason="No available upgrade or patch" && npx snyk ignore --id="SNYK-JS-DECODEURICOMPONENT-3149970" --reason="No available upgrade or patch"
```

Note: I updated the ignore for `DECODEURICOMPONENT-3149970` (https://github.com/uswds/uswds-site/pull/1925) as well so that all updates will be on the same cycle.

## Testing and review
To test, run `npx snyk test` and check for errors.

## Reference
[Ignore vulnerabilities using Snyk CLI](https://docs.snyk.io/snyk-cli/test-for-vulnerabilities/ignore-vulnerabilities-using-snyk-cli)