### PR TITLE
USWDS-Site: Update snyk ignore

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1420,8 +1420,8 @@ ignore:
         expires: '2022-01-27T21:29:25.296Z'
     - '*':
         reason: No available upgrade or patch
-        expires: 2023-02-18T22:00:28.783Z
-        created: 2023-01-19T22:00:28.836Z
+        expires: 2023-03-26T16:19:29.545Z
+        created: 2023-02-24T16:19:29.600Z
   SNYK-JS-NODESASS-1059081:
     - gulp-sass > node-sass:
         reason: No available upgrade or patch.
@@ -2707,8 +2707,8 @@ ignore:
         expires: '2022-01-27T21:29:25.295Z'
     - '*':
         reason: No available upgrade or patch
-        expires: 2023-02-18T22:00:36.143Z
-        created: 2023-01-19T22:00:36.197Z
+        expires: 2023-03-26T16:19:35.361Z
+        created: 2023-02-24T16:19:35.416Z
   SNYK-JS-AXIOS-1579269:
     - uswds > @frctl/fractal > @frctl/web > browser-sync > localtunnel > axios:
         reason: None given
@@ -3498,18 +3498,18 @@ ignore:
   SNYK-JS-UNSETVALUE-2400660:
     - '*':
         reason: No available upgrade or patch
-        expires: 2023-02-18T22:00:30.724Z
-        created: 2023-01-19T22:00:30.770Z
+        expires: 2023-03-26T16:19:31.262Z
+        created: 2023-02-24T16:19:31.316Z
   SNYK-JS-DECODEURICOMPONENT-3149970:
     - '*':
         reason: No available upgrade or patch
-        expires: 2023-02-18T22:00:32.475Z
-        created: 2023-01-19T22:00:32.522Z
+        expires: 2023-03-26T16:19:32.901Z
+        created: 2023-02-24T16:19:32.956Z
   SNYK-JS-DEBUG-3227433:
     - '*':
         reason: No available upgrade or patch
-        expires: 2023-02-18T22:00:26.730Z
-        created: 2023-01-19T22:00:26.779Z
+        expires: 2023-03-26T16:19:27.833Z
+        created: 2023-02-24T16:19:27.892Z
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   'npm:minimatch:20160620':


### PR DESCRIPTION
## Related issue
Closes #2012

## Problem statement
`npx snyk test` was throwing errors.

## Solution
This PR updates snyk to ignore the following items: 
- SNYK-JS-DEBUG-3227433
- SNYK-JS-GLOBPARENT-1016905
- SNYK-JS-UNSETVALUE-2400660
- SNYK-JS-DECODEURICOMPONENT-3149970
- SNYK-JS-ANSIREGEX-1583908

Ran the following in the command line:
```
npx snyk ignore --id="SNYK-JS-DEBUG-3227433" --reason="No available upgrade or patch" &&  
npx snyk ignore --id="SNYK-JS-GLOBPARENT-1016905" --reason="No available upgrade or patch" && 
npx snyk ignore --id="SNYK-JS-UNSETVALUE-2400660" --reason="No available upgrade or patch" && 
npx snyk ignore --id="SNYK-JS-DECODEURICOMPONENT-3149970" --reason="No available upgrade or patch" &&
npx snyk ignore --id="SNYK-JS-ANSIREGEX-1583908" --reason="No available upgrade or patch"
```

## Testing and review
To test, run `npx snyk test` and check for errors.

## Reference
[Ignore vulnerabilities using Snyk CLI](https://docs.snyk.io/snyk-cli/test-for-vulnerabilities/ignore-vulnerabilities-using-snyk-cli)