### PR TITLE
USWDS-Site - Touchpoints Button: Fix unclickable links on widescreen

### DIFF
--- a/css/_uswds-theme-custom-styles.scss
+++ b/css/_uswds-theme-custom-styles.scss
@@ -420,6 +420,7 @@ img {
     bottom: 0;
     position: sticky;
     z-index: z-index(500);
+    pointer-events: none;
   }
 
   .usa-button {
@@ -427,6 +428,9 @@ img {
     @include at-media("desktop") {
       @include u-bg($site-background-color);
       margin: units(2) units(2) units(4);
+    }
+    @include at-media("widescreen") {
+      pointer-events: all;
     }
   }
 }


### PR DESCRIPTION
# Summary

Hey yall, i noticed that the sticky touchpoints container on widescreen actually covers the content to the left and makes it unclickable. This should make the button still work and not cover the content with an invisible container that blocks click interactions.

![Screen Shot 2023-04-03 at 1 06 12 PM](https://user-images.githubusercontent.com/4451344/229591713-4cd24301-401f-4505-98e1-60d3baeef443.png)
