### PR TITLE
USWDS-Site: Remove broken reference link on research page

### DIFF
--- a/_data/changelogs/about-research.yml
+++ b/_data/changelogs/about-research.yml
@@ -1,0 +1,9 @@
+title: Research
+type: documentation
+changelogURL:
+items:
+  - date: NNNN-NN-NN
+    summary: Removed broken link.
+    affectsGuidance: true
+    githubPr: 2185
+    githubRepo: uswds-site

--- a/_data/changelogs/about-research.yml
+++ b/_data/changelogs/about-research.yml
@@ -2,7 +2,7 @@ title: Research
 type: documentation
 changelogURL:
 items:
-  - date: NNNN-NN-NN
+  - date: 2023-07-14
     summary: Removed broken link.
     affectsGuidance: true
     githubPr: 2185

--- a/pages/about/research.md
+++ b/pages/about/research.md
@@ -28,10 +28,9 @@ Web Design System. We will use this information to identify future
 improvements to the design patterns. You can use these metrics to help justify
 the adoption and continued use of USWDS.
 
-#### References
+#### Reference
 
-- [https://www.nngroup.com/articles/analytics-reports-ux-strategists/](https://www.nngroup.com/articles/analytics-reports-ux-strategists/)
-- [http://www.uxbooth.com/articles/an-analytics-first-approach-to-ux-part-1/](http://www.uxbooth.com/articles/an-analytics-first-approach-to-ux-part-1/)
+[https://www.nngroup.com/articles/analytics-reports-ux-strategists/](https://www.nngroup.com/articles/analytics-reports-ux-strategists/)
 
 ## User Research Activities
 

--- a/pages/about/research.md
+++ b/pages/about/research.md
@@ -23,10 +23,9 @@ Web Design System. We will use this information to identify future
 improvements to the design patterns. You can use these metrics to help justify
 the adoption and continued use of USWDS.
 
-#### References
+#### Reference
 
-- [https://www.nngroup.com/articles/analytics-reports-ux-strategists/](https://www.nngroup.com/articles/analytics-reports-ux-strategists/)
-- [http://www.uxbooth.com/articles/an-analytics-first-approach-to-ux-part-1/](http://www.uxbooth.com/articles/an-analytics-first-approach-to-ux-part-1/)
+[https://www.nngroup.com/articles/analytics-reports-ux-strategists/](https://www.nngroup.com/articles/analytics-reports-ux-strategists/)
 
 ## User Research Activities
 

--- a/pages/about/research.md
+++ b/pages/about/research.md
@@ -9,6 +9,11 @@ category: About
 lead: User research is a core aspect of USWDS as it’s our main source of feedback and inspiration for future product development.
 redirect_from:
   - /whats-new/research/
+subnav:
+- text: Latest updates
+  href: '#changelog'
+changelog:
+  key: about-research
 ---
 
 We plan to use a combination of research methods, quantitative research like collecting web analytics to see how frequently USWDS is used around the federal government, and qualitative research like remote observational studies to see whether USWDS is making government sites easier for people to use. We’ll use this research to see how well USWDS is working and what needs to be improved.
@@ -23,9 +28,10 @@ Web Design System. We will use this information to identify future
 improvements to the design patterns. You can use these metrics to help justify
 the adoption and continued use of USWDS.
 
-#### Reference
+#### References
 
-[https://www.nngroup.com/articles/analytics-reports-ux-strategists/](https://www.nngroup.com/articles/analytics-reports-ux-strategists/)
+- [https://www.nngroup.com/articles/analytics-reports-ux-strategists/](https://www.nngroup.com/articles/analytics-reports-ux-strategists/)
+- [http://www.uxbooth.com/articles/an-analytics-first-approach-to-ux-part-1/](http://www.uxbooth.com/articles/an-analytics-first-approach-to-ux-part-1/)
 
 ## User Research Activities
 


### PR DESCRIPTION
# Summary
Removed broken link from research page

## Related issue

Closes #2184

## Preview link

Preview link: [Research page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-500-error/about/research/)

## Problem statement

This broken link is causing build errors on uswds-site: http://www.uxbooth.com/articles/an-analytics-first-approach-to-ux-part-1/

## Solution

Removed the broken link per the recommendation from @jaclinec. 

## Possible future enhancements
- Review the content on the research page to make sure it is up-to-date and accurate. 
- Consider finding a suitable replacement link for the reference section


## Testing and review

- Confirm that the link is still broken
- Confirm that this update passes tests
- Confirm the changelog is accurate and free from error
