### PR TITLE
USWDS-Site - Table: Restore standard table and striped table component previews

### DIFF
--- a/_components/table/01-standard-table.md
+++ b/_components/table/01-standard-table.md
@@ -3,14 +3,14 @@ component:
   status: ready
   package: usa-table
   dependencies:
-  variant: scrollable
-guidancePath: guidance/variants/scrollable
+  variant:
+guidancePath: guidance/variants/default
 layout: styleguide
-lead: A scrollable table is ideal for dense data.
-order: 02
+lead: 
+order: 01
 parent: Table
 sitemap: false
-title: Scrollable table
+title: Standard table
 ---
 
 {% include component-preview-and-code.html level="h3" %}

--- a/_components/table/02-striped-table.md
+++ b/_components/table/02-striped-table.md
@@ -1,0 +1,16 @@
+---
+component:
+  status: ready
+  package: usa-table
+  dependencies:
+  variant: striped
+guidancePath: guidance/variants/default
+layout: styleguide
+lead: 
+order: 02
+parent: Table
+sitemap: false
+title: Striped table
+---
+
+{% include component-preview-and-code.html level="h3" %}

--- a/_components/table/03-borderless-table.md
+++ b/_components/table/03-borderless-table.md
@@ -7,7 +7,7 @@ component:
 guidancePath: guidance/variants/default
 layout: styleguide
 lead: A borderless table can be useful when you want the information to feel more a part of the text it accompanies and extends.
-order: 01
+order: 03
 parent: Table
 sitemap: false
 title: Borderless table

--- a/_components/table/04-stacked-table.md
+++ b/_components/table/04-stacked-table.md
@@ -7,7 +7,7 @@ component:
 guidancePath: guidance/variants/scrollable
 layout: styleguide
 lead: A responsive stacked table collapses at narrow widths for better readability on small screens.
-order: 03
+order: 04
 parent: Table
 sitemap: false
 title: Responsive stacked table

--- a/_components/table/05-scrollable-table.md
+++ b/_components/table/05-scrollable-table.md
@@ -1,0 +1,16 @@
+---
+component:
+  status: ready
+  package: usa-table
+  dependencies:
+  variant: scrollable
+guidancePath: guidance/variants/scrollable
+layout: styleguide
+lead: A scrollable table is ideal for dense data.
+order: 05
+parent: Table
+sitemap: false
+title: Scrollable table
+---
+
+{% include component-preview-and-code.html level="h3" %}

--- a/_components/table/06-sortable-table-rows.md
+++ b/_components/table/06-sortable-table-rows.md
@@ -7,7 +7,7 @@ component:
 guidancePath: guidance/variants/sortable
 layout: styleguide
 lead: A sorted column changes the row ordering based on alphabetical or numeric cell values.
-order: 04
+order: 06
 parent: Table
 sitemap: false
 title: Sortable table rows

--- a/_components/table/table.md
+++ b/_components/table/table.md
@@ -11,6 +11,10 @@ redirect_from:
 - /components/tables/
 layout: styleguide
 subnav:
+- test: Standard table
+  href: '#usa-table'
+- test: Striped table
+  href: '#striped-table'
 - text: Borderless table
   href: '#borderless-table'
 - text: Scrollable table

--- a/_includes/code/components/table--striped.html
+++ b/_includes/code/components/table--striped.html
@@ -1,0 +1,4 @@
+{% capture table--striped %}
+  {% library_component usa-table~striped %}
+{% endcapture %}{{ table--striped | strip }}
+


### PR DESCRIPTION
# Summary

**Restore standard table and striped table component previews to guidance page**

## Related issue

Closes #2140 

## Preview link

Preview link:
Table →

## Problem statement

The Table guidance page was missing the standard and striped component previews and code blocks

## Solution

Create standard and striped variant markdown files and component code `include` file.

## Testing and review

1. Visit the Table guidance page
2. Confirm that standard & striped table previews are visible
3. Confirm their code previews are correct and not missing any markup
4. Confirm that side-nav matches page flow and that variants are in the expected order
5. Confirm appropriate change log items


<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `main`).
- [ ] Run `npm run prettier:scss` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->