### PR TITLE
Contact preferences: Replace unassociated `label` element with a `p` element

### DIFF
--- a/_includes/patterns/contact-preferences.html
+++ b/_includes/patterns/contact-preferences.html
@@ -1,7 +1,7 @@
 <form class="usa-form usa-form--large">
   <fieldset class="usa-fieldset">
     <legend class="usa-legend usa-legend--large">Contact preferences</legend>
-    <label class="usa-label" for="preferred-means-of-communication">We will only contact you if there is a question about your application.</label>
+    <p>We will only contact you if there is a question about your application.</p>
     <div class="usa-radio">
       <input class="usa-radio__input" id="telephone-call" type="radio" name="preferred-means-of-communication" value="telephone-call" />
       <label class="usa-radio__label" for="telephone-call">Telephone call</label>


### PR DESCRIPTION
## Description

The [Contact Preferences pattern code](https://designsystem.digital.gov/patterns/create-a-user-profile/contact-preferences/) includes the following:

```html
<label class="usa-label" for="preferred-means-of-communication">We will only contact you if there is a question about your application.</label>
```

However, there isn't a corresponding form field with an `id="preferred-means-of-communication"`, so this label isn't associated with a field. I _think_ this is a bug in the markup, and this text doesn't need to be a `label`.

[From MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label):

> To explicitly associate a `<label>` element with an `<input>` element, you first need to add the `id` attribute to the `<input>` element. Next, you add the for attribute to the `<label>` element, where the value of for is the same as the `id` in the `<input>` element.

## Additional information

<img width="996" alt="CleanShot 2023-02-28 at 10 08 53@2x" src="https://user-images.githubusercontent.com/371943/221942368-2411e3bd-4341-44a9-a110-4428a3ba60c5.png">

