### PR TITLE
USWDS-Site: Add content tag to changelog table

### DIFF
--- a/_includes/changelog-table.html
+++ b/_includes/changelog-table.html
@@ -46,6 +46,9 @@
           {% if item.affectsAssets %}
             <li><span class="output-neutral">Assets</span></li>
           {% endif %}
+          {% if item.affectsContent %}
+            <li><span class="output-neutral">Content</span></li>
+          {% endif %}
           {% if item.affectsGuidance %}
             <li><span class="output-neutral">Guidance</span></li>
           {% endif %}


### PR DESCRIPTION
# Summary

Added the `Content` tag to the changelog table. 

This review should require a low level of effort. 

## Related issue

Closes #2202

## Preview link
- [Banner](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-affectscontent-tag/components/banner/#changelog)
- [Identifier](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-affectscontent-tag/components/identifier/#changelog)

## Problem statement
The content tag currently does not appear in the changelog tables. Here is an example on the [identifer page](https://designsystem.digital.gov/components/identifier/#latest-updates):

![image](https://github.com/uswds/uswds-site/assets/93996430/7ed0605d-fff3-4d04-81e0-af51bc86f4e6)

And on the banner page:
![image](https://github.com/uswds/uswds-site/assets/93996430/3ac95549-54be-4c71-8b77-880431417c62)


## Solution
Including a check for `affectsContent` in the changelog table adds the "Content" tag. 

After:

Identifier

![image](https://github.com/uswds/uswds-site/assets/93996430/073158ea-d0ec-433d-8b7d-5694200aefcf)

Banner

![image](https://github.com/uswds/uswds-site/assets/93996430/bcebf0c9-9f04-4f72-bfd7-93d79a2c0400)

## Testing and review
Confirm that the items tagged with `affectsContent: true` receive the Content tag in the changelog table. 