### PR TITLE
Update changelog with 3.4.0 release notes

### DIFF
--- a/_data/changelogs/component-alert.yml
+++ b/_data/changelogs/component-alert.yml
@@ -2,6 +2,13 @@ title: Alert
 type: component
 changelogURL:
 items:
+  - date: 2023-03-09
+    summary: Updated padding to accept any valid spacing token.
+    summaryAdditional: The site alert and banner component was also updated.
+    affectsStyles: true
+    githubPr: 5076
+    githubRepo: uswds
+    versionUswds: 3.4.0
   - date: 2022-10-19
     summary: Updated the alignment of alert content to visually match banner content.
     summaryAdditional: The site alert component was also updated.

--- a/_data/changelogs/component-alert.yml
+++ b/_data/changelogs/component-alert.yml
@@ -3,8 +3,8 @@ type: component
 changelogURL:
 items:
   - date: 2023-03-09
-    summary: Updated padding to accept any valid spacing token.
-    summaryAdditional: The site alert and banner component was also updated.
+    summary: Updated padding settings to accept any valid spacing token.
+    summaryAdditional:
     affectsStyles: true
     githubPr: 5076
     githubRepo: uswds

--- a/_data/changelogs/component-banner.yml
+++ b/_data/changelogs/component-banner.yml
@@ -2,6 +2,13 @@ title: Banner
 type: component
 changelogURL:
 items:
+  - date: 2023-03-09
+    summary: Removed grid dependency from Banner.
+    summaryAdditional: Banner no longer needs the `usa-layout-grid` package resulting in a much smaller package size.
+    affectsStyles: true
+    githubPr: 5000
+    githubRepo: uswds
+    versionUswds: 3.4.0
   - date: 2022-10-09
     summary: Updated the aria-label in English versions of banner.
     summaryAdditional: When read out on a screen reader, the statement "An official website of the United States government" can sound like "Unofficial website of the United States government". To minimize confusion, we updated the component's `aria-label` to instead read "Official website of the United States government".

--- a/_data/changelogs/component-banner.yml
+++ b/_data/changelogs/component-banner.yml
@@ -3,6 +3,20 @@ type: component
 changelogURL:
 items:
   - date: 2023-03-09
+    summary: Improved display of focus outline on mobile.
+    summaryAdditional: Now the focus outline is visible all around the banner on mobile devices.
+    affectsStyles: true
+    githubPr: 5013
+    githubRepo: uswds
+    versionUswds: 3.4.0
+  - date: 2023-03-09
+    summary: Updated padding to accept any valid spacing token.
+    summaryAdditional: The alert and site alert component was also updated.
+    affectsStyles: true
+    githubPr: 5076
+    githubRepo: uswds
+    versionUswds: 3.4.0
+  - date: 2023-03-09
     summary: Removed grid dependency from Banner.
     summaryAdditional: Banner no longer needs the `usa-layout-grid` package resulting in a much smaller package size.
     affectsStyles: true

--- a/_data/changelogs/component-banner.yml
+++ b/_data/changelogs/component-banner.yml
@@ -10,8 +10,8 @@ items:
     githubRepo: uswds
     versionUswds: 3.4.0
   - date: 2023-03-09
-    summary: Updated padding to accept any valid spacing token.
-    summaryAdditional: The alert and site alert component was also updated.
+    summary: Updated padding settings to accept any valid spacing token.
+    summaryAdditional:
     affectsStyles: true
     githubPr: 5076
     githubRepo: uswds

--- a/_data/changelogs/component-date-picker.yml
+++ b/_data/changelogs/component-date-picker.yml
@@ -2,6 +2,13 @@ title: Date picker
 type: component
 changelogURL:
 items:
+  - date: 2023-03-09
+    summary: Updated documentation for accessibility guidance.
+    summaryAdditional: Added instructions for keyboard navigation.
+    affectsAccessibility:
+    affectsStyles:
+    githubPr: 1695
+    githubRepo: uswds-site
   - date: 2022-08-05
     summary: Styled aria-disabled to match disabled.
     summaryAdditional: Now disabled styling is applied whether you use `disabled` (disabled and hidden from screen readers) or `aria-disabled` (disabled and visible to screen readers).
@@ -51,7 +58,6 @@ items:
     githubPr: 4610
     githubRepo: uswds
     versionUswds: 2.13.3
-    affectsAccessibility: true
   - date: 2022-01-20
     summary: Fixed date picker input bug in Safari.
     summaryAdditional: We fixed a bug where date picker selections would not propagate into the input field in Safari.

--- a/_data/changelogs/component-footer.yml
+++ b/_data/changelogs/component-footer.yml
@@ -4,7 +4,7 @@ changelogURL:
 items:
   - date: 2023-03-09
     summary: Footer now accepts any heading level for primary link headers.
-    summaryAdditional: Use any heading level for `.usa-footer__primary-link` without it reverting to an h4 when the JavaScript rebuilds the element for mobile.
+    summaryAdditional: Use any heading level for `.usa-footer__primary-link` without it reverting to an `h4` when the JavaScript rebuilds the element for mobile.
     affectsAccessibility: true
     affectsJavascript: true
     affectsMarkup: true

