### PR TITLE
USWDS-Site - Implementations: Add comet from metrostar

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2707,8 +2707,8 @@ ignore:
         expires: '2022-01-27T21:29:25.295Z'
     - '*':
         reason: No available upgrade or patch
-        expires: 2023-07-09T22:06:05.497Z
-        created: 2023-06-09T22:06:05.590Z
+        expires: 2023-08-10T15:54:47.844Z
+        created: 2023-07-11T15:54:47.936Z
   SNYK-JS-AXIOS-1579269:
     - uswds > @frctl/fractal > @frctl/web > browser-sync > localtunnel > axios:
         reason: None given
@@ -3498,8 +3498,8 @@ ignore:
   SNYK-JS-UNSETVALUE-2400660:
     - '*':
         reason: No available upgrade or patch
-        expires: 2023-07-09T22:06:36.828Z
-        created: 2023-06-09T22:06:36.923Z
+        expires: 2023-08-10T15:54:16.870Z
+        created: 2023-07-11T15:54:16.975Z
   SNYK-JS-DECODEURICOMPONENT-3149970:
     - '*':
         reason: No available upgrade or patch

--- a/_data/changelogs/docs-implementations.yml
+++ b/_data/changelogs/docs-implementations.yml
@@ -2,7 +2,7 @@ title: Implementations
 type: documentation
 changelogURL:
 items:
-  - date: 2023-06-27
+  - date: 2023-07-11
     summary: Added entry for "Comet".
     summaryAdditional:
     isBreaking:

--- a/_data/changelogs/docs-implementations.yml
+++ b/_data/changelogs/docs-implementations.yml
@@ -2,6 +2,18 @@ title: Implementations
 type: documentation
 changelogURL:
 items:
+  - date: 2023-06-27
+    summary: Added entry for "Comet".
+    summaryAdditional:
+    isBreaking:
+    affectsAccessibility:
+    affectsAssets:
+    affectsGuidance: true
+    affectsJavascript:
+    affectsMarkup:
+    affectsStyles:
+    githubPr: 2152
+    githubRepo: uswds-site
   - date: 2023-03-09
     summary: Added entry for "sam.gov" implementations.
     summaryAdditional:

--- a/_data/implementations.yml
+++ b/_data/implementations.yml
@@ -145,7 +145,7 @@
     name: MetroStar
     url: https://github.com/MetroStar
   version: 3.5.0
-  notes: "React with TypeScript implementation of USWDS, providing additional modular support for custom components, data visualization, and command line tools. Sample starter app included that is focused on accelerating and scaling design across the enterprise."
+  notes: "A React with TypeScript component library based on USWDS 3.0. This library provides modular support for custom components, data visualization, and command line tools. Comet also includes a sample starter app that is focused on accelerating and scaling design across the enterprise."
 
 - name: react-uswds
   distribution: React
@@ -217,7 +217,7 @@
     name: Brian Hurst
     url: https://github.com/hursey013
   notes: "A Tailwind CSS plugin for adding U.S. Web Design System design tokens to supported Tailwind utilities."
-  
+
 - name: Vue USWDS
   distribution: Vue.js
   id: vue-uswds

--- a/_data/implementations.yml
+++ b/_data/implementations.yml
@@ -137,6 +137,16 @@
     url: https://github.com/18F
   notes: "This [Ruby on Rails](http://rubyonrails.org/) gem is not currently maintained."
 
+- name: Comet
+  distribution: React
+  id: comet-uswds
+  url: https://github.com/MetroStar/comet
+  author:
+    name: MetroStar
+    url: https://github.com/MetroStar
+  version: 3.5.0
+  notes: "React with TypeScript implementation of USWDS, providing additional modular support for custom components, data visualization, and command line tools. Sample starter app included that is focused on accelerating and scaling design across the enterprise."
+
 - name: react-uswds
   distribution: React
   id: react-uswds

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "federalist": "npx gulp build",
     "lint": "npx gulp lintJS lintSass && npm run prettier:scss",
     "prestart": "npx gulp build",
-    "proof": "bundle exec htmlproofer --allow-hash-href=true --enforce-https=false --allow-missing-href=true --ignore-empty-alt=true --ignore-status-codes 0,403,429,503,302 --swap-urls 'https\\://designsystem.digital.gov/:/' --ignore-files \"//select-a-language//,//2017//,//2018//,//2019//\" ./_site",
+    "proof": "bundle exec htmlproofer --allow-hash-href=true --enforce-https=false --allow-missing-href=true --ignore-empty-alt=true --ignore-status-codes 0,403,429,503,302 --swap-urls 'https\\://designsystem.digital.gov/:/' --ignore-files \"//select-a-language//,//2017//,//2018//,//2019//,//code-guidelines//\" ./_site",
     "serve": "npm run build:all-assets && bundle exec jekyll serve --drafts --future --incremental --livereload --host=localhost",
     "serve:package": "npm run build:uswds && npm run serve",
     "serve:local": "export LIBRARY_BASE_URL=\"http://localhost:3000\" && npm run serve",


### PR DESCRIPTION
Internal PR from https://github.com/uswds/uswds-site/pull/2152. Adds metrostar Comet implementation.

This PR also:
- Ignores code guidelines URL in HTMLProofer because of a false positive [f4166c8](https://github.com/uswds/uswds-site/pull/2167/commits/f4166c86fe41e076ace21c082d51b422a886bf7a).
- Updates snyk ignore (USWDS/Compile warnings) [bb873d2](https://github.com/uswds/uswds-site/pull/2167/commits/bb873d2ff7ff1e65fc897cde0fda7184de8b5428).