### PR TITLE
USWDS-Site: Update snyk ignore

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1420,8 +1420,8 @@ ignore:
         expires: '2022-01-27T21:29:25.296Z'
     - '*':
         reason: No available upgrade or patch
-        expires: 2023-02-08T23:54:37.979Z
-        created: 2023-01-09T23:54:38.031Z
+        expires: 2023-02-18T22:00:28.783Z
+        created: 2023-01-19T22:00:28.836Z
   SNYK-JS-NODESASS-1059081:
     - gulp-sass > node-sass:
         reason: No available upgrade or patch.
@@ -2707,8 +2707,8 @@ ignore:
         expires: '2022-01-27T21:29:25.295Z'
     - '*':
         reason: No available upgrade or patch
-        expires: 2023-01-18T23:30:10.990Z
-        created: 2022-12-19T23:30:11.047Z
+        expires: 2023-02-18T22:00:36.143Z
+        created: 2023-01-19T22:00:36.197Z
   SNYK-JS-AXIOS-1579269:
     - uswds > @frctl/fractal > @frctl/web > browser-sync > localtunnel > axios:
         reason: None given
@@ -3498,18 +3498,18 @@ ignore:
   SNYK-JS-UNSETVALUE-2400660:
     - '*':
         reason: No available upgrade or patch
-        expires: 2023-02-08T23:54:39.844Z
-        created: 2023-01-09T23:54:39.898Z
+        expires: 2023-02-18T22:00:30.724Z
+        created: 2023-01-19T22:00:30.770Z
   SNYK-JS-DECODEURICOMPONENT-3149970:
     - '*':
         reason: No available upgrade or patch
-        expires: 2023-02-08T23:54:41.654Z
-        created: 2023-01-09T23:54:41.708Z
+        expires: 2023-02-18T22:00:32.475Z
+        created: 2023-01-19T22:00:32.522Z
   SNYK-JS-DEBUG-3227433:
     - '*':
         reason: No available upgrade or patch
-        expires: 2023-02-08T23:54:33.524Z
-        created: 2023-01-09T23:54:33.576Z
+        expires: 2023-02-18T22:00:26.730Z
+        created: 2023-01-19T22:00:26.779Z
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   'npm:minimatch:20160620':


### PR DESCRIPTION
## Related issue
Closes #1977 

## Problem statement
The snyk ignore update earlier this month (PR #1967) was missing one item that should have been included: ANSIREGEX-1583908. 

## Solution
Updated the snyk policy to ignore these alerts for 30 days. 

This PR updates snyk to ignore the following items: 
- SNYK-JS-DEBUG-3227433
- SNYK-JS-GLOBPARENT-1016905
- SNYK-JS-UNSETVALUE-2400660
- SNYK-JS-DECODEURICOMPONENT-3149970
- SNYK-JS-ANSIREGEX-1583908

Ran the following in the command line:
```
npx snyk ignore --id="SNYK-JS-DEBUG-3227433" --reason="No available upgrade or patch" &&  
npx snyk ignore --id="SNYK-JS-GLOBPARENT-1016905" --reason="No available upgrade or patch" && 
npx snyk ignore --id="SNYK-JS-UNSETVALUE-2400660" --reason="No available upgrade or patch" && 
npx snyk ignore --id="SNYK-JS-DECODEURICOMPONENT-3149970" --reason="No available upgrade or patch" &&
npx snyk ignore --id="SNYK-JS-ANSIREGEX-1583908" --reason="No available upgrade or patch"
```

## Testing and review
To test, run `npx snyk test` and check for errors.

## Reference
[Ignore vulnerabilities using Snyk CLI](https://docs.snyk.io/snyk-cli/test-for-vulnerabilities/ignore-vulnerabilities-using-snyk-cli)