### PR TITLE
USWDS-Site: Add changelog entries for #5358

### DIFF
--- a/_data/changelogs/component-pagination.yml
+++ b/_data/changelogs/component-pagination.yml
@@ -17,7 +17,7 @@ items:
   affectsStyles: true
   githubPr: 5358
   githubRepo: uswds
-  versionUswds: 3.6.0
+  versionUswds: N.N.N
 - date: 2023-06-09
   summary: Improved legibility in forced colors mode.
   summaryAdditional: Adds a consistent border in forced colors mode.

--- a/_data/changelogs/component-pagination.yml
+++ b/_data/changelogs/component-pagination.yml
@@ -2,6 +2,14 @@ title: Pagination
 type: component
 changelogURL:
 items:
+- date: NNNN-NN-NN
+  summary: Updated the ellipsis color to meet color contrast requirements.
+  summaryAdditional:
+  affectsAccessibility: true
+  affectsStyles: true
+  githubPr: 5358
+  githubRepo: uswds
+  versionUswds: 3.6.0
 - date: 2023-06-09
   summary: Improved legibility in forced colors mode.
   summaryAdditional: Adds a consistent border in forced colors mode.

--- a/_data/changelogs/component-pagination.yml
+++ b/_data/changelogs/component-pagination.yml
@@ -9,7 +9,7 @@ items:
   affectsStyles: true
   githubPr: 5358
   githubRepo: uswds
-  versionUswds: 3.6.0
+  versionUswds: N.N.N
 - date: NNNN-NN-NN
   summary: Updated the ellipsis color to meet color contrast requirements.
   summaryAdditional:

--- a/_data/changelogs/component-pagination.yml
+++ b/_data/changelogs/component-pagination.yml
@@ -4,7 +4,7 @@ changelogURL:
 items:
 - date: NNNN-NN-NN
   summary: Updated styles to respect the value of `$theme-pagination-background-color`.
-  summaryAdditional:
+  summaryAdditional: Users should confirm that pagination colors display as expected.
   isBreaking: true
   affectsStyles: true
   githubPr: 5358

--- a/_data/changelogs/component-pagination.yml
+++ b/_data/changelogs/component-pagination.yml
@@ -3,6 +3,14 @@ type: component
 changelogURL:
 items:
 - date: NNNN-NN-NN
+  summary: Updated styles to respect the value of `$theme-pagination-background-color`.
+  summaryAdditional:
+  isBreaking: true
+  affectsStyles: true
+  githubPr: 5358
+  githubRepo: uswds
+  versionUswds: 3.6.0
+- date: NNNN-NN-NN
   summary: Updated the ellipsis color to meet color contrast requirements.
   summaryAdditional:
   affectsAccessibility: true


### PR DESCRIPTION
# Summary
Added changelog entries for https://github.com/uswds/uswds/pull/5358

> Updated the ellipsis color to meet color contrast requirements.
> Updated styles to respect the value added to $theme-pagination-background-color.

## Preview link
[Pagination changelog](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-changelog-5358/components/pagination/#changelog)
