### PR TITLE
USWDS-Site - Changelog: Add entry for in-page nav exclude hidden headers [USWDS#5393]

### DIFF
--- a/_data/changelogs/component-in-page-navigation.yml
+++ b/_data/changelogs/component-in-page-navigation.yml
@@ -8,7 +8,7 @@ items:
     affectsJavascript: true
     githubRepo: uswds
     githubPr: 5393
-    versionUswds: 3.5.1
+    versionUswds: N.N.N
   - date: 2023-06-09
     summary: Fixed a bug that prevented links that start with a number from scrolling when clicked.
     summaryAdditional:

--- a/_data/changelogs/component-in-page-navigation.yml
+++ b/_data/changelogs/component-in-page-navigation.yml
@@ -3,8 +3,8 @@ type: component
 changelogURL:
 items:
   - date: NNNN-NN-NN
-    summary: Excluded hidden headers from the in-page navigation link list.
-    summaryAdditional: Any header with a style of `display:none` or `visibility:hidden` will be excluded from the list of links in the component.
+    summary: Updated JavaScript to exclude hidden headers from the in-page navigation link list.
+    summaryAdditional: Any header with a style of `display:none` or `visibility:hidden` will now be excluded from the list of links in the component.
     affectsJavascript: true
     githubRepo: uswds
     githubPr: 5393

--- a/_data/changelogs/component-in-page-navigation.yml
+++ b/_data/changelogs/component-in-page-navigation.yml
@@ -8,7 +8,7 @@ items:
     affectsJavascript: true
     githubRepo: uswds
     githubPr: 5393
-    versionUswds: 3.6.0
+    versionUswds: 3.5.1
   - date: 2023-06-09
     summary: Fixed a bug that prevented links that start with a number from scrolling when clicked.
     summaryAdditional:

--- a/_data/changelogs/component-in-page-navigation.yml
+++ b/_data/changelogs/component-in-page-navigation.yml
@@ -2,6 +2,13 @@ title: In-page navigation
 type: component
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Excluded hidden headers from the in-page navigation link list.
+    summaryAdditional: Any header with a style of `display:none` or `visibility:hidden` will be excluded from the list of links in the component.
+    affectsJavascript: true
+    githubRepo: uswds
+    githubPr: 5393
+    versionUswds: 3.6.0
   - date: 2023-06-09
     summary: Fixed a bug that prevented links that start with a number from scrolling when clicked.
     summaryAdditional:


### PR DESCRIPTION
# Summary
Added changelog entries for https://github.com/uswds/uswds/pull/5393

## Related PR 
Related to https://github.com/uswds/uswds/pull/5393

> Excluded hidden headers from the in-page navigation link list. Any header with a style of display:none or visibility:hidden will be excluded from the list of links in the component.

## Preview link
[Changelog entry](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-changelog-5393-2/components/in-page-navigation/#latest-updates)