### PR TITLE
USWDS-Site - Changelog: Add entry for generate font-[family]-[size] classes [USWDS#5388]

### DIFF
--- a/_data/changelogs/utilities-font-size.yml
+++ b/_data/changelogs/utilities-font-size.yml
@@ -8,4 +8,4 @@ items:
     affectsStyles: true
     githubPr: 5388
     githubRepo: uswds
-    versionUswds: 3.5.1
+    versionUswds: N.N.N

--- a/_data/changelogs/utilities-font-size.yml
+++ b/_data/changelogs/utilities-font-size.yml
@@ -1,0 +1,11 @@
+title: Font size and family
+type: utility
+changelogURL:
+items:
+  - date: NNNN-NN-NN
+    summary: Fixed a bug that caused `font-[family]-[size]` utility classes to not generate font-family rules.
+    summaryAdditional:
+    affectsStyles: true
+    githubPr: 5388
+    githubRepo: uswds
+    versionUswds: 3.5.1

--- a/_utilities/font-size-and-family.md
+++ b/_utilities/font-size-and-family.md
@@ -14,7 +14,10 @@ subnav:
     href: "#utility-mixins"
   - text: Advanced settings
     href: "#advanced-settings"
-
+  - text: Latest updates
+    href: '#changelog'
+changelog:
+  key: utilities-font-size
 utilities:
   - base: font
     var: font


### PR DESCRIPTION
# Summary

- Add changelog for font family and size page
- Create changelog entry for uswds/uswds#5388

## Related PR

Related to uswds/uswds#5388.
> Fixed a bug that caused `font-[family]-[size]` utility classes to not generate font-family rules.

## Preview link

[Changelog entry](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-changelog-5388/utilities/font-size-and-family/#changelog)




