### PR TITLE
USWDS-Site - Changelog: Add entry & Doc updates for disabled color changes [USWDS#5402]

### DIFF
--- a/_data/changelogs/docs-settings.yml
+++ b/_data/changelogs/docs-settings.yml
@@ -2,6 +2,14 @@ title: Settings
 type: utility
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Fixed configuration errors with disabled color settings.
+    summaryAdditional: All disabled color settings should now be configurable and accept hex color values.
+    affectsSettings: true
+    affectsStyles: true
+    githubPr: 5402
+    githubRepo: uswds
+    versionUswds: N.N.N
   - date: 2023-06-09
     summary: Added accordion color settings.
     summaryAdditional: You can now customize accordion button and content background colors with `$theme-accordion-button-background-color` and `$theme-accordion-background-color`.

--- a/_data/changelogs/docs-settings.yml
+++ b/_data/changelogs/docs-settings.yml
@@ -3,6 +3,14 @@ type: utility
 changelogURL:
 items:
   - date: NNNN-NN-NN
+    summary: Added `$theme-color-disabled-lighter` and `$theme-color-disabled-darker` settings.
+    summaryAdditional:
+    affectsSettings: true
+    affectsStyles: true
+    githubPr: 5402
+    githubRepo: uswds
+    versionUswds: N.N.N
+  - date: NNNN-NN-NN
     summary: Fixed configuration errors with disabled color settings.
     summaryAdditional: All disabled color settings should now be configurable and accept hex color values.
     affectsSettings: true

--- a/_data/changelogs/docs-settings.yml
+++ b/_data/changelogs/docs-settings.yml
@@ -3,8 +3,9 @@ type: utility
 changelogURL:
 items:
   - date: NNNN-NN-NN
-    summary: Added `$theme-color-disabled-lighter` and `$theme-color-disabled-darker` settings.
-    summaryAdditional:
+    summary: Updated default disabled color settings values and added `$theme-color-disabled-lighter` and `$theme-color-disabled-darker`.
+    summaryAdditional: If your project customizes disabled colors, confirm that disabled states meet color contrast requirements.
+    isBreaking: true
     affectsSettings: true
     affectsStyles: true
     githubPr: 5402

--- a/_data/changelogs/tokens-color-state.yml
+++ b/_data/changelogs/tokens-color-state.yml
@@ -5,6 +5,7 @@ items:
   - date: NNNN-NN-NN
     summary: Added `disabled-lighter` and `disabled-darker` tokens.
     summaryAdditional: Also updated the default values for all disabled tokens.
+    isBreaking: true
     affectsStyles: true
     githubPr: 5402
     githubRepo: uswds

--- a/_data/changelogs/tokens-color-state.yml
+++ b/_data/changelogs/tokens-color-state.yml
@@ -2,6 +2,13 @@ title: State color tokens
 type: token
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Added `disabled-lighter` and `disabled-darker` tokens.
+    summaryAdditional:
+    affectsStyles: true
+    githubPr: 5402
+    githubRepo: uswds
+    versionUswds: N.N.N
   - date: 2021-12-21
     summary: Updated the documentation for `success-dark` and `success-darker` to match the current USWDS values.
     summaryAdditional:

--- a/_data/changelogs/tokens-color-state.yml
+++ b/_data/changelogs/tokens-color-state.yml
@@ -4,7 +4,7 @@ changelogURL:
 items:
   - date: NNNN-NN-NN
     summary: Added `disabled-lighter` and `disabled-darker` tokens.
-    summaryAdditional:
+    summaryAdditional: Also updated the default values for all disabled tokens.
     affectsStyles: true
     githubPr: 5402
     githubRepo: uswds

--- a/_data/settings/color.yml
+++ b/_data/settings/color.yml
@@ -438,23 +438,35 @@ contents:
     var: $theme-color-disabled-family
     default: '"gray"'
     type: color
+  - name: disabled-lighter
+    subsection: state color token
+    description: Use grade 20.
+    var: $theme-color-disabled-lighter
+    default: '"gray-20"'
+    type: color
   - name: disabled-light
     subsection: state color token
-    description: Use grade 10.
+    description: Use grade 40.
     var: $theme-color-disabled-light
-    default: '"gray-10"'
+    default: '"gray-40"'
     type: color
   - name: disabled
     subsection: state color token
-    description: Use grade 20.
+    description: Use grade 50.
     var: $theme-color-disabled
-    default: '"gray-20"'
+    default: '"gray-50"'
     type: color
   - name: disabled-dark
     subsection: state color token
-    description: Use grade 30.
+    description: Use grade 70.
     var: $theme-color-disabled-dark
-    default: '"gray-30"'
+    default: '"gray-70"'
+    type: color
+  - name: disabled-darker
+    subsection: state color token
+    description: Use grade 90.
+    var: $theme-color-disabled-darker
+    default: '"gray-90"'
     type: color
 
   - name: Body background color

--- a/_data/tokens/color.yml
+++ b/_data/tokens/color.yml
@@ -89,12 +89,16 @@ state:
     default: "green-cool-50v"
   - token: success-darker
     default: "green-cool-60v"
-  - token: disabled-light
-    default: "gray-10"
-  - token: disabled
+  - token: disabled-lighter
     default: "gray-20"
+  - token: disabled-light
+    default: "gray-40"
+  - token: disabled
+    default: "gray-50"
   - token: disabled-dark
-    default: "gray-30"
+    default: "gray-70"
+  - token: disabled-darker
+    default: "gray-90"
   - token: emergency
     default: "red-warm-60v"
   - token: emergency-dark

--- a/css/settings/_uswds-theme-color.scss
+++ b/css/settings/_uswds-theme-color.scss
@@ -116,9 +116,11 @@ $theme-color-info-darker: "blue-cool-60";
 
 // Disabled colors
 $theme-color-disabled-family: "gray";
-$theme-color-disabled-light: "gray-10";
-$theme-color-disabled: "gray-20";
-$theme-color-disabled-dark: "gray-30";
+$theme-color-disabled-lighter: "gray-20";
+$theme-color-disabled-light: "gray-40";
+$theme-color-disabled: "gray-50";
+$theme-color-disabled-dark: "gray-70";
+$theme-color-disabled-darker: "gray-90";
 
 /*
 ----------------------------------------


### PR DESCRIPTION
# Summary

- Created changelog entries for uswds/uswds#5402
- Updated settings page with new disabled color settings and values
- Updated tokens page to include new disabled state tokens and show updated token values
  > **Warning**
  > The tokens page will not show a preview of the new `disabled-lighter` or `disabled-darker` color tokens until release 3.5.1 is installed. Wanted to make a note that the page did show the new color previews locally when I ran `npm link` with the branch from [#5402](https://github.com/uswds/uswds/pull/5402). 
  > Before:
  > ![image](https://github.com/uswds/uswds-site/assets/93996430/3dd5c51e-ea9e-42ac-afc1-85a7c232b50d)
  > After: 
  > ![image](https://github.com/uswds/uswds-site/assets/93996430/314ea2a4-e516-4b95-bd91-31a595d0a9d9)

## Preview links
- [Settings - disabled state](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-changelog-5402/documentation/settings/#color-settings)
- [Settings - Changelog entry](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-changelog-5402/documentation/settings/#changelog)
- [Tokens - state colors](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-changelog-5402/design-tokens/color/state-tokens/#uswds-state-color-tokens)
- [Tokens - changelog entry](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-changelog-5402/design-tokens/color/state-tokens/#changelog)

## Testing and review
- Confirm that the disabled color settings and tokens match the updated keys and values in uswds/uswds#5402
- Confirm no spelling or grammar errors
- Confirm that the appropriate changelogs are added where needed and that the entries are accurate
