### PR TITLE
USWDS-Site: Add note about settings with dot notation

### DIFF
--- a/pages/documentation/settings.md
+++ b/pages/documentation/settings.md
@@ -77,6 +77,12 @@ This will generate the same output as configuring the setting with default value
 );
 ```
 
+{:.site-note.radius-bottom-0}
+**Note:** We use dot notation to describe settings that are nested inside a Sass map. For example, for the code sample above, `$background-color-settings.responsive` would refer to the `responsive` property inside `$background-color-settings`.
+
+{:.site-note.margin-top-0.radius-top-0}
+Settings described with dot notation should be configured as a map, as shown in the previous example.
+
 ### What to include in your configuration
 Include only USWDS settings that you wish to modify in this configuration. These items should be comma-separated and given values of the appropriate type, as identified in the tables below.
 


### PR DESCRIPTION
# Summary
Added a note for how to configure settings described using dot notation. 

## Related issue

Closes #2116 

## Preview link

Preview link: Settings page

## Problem statement
On our site, we use dot notation to describe settings that are nested inside a settings map. For example: we refer to `$background-color-settings.responsive` in our [utilities documentation](https://designsystem.digital.gov/utilities/color/#responsive-variants). This can lead to confusion when users try to configure this setting, because you cannot include the following in your USWDS configuration:
```
@use "uswds-core" with (
  $background-color-settings.responsive: true,
);
```

Instead, the configuration would need to look like this:
```
@use "uswds-core" with (
  $background-color-settings: (
      responsive: true,
    )
);
```

## Solution
Adding a note about dot notation next to the settings map configuration will help guide users to understand how to configure a setting described in dot notation.

## Testing and review
1. Confirm that the note conveys necessary meaning and is placed in the appropriate location on site. 
1. Confirm there are no spelling or grammatical errors.

