### PR TITLE
USWDS-Site - Changelog: Add entry for remove high-contrast disabled border from %block-input-styles [USWDS#5397]

### DIFF
--- a/_data/changelogs/component-form.yml
+++ b/_data/changelogs/component-form.yml
@@ -7,7 +7,7 @@ changelogURL:
 items:
   - date: NNNN-NN-NN
     summary: Fixed a bug that caused standard text input variants to show disabled styles when in forced colors mode.
-    summaryAdditional: Now the disabled border color only shows when the element is correctly disabled.
+    summaryAdditional: Now the disabled border color only shows when the element is disabled.
     affectsStyles: true
     affectsAccessibility: true
     githubPr: 5397

--- a/_data/changelogs/component-form.yml
+++ b/_data/changelogs/component-form.yml
@@ -12,7 +12,7 @@ items:
     affectsAccessibility: true
     githubPr: 5397
     githubRepo: uswds
-    versionUswds: 3.5.1
+    versionUswds: N.N.N
   - date: 2023-06-09
     summary: Updated guidance to suggest identifying required and optional fields.
     summaryAdditional: We added a new section on identifying required fields and now suggest labeling required fields with a red asterisk and optional fields with the word "optional".

--- a/_data/changelogs/component-form.yml
+++ b/_data/changelogs/component-form.yml
@@ -12,7 +12,7 @@ items:
     affectsAccessibility: true
     githubPr: 5397
     githubRepo: uswds
-    versionUswds: 3.6.0
+    versionUswds: 3.5.1
   - date: 2023-06-09
     summary: Updated guidance to suggest identifying required and optional fields.
     summaryAdditional: We added a new section on identifying required fields and now suggest labeling required fields with a red asterisk and optional fields with the word "optional".

--- a/_data/changelogs/component-form.yml
+++ b/_data/changelogs/component-form.yml
@@ -5,6 +5,14 @@ title: Form
 type: component
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Removed high-contrast disabled border from text input standard variants.
+    summaryAdditional: Now the disabled border color only shows when the element is correctly disabled.
+    affectsStyles: true
+    affectsAccessibility: true
+    githubPr: 5397
+    githubRepo: uswds
+    versionUswds: 3.6.0
   - date: 2023-06-09
     summary: Updated guidance to suggest identifying required and optional fields.
     summaryAdditional: We added a new section on identifying required fields and now suggest labeling required fields with a red asterisk and optional fields with the word "optional".

--- a/_data/changelogs/component-form.yml
+++ b/_data/changelogs/component-form.yml
@@ -6,7 +6,7 @@ type: component
 changelogURL:
 items:
   - date: NNNN-NN-NN
-    summary: Removed high-contrast disabled border from text input standard variants.
+    summary: Fixed a bug that caused standard text input variants to show disabled styles when in forced colors mode.
     summaryAdditional: Now the disabled border color only shows when the element is correctly disabled.
     affectsStyles: true
     affectsAccessibility: true


### PR DESCRIPTION
# Summary

Add change log item for https://github.com/uswds/uswds/pull/5397

## Preview link

[Form change log](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cm-hc-input-border-changelog/components/form/#latest-updates) →
