### PR TITLE
USWDS-Site - Install: Fix package name in package.json example

### DIFF
--- a/pages/documentation/getting-started-developers/phase-one.md
+++ b/pages/documentation/getting-started-developers/phase-one.md
@@ -77,7 +77,7 @@ npm will show some notifications, install USWDS, and display the version number 
 {:.site-terminal}
 ```json
 "dependencies": {
-  "uswds": "^{{ site.uswds_version }}" [or another version number]
+  "@uswds/uswds": "^{{ site.uswds_version }}" [or another version number]
 }
 ```
 


### PR DESCRIPTION
# Summary

Fixes an outdated reference to `uswds` package in the installation instructions. After following the steps preceding the edited snippet, a developer should expect `package.json` to include `@uswds/uswds`, not `uswds`.