### PR TITLE
USWDS - Site: Change log items for Disabled Forms normalization

### DIFF
--- a/_data/changelogs/component-button.yml
+++ b/_data/changelogs/component-button.yml
@@ -2,6 +2,14 @@ title: Button
 type: component
 changelogURL:
 items:
+  - date: 2023-03-28
+    summary: Normalize disabled form elements
+    summaryAdditional: Form elements with the `disabled` or `aria-disabled` attribute are now consistently styled accross USWDS and ensure proper color contrast
+    affectsAccessibility: true
+    affectsStyles: true
+    githubPr: 5063
+    githubRepo: uswds
+    versionUswds: 3.5.0
   - date: 2022-08-05
     summary: Styled aria-disabled to match disabled.
     summaryAdditional: Now disabled styling is applied whether you use `disabled` (disabled and hidden from screen readers) or `aria-disabled` (disabled and visible to screen readers).

--- a/_data/changelogs/component-character-count.yml
+++ b/_data/changelogs/component-character-count.yml
@@ -1,7 +1,7 @@
 title: Character count
 type: component
 changelogURL:
-items:
+items:  
   - date: 2022-10-19
     summary: Improved screen reader experience.
     summaryAdditional: The character counter now includes a brief pause after input before announcing how many characters remain. Announcing the input no longer prevents the character counter from reading.

--- a/_data/changelogs/component-checkbox.yml
+++ b/_data/changelogs/component-checkbox.yml
@@ -2,6 +2,14 @@ title: Checkbox
 type: component
 changelogURL:
 items:
+  - date: 2023-03-28
+    summary: Normalize disabled form elements
+    summaryAdditional: Form elements with the `disabled` or `aria-disabled` attribute are now consistently styled accross USWDS and ensure proper color contrast
+    affectsAccessibility: true
+    affectsStyles: true
+    githubPr: 5063
+    githubRepo: uswds
+    versionUswds: 3.5.0
   - date: 2022-08-05
     summary: Styled aria-disabled to match disabled.
     summaryAdditional: Now disabled styling is applied whether you use `disabled` (disabled and hidden from screen readers) or `aria-disabled` (disabled and visible to screen readers).

--- a/_data/changelogs/component-combo-box.yml
+++ b/_data/changelogs/component-combo-box.yml
@@ -2,6 +2,14 @@ title: Combo box
 type: component
 changelogURL:
 items:
+  - date: 2023-03-28
+    summary: Normalize disabled form elements
+    summaryAdditional: Form elements with the `disabled` or `aria-disabled` attribute are now consistently styled accross USWDS and ensure proper color contrast
+    affectsAccessibility: true
+    affectsStyles: true
+    githubPr: 5063
+    githubRepo: uswds
+    versionUswds: 3.5.0
   - date: 2022-11-14
     summary: Added note on usability issues with assistive technology.
     summaryAdditional: Testing with people using assistive technology revealed usability concerns that require additional investigation. Until addressed, consider using a Select component instead of a Combo box.

--- a/_data/changelogs/component-date-picker.yml
+++ b/_data/changelogs/component-date-picker.yml
@@ -2,6 +2,15 @@ title: Date picker
 type: component
 changelogURL:
 items:
+  - date: 2023-03-28
+    summary: Normalize disabled form elements
+    summaryAdditional: Form elements with the `disabled` or `aria-disabled` attribute are now consistently styled accross USWDS and ensure proper color contrast
+    affectsAccessibility: true
+    affectsJavascript: true
+    affectsStyles: true
+    githubPr: 5063
+    githubRepo: uswds
+    versionUswds: 3.5.0
   - date: 2023-03-09
     summary: Updated documentation for accessibility guidance.
     summaryAdditional: Added instructions for keyboard navigation.

--- a/_data/changelogs/component-file-input.yml
+++ b/_data/changelogs/component-file-input.yml
@@ -2,6 +2,15 @@ title: File input
 type: component
 changelogURL:
 items:
+  - date: 2023-03-28
+    summary: Normalize disabled form elements
+    summaryAdditional: Form elements with the `disabled` or `aria-disabled` attribute are now consistently styled accross USWDS and ensure proper color contrast
+    affectsAccessibility: true
+    affectsJavascript: true
+    affectsStyles: true
+    githubPr: 5063
+    githubRepo: uswds
+    versionUswds: 3.5.0
   - date: 2022-04-28
     summary: Updated package name to `usa-file-input`.
     affectsGuidance: true

--- a/_data/changelogs/component-input-mask.yml
+++ b/_data/changelogs/component-input-mask.yml
@@ -2,6 +2,14 @@ title: Input mask
 type: component
 changelogURL:
 items:
+  - date: 2023-03-28
+    summary: Normalize disabled form elements
+    summaryAdditional: Form elements with the `disabled` or `aria-disabled` attribute are now consistently styled accross USWDS and ensure proper color contrast
+    affectsAccessibility: true
+    affectsStyles: true
+    githubPr: 5063
+    githubRepo: uswds
+    versionUswds: 3.5.0
   - date: 2022-11-14
     summary: Component released.
     affectsGuidance: true

--- a/_data/changelogs/component-input-prefix-suffix.yml
+++ b/_data/changelogs/component-input-prefix-suffix.yml
@@ -2,6 +2,15 @@ title: Input prefix or suffix
 type: component
 changelogURL:
 items:
