### PR TITLE
USWDS-Site - Touchpoints: Fix visual regression on local builds

### DIFF
--- a/css/_uswds-theme-custom-styles.scss
+++ b/css/_uswds-theme-custom-styles.scss
@@ -434,6 +434,10 @@ abbr[title="required"] {
       @include u-bg($site-background-color);
       margin: units(2) units(2) units(4);
     }
+
+    &#{$external-href} {
+      display: inline-block;
+    }
   }
 }
 

--- a/css/settings/_variables.scss
+++ b/css/settings/_variables.scss
@@ -3,10 +3,9 @@ $color-grid-dark: "base";
 $color-grid-light: "base-lightest";
 $font-monospace: Consolas, Monaco, "Andale Mono", monospace;
 $asset-path: "../";
-$font-path: "#{$asset-path}fonts";
 $image-path: "#{$asset-path}img";
 
-$external-href: '[href^="http"]:not([href*="designsystem.digital.gov"]):not([href*="touchpoints.app.cloud.gov/touchpoints/5c2410e4/submit"])';
+$external-href: '[href^="http"]:not([href*="designsystem.digital.gov"])';
 
 $z-nav-secondary: 100;
 

--- a/css/settings/_variables.scss
+++ b/css/settings/_variables.scss
@@ -6,7 +6,7 @@ $asset-path: "../";
 $font-path: "#{$asset-path}fonts";
 $image-path: "#{$asset-path}img";
 
-$external-href: '[href^="http"]:not([href*="designsystem.digital.gov"]):not([href*="touchpoints.app.cloud.gov/touchpoints/5c2410e4/submit"])';
+$external-href: '[href^="http"]:not([href*="designsystem.digital.gov"]):not([href*="touchpoints.app.cloud.gov/touchpoints/5c2410e4/submit"])'
 
 $z-nav-secondary: 100;
 

--- a/css/settings/_variables.scss
+++ b/css/settings/_variables.scss
@@ -6,7 +6,7 @@ $asset-path: "../";
 $font-path: "#{$asset-path}fonts";
 $image-path: "#{$asset-path}img";
 
-$external-href: '[href^="http"]:not([href*="designsystem.digital.gov"]):not([href*="touchpoints.app.cloud.gov/touchpoints/5c2410e4/submit"])'
+$external-href: '[href^="http"]:not([href*="designsystem.digital.gov"]):not([href*="touchpoints.app.cloud.gov/touchpoints/5c2410e4/submit"])';
 
 $z-nav-secondary: 100;
 

--- a/css/settings/_variables.scss
+++ b/css/settings/_variables.scss
@@ -3,6 +3,7 @@ $color-grid-dark: "base";
 $color-grid-light: "base-lightest";
 $font-monospace: Consolas, Monaco, "Andale Mono", monospace;
 $asset-path: "../";
+$font-path: "#{$asset-path}fonts";
 $image-path: "#{$asset-path}img";
 
 $external-href: '[href^="http"]:not([href*="designsystem.digital.gov"])';

--- a/css/settings/_variables.scss
+++ b/css/settings/_variables.scss
@@ -6,7 +6,7 @@ $asset-path: "../";
 $font-path: "#{$asset-path}fonts";
 $image-path: "#{$asset-path}img";
 
-$external-href: '[href^="http"]:not([href*="designsystem.digital.gov"])';
+$external-href: '[href^="http"]:not([href*="designsystem.digital.gov"]):not([href*="touchpoints.app.cloud.gov/touchpoints/5c2410e4/submit"])';
 
 $z-nav-secondary: 100;
 


### PR DESCRIPTION
# Summary

Fixes visual regression of touchpoints survey caused by `inline` external links change in https://github.com/uswds/uswds-site/pull/1322

## Related issue

Closes #2186 

## Preview link

_Scroll to the bottom and view the touchpoints button at mobile breakpoints_
[Banner component page →](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cm-touchpoints-regression-fix/components/banner/)

## Problem statement

All external links were changed to `inline` elements in https://github.com/uswds/uswds-site/pull/1322. This caused a visual regression in **local builds** only. The survey link on the live build appears to have been unaffected.

From @mejiaj:
> I'm guessing it doesn't happen on production because the way the CSS is bundled and minified for production.
>
> We should still try to fix if we're able to, but we can deprioritize because the impact doesn't seem to be very big.

## Solution

Exclude "Was this page helpful" touchpoints survey link from `external-href` variable.

It's important we include the _specific_ link instead of a general toucpoints hreft because we have a second, "Get in touch" survey link that needs to remain `inline`.

## Testing and review

1. Confirm bug exists on `main`
   1. On your machine, checkout `main` branch
   2. Build and start local build
   3. Inspect a component page on mobile width
   4. Confirm touchpoints button crosses border into footer area
2. View a guidance page with the touchpoints survey _(component pages for example)_
3. Visit the same page you viewed from before
4. Confirm touchpoints survey no longer crosses into footer area.
5. Confirm other external links maintain `display: inline`

### Testing Checklist

- [ ] Bug exists on local builds
- [ ] Excluding link from `$external-link` resolves the issue
- [ ] No unintended additional changes 

---

Before opening this PR, make sure you’ve done whichever of these applies to you:
- [x] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `main`).
- [x] Run `npm run prettier:scss` to format any Sass updates.
- [x] Run `npm test` and confirm that all tests pass.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
