### PR TITLE
Update design assets links to v2.6.0

### DIFF
--- a/_includes/download-buttons-design.html
+++ b/_includes/download-buttons-design.html
@@ -4,9 +4,9 @@ repository. See: https://github.com/uswds/uswds-for-designers
 {% endcomment %}
 <div class="link__group-download">
   <a class="link-download"
-    href="https://github.com/uswds/uswds-for-designers/releases/download/v2.5.0/uswds-for-designers-v2.5.0.zip"
-    onclick="ga('send', 'event', 'Downloaded design files - Sketch', 'Clicked download design files button inside site');">Download the USWDS {{ site.uswds_version }} Design Kit (Sketch) [ZIP; 13.2 MB]</a>
+    href="https://github.com/uswds/uswds-for-designers/releases/download/v2.6.0/uswds-for-designers-v2.6.0.zip"
+    onclick="ga('send', 'event', 'Downloaded design files - Sketch', 'Clicked download design files button inside site');">Download the USWDS {{ site.uswds_version }} Design Kit (Sketch) [ZIP; 12.4 MB]</a>
   <a class="link-download"
-    href="https://github.com/uswds/uswds-for-designers/releases/download/v2.5.0/uswds-for-designers-v2.5.0.zip"
-    onclick="ga('send', 'event', 'Downloaded design files - Adobe XD', 'Clicked download design files button inside site');">Download the USWDS {{ site.uswds_version }} Design Kit (Adobe XD) [ZIP; 13.2 MB]</a>
+    href="https://github.com/uswds/uswds-for-designers/releases/download/v2.6.0/uswds-for-designers-v2.6.0.zip"
+    onclick="ga('send', 'event', 'Downloaded design files - Adobe XD', 'Clicked download design files button inside site');">Download the USWDS {{ site.uswds_version }} Design Kit (Adobe XD) [ZIP; 12.4 MB]</a>
 </div>


### PR DESCRIPTION
## Description

**Update design assets links to v2.6.0.** I've updated the design assets in the `uswds-for-designers` repo: https://github.com/uswds/uswds-for-designers/releases/tag/v2.6.0. This PR updates the link to the release ZIP.

## Additional information

Both asset links should point to https://github.com/uswds/uswds-for-designers/releases/download/v2.6.0/uswds-for-designers-v2.6.0.zip — there are only two links for analytics tracking purposes. 

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [ ] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