+  - date: 2023-03-28
+    summary: Normalize disabled form elements
+    summaryAdditional: Form elements with the `disabled` or `aria-disabled` attribute are now consistently styled accross USWDS and ensure proper color contrast
+    affectsAccessibility: true
+    affectsJavascript: true
+    affectsStyles: true
+    githubPr: 5063
+    githubRepo: uswds
+    versionUswds: 3.5.0
   - date: 2022-04-28
     summary: Updated package name to `usa-input-prefix-suffix`.
     affectsGuidance: true

--- a/_data/changelogs/component-radio-buttons.yml
+++ b/_data/changelogs/component-radio-buttons.yml
@@ -2,6 +2,14 @@ title: Radio buttons
 type: component
 changelogURL:
 items:
+- date: 2023-03-28
+  summary: Normalize disabled form elements
+  summaryAdditional: Form elements with the `disabled` or `aria-disabled` attribute are now consistently styled accross USWDS and ensure proper color contrast
+  affectsAccessibility: true
+  affectsStyles: true
+  githubPr: 5063
+  githubRepo: uswds
+  versionUswds: 3.5.0
 - date: 2022-08-05
   summary: Styled aria-disabled to match disabled.
   summaryAdditional: Now disabled styling is applied whether you use `disabled` (disabled and hidden from screen readers) or `aria-disabled` (disabled and visible to screen readers).

--- a/_data/changelogs/component-range-slider.yml
+++ b/_data/changelogs/component-range-slider.yml
@@ -2,6 +2,14 @@ title: Range slider
 type: component
 changelogURL:
 items:
+- date: 2023-03-28
+  summary: Normalize disabled form elements
+  summaryAdditional: Form elements with the `disabled` or `aria-disabled` attribute are now consistently styled accross USWDS and ensure proper color contrast
+  affectsAccessibility: true
+  affectsStyles: true
+  githubPr: 5063
+  githubRepo: uswds
+  versionUswds: 3.5.0
 - date: 2022-04-28
   summary: Updated to Sass module syntax and new package structure.
   isBreaking: true

--- a/_data/changelogs/component-select.yml
+++ b/_data/changelogs/component-select.yml
@@ -2,6 +2,14 @@ title: Select
 type: component
 changelogURL:
 items:
+- date: 2023-03-28
+  summary: Normalize disabled form elements
+  summaryAdditional: Form elements with the `disabled` or `aria-disabled` attribute are now consistently styled accross USWDS and ensure proper color contrast
+  affectsAccessibility: true
+  affectsStyles: true
+  githubPr: 5063
+  githubRepo: uswds
+  versionUswds: 3.5.0
 - date:  2022-08-05
   summary: Improved styling for select when the `multiple` attribute is present.
   summaryAdditional: According to the HTML5 standard, a select element whose `multiple` attribute is present is "expected to render as an inline-block box whose height is the height necessary to contain as many rows for items as given by the element's display size, or four rows if the [size] attribute is absent." Our select now conforms to this guidance.

--- a/_data/changelogs/component-text-input.yml
+++ b/_data/changelogs/component-text-input.yml
@@ -5,6 +5,14 @@ type: component
 changelogURL:
 
 items:
+  - date: 2023-03-28
+    summary: Normalize disabled form elements
+    summaryAdditional: Form elements with the `disabled` or `aria-disabled` attribute are now consistently styled accross USWDS and ensure proper color contrast
+    affectsAccessibility: true
+    affectsStyles: true
+    githubPr: 5063
+    githubRepo: uswds
+    versionUswds: 3.5.0
   # 3.0.2 release
   - date: 2022-06-17
     summary: Improved form group error display.

--- a/_data/changelogs/component-time-picker.yml
+++ b/_data/changelogs/component-time-picker.yml
@@ -4,6 +4,15 @@ type: component
 changelogURL:
 
 items:
+  - date: 2023-03-28
+    summary: Normalize disabled form elements
+    summaryAdditional: Form elements with the `disabled` or `aria-disabled` attribute are now consistently styled accross USWDS and ensure proper color contrast
+    affectsAccessibility: true
+    affectsJavascript: true
+    affectsStyles: true
+    githubPr: 5063
+    githubRepo: uswds
+    versionUswds: 3.5.0
   # 3.0 release
   - date: 2022-04-28
     summary: Updated to Sass module syntax and new package structure.


### PR DESCRIPTION
# Summary

Contains change log items for all components which code was affected during disabled normalization

## Related issue

[USWDS #5063](https://github.com/uswds/uswds/pull/5063)

## Preview link

[Components Page →](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cm-disabled-changelogs/components/overview/)

## Component pages affected:

- Button
- Character Count
- Checkbox
- Combo Box
- Date Picker
- File Input
- Input Mask
- Input Prefix / Suffix
- Radio Buttons
- Range Slider
- Select
- Text Input
- Time Picker

### Further Consideration

I abstained from updated components whose direct code was not changed during the disabled styles work. These components still receive disabled styles, but weren't _directly_ changed.

For example, `character count` adopts the styles from input and `date range picker` adopts the styles from `date picker`

If we prefer to still add the change log items to these components, I will go back and add!

