### PR TITLE
USWDS-Site: Add changelog entries for #5372

### DIFF
--- a/_data/changelogs/component-memorable-date.yml
+++ b/_data/changelogs/component-memorable-date.yml
@@ -8,7 +8,7 @@ items:
   affectsStyles: true
   githubRepo: uswds
   githubPr: 5372
-  versionUswds: 3.6.0
+  versionUswds: N.N.N
 - date: 2022-11-14
   summary: Updated the month entry to a `select` from an `input`.
   summaryAdditional: Recent usability testing indicated that using a `select` for month entry was more clear and reduced mistakes.

--- a/_data/changelogs/component-memorable-date.yml
+++ b/_data/changelogs/component-memorable-date.yml
@@ -2,6 +2,13 @@ title: Memorable date
 type: component
 changelogURL:
 items:
+- date: NNNN-NN-NN
+  summary: Updated memorable date styles to allow elements to wrap to multiple lines at narrow widths.
+  summaryAdditional:
+  affectsStyles: true
+  githubRepo: uswds
+  githubPr: 5372
+  versionUswds: 3.6.0
 - date: 2022-11-14
   summary: Updated the month entry to a `select` from an `input`.
   summaryAdditional: Recent usability testing indicated that using a `select` for month entry was more clear and reduced mistakes.

--- a/_data/changelogs/component-memorable-date.yml
+++ b/_data/changelogs/component-memorable-date.yml
@@ -3,7 +3,7 @@ type: component
 changelogURL:
 items:
 - date: NNNN-NN-NN
-  summary: Updated memorable date styles to allow elements to wrap to multiple lines at narrow widths.
+  summary: Updated styles to allow the component to wrap to multiple lines at narrow widths.
   summaryAdditional:
   affectsStyles: true
   githubRepo: uswds


### PR DESCRIPTION
# Summary
Added changelog entry for https://github.com/uswds/uswds/pull/5372

> Updated memorable date styles to allow elements to wrap to multiple lines at narrow widths.

## Preview link

Preview link: [Memorable date changelog](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-changelog-5372/components/memorable-date/#changelog)