### PR TITLE
Homepage: Remove survey banner

### DIFF
--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -3,12 +3,6 @@ layout: default
 ---
 
 <main id="main-content">
-  <div class="bg-info-light padding-x-2 desktop:padding-x-4 padding-y-1 line-height-sans-5 font-lang-4">
-    <strong>What are the most important things you need to accomplish on our site?</strong> Please take <a
-      href="https://touchpoints.app.cloud.gov/touchpoints/0a9a9227/submit" class="text-ink hover:text-no-underline">
-      this 5 minute survey
-    </a> so we can make the site work better for you!
-  </div>
   <section class="site-hero">
     <div class="grid-container">
       <div class="maxw-mobile-lg">


### PR DESCRIPTION
Removes top tasks survey banner on homepage. Closes #2019.

![image](https://user-images.githubusercontent.com/3385219/222844032-9c1ef087-d5ad-4e82-a568-4ce64d1a991c.png)