--- a/_data/changelogs/component-footer.yml
+++ b/_data/changelogs/component-footer.yml
@@ -2,6 +2,14 @@ title: Footer
 type: component
 changelogURL:
 items:
+  - date: 2023-03-09
+    summary: Footer now accepts any heading level for primary link headers.
+    summaryAdditional: Use any heading level for `.usa-footer__primary-link` without it reverting to an h4 when the JavaScript rebuilds the element for mobile.
+    affectsJavascript: true
+    affectsMarkup: true
+    githubPr: 5044
+    githubRepo: uswds
+    versionUswds: 3.4.0
   - date: 2022-08-29
     summary: Added documentation for `$theme-footer-max-width`.
     affectsGuidance: true

--- a/_data/changelogs/component-footer.yml
+++ b/_data/changelogs/component-footer.yml
@@ -5,6 +5,7 @@ items:
   - date: 2023-03-09
     summary: Footer now accepts any heading level for primary link headers.
     summaryAdditional: Use any heading level for `.usa-footer__primary-link` without it reverting to an h4 when the JavaScript rebuilds the element for mobile.
+    affectsAccessibility: true
     affectsJavascript: true
     affectsMarkup: true
     githubPr: 5044

--- a/_data/changelogs/component-header.yml
+++ b/_data/changelogs/component-header.yml
@@ -3,8 +3,16 @@ type: component
 changelogURL:
 items:
   - date: 2023-03-09
+    summary: Secondary nav is now read properly on screen readers.
+    summaryAdditional: The separator between nav elements is no longer read on screen readers.
+    isBreaking: false
+    affectsStyles: true
+    githubPr: 4963
+    githubRepo: uswds
+    versionUswds: 3.4.0
+  - date: 2023-03-09
     summary: Allow full-page width for header.
-    summaryAdditional: You can now set a value of `"none"` for any `max-width` setting, including `$theme-header-max-width``.
+    summaryAdditional: You can now set a value of `"none"` for any `max-width` setting, including `$theme-header-max-width`.
     isBreaking: false
     affectsStyles: true
     githubPr: 5072

--- a/_data/changelogs/component-header.yml
+++ b/_data/changelogs/component-header.yml
@@ -6,6 +6,7 @@ items:
     summary: Secondary nav is now read properly on screen readers.
     summaryAdditional: The separator between nav elements is no longer read on screen readers.
     isBreaking: false
+    affectsAccessibility: true
     affectsStyles: true
     githubPr: 4963
     githubRepo: uswds

--- a/_data/changelogs/component-header.yml
+++ b/_data/changelogs/component-header.yml
@@ -2,6 +2,14 @@ title: Header
 type: component
 changelogURL:
 items:
+  - date: 2023-03-09
+    summary: Allow full-page width for header.
+    summaryAdditional: You can now set a value of `"none"` for any `max-width` setting, including `$theme-header-max-width``.
+    isBreaking: false
+    affectsStyles: true
+    githubPr: 5072
+    githubRepo: uswds
+    versionUswds: 3.4.0
   - date: 2022-08-05
     summary: Added `type="button"` to all non-form buttons to prevent default submit behaviors.
     summaryAdditional: This allowed us to remove `preventDefault()` from the relevant component JavaScript.

--- a/_data/changelogs/component-in-page-navigation.yml
+++ b/_data/changelogs/component-in-page-navigation.yml
@@ -2,6 +2,16 @@ title: In-page navigation
 type: component
 changelogURL:
 items:
+  - date: 2023-03-09
+    summary: URL in address bar is updated when navigating component.
+    summaryAdditional: Users can now see the proper anchor link in the address bar when navigating.
+    affectsGuidance:
+    affectsJavascript: true
+    affectsMarkup:
+    affectsStyles: true
+    githubRepo: uswds
+    githubPr: 5170
+    versionUswds: 3.4.0
   - date: 2022-11-14
     summary: Component released.
     affectsGuidance: true

--- a/_data/changelogs/component-in-page-navigation.yml
+++ b/_data/changelogs/component-in-page-navigation.yml
@@ -4,7 +4,7 @@ changelogURL:
 items:
   - date: 2023-03-09
     summary: URL in address bar is updated when navigating component.
-    summaryAdditional: Users can now see the proper anchor link in the address bar when navigating.
+    summaryAdditional: Users can now see the proper anchor link in the address bar when navigating from the in-page navigation.
     affectsGuidance:
     affectsJavascript: true
     affectsMarkup:

--- a/_data/changelogs/component-link.yml
+++ b/_data/changelogs/component-link.yml
@@ -2,6 +2,12 @@ title: Link
 type: component
 changelogURL:
 items:
+- date: 2023-03-09
+  summary:	External link icons and link text now wrap as expected.
+  affectsStyles: true
+  githubPr: 5046
+  githubRepo: uswds
+  versionUswds: 3.4.0
 - date: 2022-04-28
   summary: Updated to Sass module syntax and new package structure.
   isBreaking: true

