### PR TITLE
USWDS-Site - Header: Update changelog for #5008 with note about possible break

### DIFF
--- a/_data/changelogs/component-header.yml
+++ b/_data/changelogs/component-header.yml
@@ -3,9 +3,11 @@ type: component
 changelogURL:
 items:
   - date: 2023-03-13
-    summary: Logo text width setting now works as expected.
-    summaryAdditional: Now the design system respects the value passed to `$theme-header-logo-text-width`.
-    isBreaking: false
+    summary: Extended headers now respect the value passed to `$theme-header-logo-text-width`.
+    summaryAdditional: The default setting value might differ from the previous value.
+      This can cause unexpected line breaks.
+      When updating, confirm that there are no visual regressions.
+    isBreaking: trues
     affectsStyles: true
     githubPr: 5008
     githubRepo: uswds

--- a/_data/changelogs/component-header.yml
+++ b/_data/changelogs/component-header.yml
@@ -4,9 +4,8 @@ changelogURL:
 items:
   - date: 2023-03-13
     summary: Extended headers now respect the value passed to `$theme-header-logo-text-width`.
-    summaryAdditional: The default setting value might differ from the previous value.
-      This can cause unexpected line breaks.
-      When updating, confirm that there are no visual regressions.
+    summaryAdditional: For extended headers, the default setting value is narrower than
+      the previous hard-coded value, which can cause unexpected line breaks.
     isBreaking: true
     affectsStyles: true
     githubPr: 5008

--- a/_data/changelogs/component-header.yml
+++ b/_data/changelogs/component-header.yml
@@ -5,7 +5,7 @@ items:
   - date: 2023-03-13
     summary: Extended headers now respect the value passed to `$theme-header-logo-text-width`.
     summaryAdditional: For extended headers, the default setting value is narrower than
-      the previous hard-coded value, which can cause unexpected line breaks.
+      the previous hard-coded value, which can cause unexpected line breaks for `usa-logo__text`.
     isBreaking: true
     affectsStyles: true
     githubPr: 5008

--- a/_data/changelogs/component-header.yml
+++ b/_data/changelogs/component-header.yml
@@ -7,7 +7,7 @@ items:
     summaryAdditional: The default setting value might differ from the previous value.
       This can cause unexpected line breaks.
       When updating, confirm that there are no visual regressions.
-    isBreaking: trues
+    isBreaking: true
     affectsStyles: true
     githubPr: 5008
     githubRepo: uswds


### PR DESCRIPTION
# Summary

Updated the changelog entry for [ USWDS PR #5008](https://github.com/uswds/uswds/pull/5008) so that it warns users of a  potential breaking change.

The break was originally flagged in Slack: https://gsa-tts.slack.com/archives/C3F14AHSQ/p1680208085858799

I have updated the PR description with the same information. We should also consider updating the 3.4.1 release notes. 

## Related issue

Closes #2051 

## Preview link

Preview link: [Header changelog](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-header-changelog-5008/components/header/#changelog)

## Testing and review
- Confirm that information accurately reflects and resolves the potential break
- Confirm there are no issues with grammar or punctuation
