### PR TITLE
USWDS-Site: Update width of header logo

### DIFF
--- a/css/custom-styles/_site-header.scss
+++ b/css/custom-styles/_site-header.scss
@@ -231,8 +231,12 @@ $site-secondary-nav-input-height: 38px;
 
   @include at-media("desktop") {
     @include u-margin-y(0, "!important");
-    margin-right: units(2);
+    margin-right: units(1);
     width: auto !important;
+  }
+
+  @include at-media("desktop-lg") {
+    margin-right: units(2);
   }
 
   .usa-input {

--- a/css/settings/_uswds-theme-components.scss
+++ b/css/settings/_uswds-theme-components.scss
@@ -67,7 +67,7 @@ $theme-input-state-border-width: 0.5;
 
 // Header
 $theme-header-font-family: "ui";
-$theme-header-logo-text-width: 33%;
+$theme-header-logo-text-width: 50%;
 // $theme-header-max-width: "full"; - https://github.com/uswds/uswds/issues/4851
 // $theme-header-min-width: 'full';
 


### PR DESCRIPTION
# Summary

Fixed the line break on the header logo by updating the value of `$theme-header-logo-text-width`  to 50% instead of 33%.

This review should require a low level of effort.

:warning: No changelog needed

## Related issue

Closes #2198

## Preview link

Preview link: [Home page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-update-logo-width/)

## Problem statement
For window widths from approximately 1024px to 1225px, the header displays a vertical scrollbar on the right side of the component. 

![image](https://github.com/uswds/uswds-site/assets/93996430/a48cdce1-1df2-453b-8b6a-3af476523706)

This happens because the logo text breaks to two lines. Note that in the screenshot above, the "(USWDS)" abbreviation should be shown but is not visible because it got bumped to a second line. 

## Solution
In USWDS PR https://github.com/uswds/uswds/pull/5008 (Release 3.4.1), we introduced a fix that caused the system styles to respect the value of `$theme-header-logo-text-width` in extended headers. Prior to this release, extended headers ignored this setting value (that has a default value of 33%) and instead relied on a hard-coded value of 50% in the Sass. 

I suspect that this change is what is now causing the header logo to break to two lines. Without this narrow logo width, the header has enough room to fit all its elements at all screen widths.

1. To prevent a line break in the header logo, this PR updates the value of `$theme-header-logo-text-width` from 33% to the previously hard-coded 50%.
1. To prevent slight overlap with the search bar in Safari and Chrome, this PR shrinks the right margin on the form element between "desktop" and "desktop-lg".

![image](https://github.com/uswds/uswds-site/assets/93996430/4d4893b8-fe06-4c4d-9264-2bc111fe46a5)

## Testing and review
Resize the browser window to various desktop widths. 
1.  Confirm that no scrollbar appears in the header component
2. Confirm that the logo doesn't overlap with other content