### PR TITLE
Remove file-input-disabled from file-input partial

### DIFF
--- a/_data/changelogs/component-file-input.yml
+++ b/_data/changelogs/component-file-input.yml
@@ -5,6 +5,7 @@ items:
   - date: NNNN-NN-NN
     summary: Removed disabled file input variant preview.
     summaryAdditional: 
+    affectsGuidance: true
     githubPr: 2114
     githubRepo: uswds-site
     versionUswds: 3.5.0

--- a/_data/changelogs/component-file-input.yml
+++ b/_data/changelogs/component-file-input.yml
@@ -3,6 +3,12 @@ type: component
 changelogURL:
 items:
   - date: NNNN-NN-NN
+    summary: Removed disabled file input variant preview.
+    summaryAdditional: 
+    githubPr: 2114
+    githubRepo: uswds-site
+    versionUswds: 3.5.0
+  - date: NNNN-NN-NN
     summary: Improved the file input experience for voice command and screen reader users.
     summaryAdditional: Voice command users can now interact with the component by speaking the visible instructions text.
       Additionally, screen reader users now have access to both the instructions text

--- a/_includes/code/components/file-input.html
+++ b/_includes/code/components/file-input.html
@@ -18,6 +18,3 @@
   {% library_component usa-file-input~error %}
 {% endcapture %}{{ file-input-error | strip }}
 
-{% capture file-input-disabled %}
-  {% library_component usa-file-input~disabled %}
-{% endcapture %}{{ file-input-disabled | strip }}


### PR DESCRIPTION
# Summary

Remove `file-input-disabled` from component partial to resolve build error

## Related issue

Closes #2113

## Preview link

[File input →](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cm-remove-file-input-disabled/components/file-input/)

## Problem statement

The disabled variant `json` file was removed as part of https://github.com/uswds/uswds/pull/5063, causing build errors on site when it tries to find it.

## Solution

Remove template capture from the component partial

## Testing and review

1. On main, run `npm run build`
2. Confirm error
3. `git checkout cm-remove-file-input-disabled`
4. Run `npm run build`
5. Confirm error is extinguished
6. Vising [file input](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cm-remove-file-input-disabled/components/file-input/) page
7. Confirm page and component previews are displaying correctly

- [x] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `main`).
