### PR TITLE
USWDS-Site - Changelog: Update docs and add changelog for Icon list add size tokens [USWDS#5363]

### DIFF
--- a/_components/icon-list/icon-list.md
+++ b/_components/icon-list/icon-list.md
@@ -24,7 +24,7 @@ variants:
   - variant: "`.usa-icon-list--[color]`"
     description: Change the color of all the list's icons by updating [color] to any one of the theme colors listed on the [color utilities](/utilities/color) page.
   - variant: "`usa-icon-list--size-[size]`"
-    description: "Change the size of the text and icon by updating [size] to one of the following theme font sizes: `3xs`, `2xs`, `xs`, `sm`, `md`, `lg`, `xl`, `2xl`, or `3xl` as detailed on the [font size and family](/utilities/font-size-and-family) utility page."
+    description: "Change the size of the text and icon by updating [size] to a [font size token](/design-tokens/typesetting/font-size/)."
   - variant: "`[responsive_variant]:usa-icon-list--size-[size]`"
     description: "Add a responsive breakpoint prefix separated with a `:` to target a utility at a responsive breakpoint and higher, following a mobile-first methodology."
 changelog:

--- a/_components/icon-list/icon-list.md
+++ b/_components/icon-list/icon-list.md
@@ -24,7 +24,7 @@ variants:
   - variant: "`.usa-icon-list--[color]`"
     description: Change the color of all the list's icons by updating [color] to any one of the theme colors listed on the [color utilities](/utilities/color) page.
   - variant: "`usa-icon-list--size-[size]`"
-    description: "Change the size of the text and icon by updating [size] to a theme font size: `2xs`, `xs`, `sm`, `md`, `lg`, `xl`, or `2xl` as detailed on the [font size and family](/utilities/font-size-and-family) utility page."
+    description: "Change the size of the text and icon by updating [size] to one of the following theme font sizes: `3xs`, `2xs`, `xs`, `sm`, `md`, `lg`, `xl`, `2xl`, or `3xl` as detailed on the [font size and family](/utilities/font-size-and-family) utility page."
   - variant: "`[responsive_variant]:usa-icon-list--size-[size]`"
     description: "Add a responsive breakpoint prefix separated with a `:` to target a utility at a responsive breakpoint and higher, following a mobile-first methodology."
 changelog:

--- a/_data/changelogs/docs-settings.yml
+++ b/_data/changelogs/docs-settings.yml
@@ -3,7 +3,7 @@ type: utility
 changelogURL:
 items:
   - date: NNNN-NN-NN
-    summary: Updated styles to allow `$theme-body-font-size` to accept `2xs` and `3xs` size tokens.
+    summary: Fixed a bug that prevented `$theme-body-font-size` from accepting `2xs` and `3xs` size tokens.
     affectsStyles: true
     githubPr: 5363
     githubRepo: uswds

--- a/_data/changelogs/docs-settings.yml
+++ b/_data/changelogs/docs-settings.yml
@@ -7,7 +7,7 @@ items:
     affectsStyles: true
     githubPr: 5363
     githubRepo: uswds
-    versionUswds: 3.6.0
+    versionUswds: N.N.N
   - date: 2023-06-09
     summary: Added accordion color settings.
     summaryAdditional: You can now customize accordion button and content background colors with `$theme-accordion-button-background-color` and `$theme-accordion-background-color`.

--- a/_data/changelogs/docs-settings.yml
+++ b/_data/changelogs/docs-settings.yml
@@ -2,6 +2,12 @@ title: Settings
 type: utility
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Updated styles to allow `$theme-body-font-size` to accept `2xs` and `3xs` size tokens.
+    affectsStyles: true
+    githubPr: 5363
+    githubRepo: uswds
+    versionUswds: 3.6.0
   - date: 2023-06-09
     summary: Added accordion color settings.
     summaryAdditional: You can now customize accordion button and content background colors with `$theme-accordion-button-background-color` and `$theme-accordion-background-color`.


### PR DESCRIPTION
# Summary
Added changelog entries for https://github.com/uswds/uswds/pull/5363

## Related PR
Related to https://github.com/uswds/uswds/pull/5363
> Updated icon list styles to allow `$theme-body-font-size` to accept `2xs` and `3xs` size tokens.

## Preview link

- [Settings changelog](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-changelog-5363/documentation/settings/#changelog)
- [Icon list - variants](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-changelog-5363/components/icon-list/#component-variants-icon-list)