### PR TITLE
USWDS-Site - Changelog: Add entry for Input mask fix hover state [USWDS#5378]

### DIFF
--- a/_data/changelogs/component-input-mask.yml
+++ b/_data/changelogs/component-input-mask.yml
@@ -2,6 +2,13 @@ title: Input mask
 type: component
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Fixed a bug that caused the hover state to adopt disabled styling.
+    summaryAdditional:
+    affectsStyles: true
+    githubPr: 5378
+    githubRepo: uswds
+    versionUswds: 3.6.0
   - date: 2023-06-09
     summary: Improved consistency and visibility of disabled styles.
     summaryAdditional: Form elements with the `disabled` or `aria-disabled` attribute now get consistent styling and have proper color contrast.

--- a/_data/changelogs/component-input-mask.yml
+++ b/_data/changelogs/component-input-mask.yml
@@ -4,14 +4,12 @@ changelogURL:
 items:
   - date: NNNN-NN-NN
     summary: Fixed a bug that caused the hover state to adopt disabled styling.
-    summaryAdditional:
     affectsStyles: true
     githubPr: 5378
     githubRepo: uswds
     versionUswds: N.N.N
   - date: NNNN-NN-NN
     summary: Improved legibility in forced colors mode.
-    summaryAdditional:
     affectsStyles: true
     githubPr: 5378
     githubRepo: uswds

--- a/_data/changelogs/component-input-mask.yml
+++ b/_data/changelogs/component-input-mask.yml
@@ -9,6 +9,13 @@ items:
     githubPr: 5378
     githubRepo: uswds
     versionUswds: 3.6.0
+  - date: NNNN-NN-NN
+    summary: Improved legibility in forced colors mode.
+    summaryAdditional:
+    affectsStyles: true
+    githubPr: 5378
+    githubRepo: uswds
+    versionUswds: 3.6.0
   - date: 2023-06-09
     summary: Improved consistency and visibility of disabled styles.
     summaryAdditional: Form elements with the `disabled` or `aria-disabled` attribute now get consistent styling and have proper color contrast.

--- a/_data/changelogs/component-input-mask.yml
+++ b/_data/changelogs/component-input-mask.yml
@@ -8,14 +8,14 @@ items:
     affectsStyles: true
     githubPr: 5378
     githubRepo: uswds
-    versionUswds: 3.6.0
+    versionUswds: N.N.N
   - date: NNNN-NN-NN
     summary: Improved legibility in forced colors mode.
     summaryAdditional:
     affectsStyles: true
     githubPr: 5378
     githubRepo: uswds
-    versionUswds: 3.6.0
+    versionUswds: N.N.N
   - date: 2023-06-09
     summary: Improved consistency and visibility of disabled styles.
     summaryAdditional: Form elements with the `disabled` or `aria-disabled` attribute now get consistent styling and have proper color contrast.


### PR DESCRIPTION
# Summary
Added changelog entries for uswds/uswds#5378

## Related PR

Related to uswds/uswds#5378
> Fixed a bug that caused the input mask hover state to adopt disabled styling.

## Preview link
[Input mask changelog](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-changelog-5378/components/input-mask/#latest-updates)