--- a/_data/changelogs/component-modal.yml
+++ b/_data/changelogs/component-modal.yml
@@ -3,7 +3,7 @@ type: component
 changelogURL:
 items:
 - date: 2023-03-09
-  summary: Fixed Interactive form elements like Date Picker in modal window.
+  summary: Fixed the display of interactive form elements (like Date Picker) in modal windows.
   summaryAdditional: Now any element in a modal should work as expected.
   isBreaking: false
   affectsJavascript: true

--- a/_data/changelogs/component-modal.yml
+++ b/_data/changelogs/component-modal.yml
@@ -2,6 +2,14 @@ title: Modal
 type: component
 changelogURL:
 items:
+- date: 2023-03-09
+  summary: Fixed Interactive form elements like Date Picker in modal window.
+  summaryAdditional: Now any element in a modal should work as expected.
+  isBreaking: false
+  affectsJavascript: true
+  githubPr: 5049
+  githubRepo: uswds
+  versionUswds: 3.4.0
 - date: 2022-08-05
   summary: Styled aria-disabled to match disabled.
   summaryAdditional: Now disabled styling is applied whether you use `disabled` (disabled and hidden from screen readers) or `aria-disabled` (disabled and visible to screen readers).

--- a/_data/changelogs/component-site-alert.yml
+++ b/_data/changelogs/component-site-alert.yml
@@ -2,6 +2,13 @@ title: Site alert
 type: component
 changelogURL:
 items:
+  - date: 2023-03-09
+    summary: Updated padding to accept any valid spacing token.
+    summaryAdditional: The alert and banner component was also updated.
+    affectsStyles: true
+    githubPr: 5076
+    githubRepo: uswds
+    versionUswds: 3.4.0
   - date: 2022-09-26
     summary: Added guidance for using ARIA roles and ARIA labels.
     affectsGuidance: true

--- a/_data/changelogs/component-site-alert.yml
+++ b/_data/changelogs/component-site-alert.yml
@@ -3,8 +3,8 @@ type: component
 changelogURL:
 items:
   - date: 2023-03-09
-    summary: Updated padding to accept any valid spacing token.
-    summaryAdditional: The alert and banner component was also updated.
+    summary: Updated padding settings to accept any valid spacing token.
+    summaryAdditional:
     affectsStyles: true
     githubPr: 5076
     githubRepo: uswds

--- a/_data/changelogs/component-step-indicator.yml
+++ b/_data/changelogs/component-step-indicator.yml
@@ -4,6 +4,16 @@ type: component
 changelogURL:
 
 items:
+  # 3.4.0 release
+  - date: 2023-03-09
+    summary: Improved contrast on pending items.
+    summaryAdditional: Graphical elements related to pending items now meet accessibility standards for contrast ratio.
+    isBreaking: false
+    affectsAccessibility: true
+    affectsStyles: true
+    githubPr: 5048
+    githubRepo: uswds
+    versionUswds: 3.4.0
   # 3.0 release
   - date: 2022-04-28
     summary: Updated to Sass module syntax and new package structure.

--- a/_data/changelogs/docs-implementations.yml
+++ b/_data/changelogs/docs-implementations.yml
@@ -2,6 +2,18 @@ title: Implementations
 type: documentation
 changelogURL:
 items:
+  - date: 2023-03-09
+    summary: Added entry for "sam.gov" implementations.
+    summaryAdditional:
+    isBreaking:
+    affectsAccessibility:
+    affectsAssets:
+    affectsGuidance: true
+    affectsJavascript:
+    affectsMarkup:
+    affectsStyles:
+    githubPr: 1714
+    githubRepo: uswds-site
   - date: 2022-10-11
     summary: Added entry for "ngx-uswds".
     summaryAdditional:

--- a/_data/changelogs/utilities.yml
+++ b/_data/changelogs/utilities.yml
@@ -2,6 +2,19 @@ title: Utilities
 type: utility
 changelogURL:
 items:
+  - date: 2023-03-09
+    summary: Outline utility and mixin now accept the 05 token.
+    summaryAdditional: Now, the `.outline-05` utility class and the `u-outline('05')` mixin should work as expected.
+    isBreaking:
+    affectsAccessibility:
+    affectsAssets:
+    affectsGuidance: true
+    affectsJavascript:
+    affectsMarkup:
+    affectsStyles: true
+    githubPr: 5079
+    githubRepo: uswds
+    versionUswds: 3.4.0
   - date: 2022-05-04
     summary: Added `margin-horizontal` and `margin-vertical` utility modules.
     summaryAdditional:


### PR DESCRIPTION
Added 3.4.0 updates to changelogs.

Guidance changelog updates:

- Implementations #1714 
- Date picker guidance #1695
- Utilities

Component updates:

- Banner
- Header
- In-page nav
- Alert & Site Alert
- Header
- Footer
- Link
- Modal
- Step indicator

[3.4.0 Release notes ](https://github.com/uswds/uswds/releases/tag/v3.4.0)