### PR TITLE
Remove duplicative page navigation

### DIFF
--- a/pages/about/key-benefits.md
+++ b/pages/about/key-benefits.md
@@ -15,15 +15,7 @@ changelog:
 ---
 The U.S. Web Design System (USWDS) is a toolkit of principles, guidance, and code that makes it easier to build accessible, mobile-friendly government websites. We use human-centered design to support human-centered design teams.
 
-There are many ways to build a website or service. We designed USWDS to deliver unique benefits to government teams:
-
-- [Compliance from the start](#compliance-from-the-start)
-- [Proven design solutions that users expect](#proven-design-solutions-that-users-expect)
-- [Team alignment and common goals](#team-alignment-and-common-goals)
-- [Mission focus](#mission-focus)
-- [A cross-functional design system community](#a-cross-functional-design-system-community)
-- [Effective stewardship of public resources](#effective-stewardship-of-public-resources)
-
+There are many ways to build a website or service. We designed USWDS to deliver unique benefits to government teams.
 
 {:.border-top-05.border-primary.padding-top-2.margin-bottom-2}
 

--- a/pages/about/website-policies-and-notices.md
+++ b/pages/about/website-policies-and-notices.md
@@ -16,20 +16,6 @@ changelog:
 
 Read the U.S. Web Design System (USWDS) policies on accessibility, linking, open source, privacy, and more. These policies and notices apply only to our websites --- [designsystem.digital.gov](https://designsystem.digital.gov) and [public-sans.digital.gov](https://public-sans.digital.gov) --- and not any other government websites.
 
-## On this page
-
--   [Accessibility policy](#accessibility-policy) →
-
--   [Linking policy](#linking-policy) →
-
--   [Open source policy](#open-source-policy) →
-
--   [Privacy and security policies](#privacy-and-security-policies) →
-
--   [System requirements notice](#system-requirements-notice) →
-
--   [Required content notice](#required-content-notice) →
-
 ## Accessibility policy
 
 We strive to make our website as accessible and usable as possible. We do this by following [Section 508 laws and policies](https://section508.gov/manage/laws-and-policies) and the [Web Content Accessibility Guidelines (WCAG 2.1)](https://www.w3.org/TR/WCAG21/) produced by the World Wide Web Consortium (W3C, the web's governing body).


### PR DESCRIPTION

## Description

This issue removes duplicative in-page navigation that repeats what is automatically pulled in to the right-side page navigation. There may be others on the site, but these were found in #1942 . 

## Additional information

Pages updated: 
- [Key benefits](https://designsystem.digital.gov/about/key-benefits/)
- [Website policies and notices](https://designsystem.digital.gov/about/website-policies-notices/)

