### PR TITLE
USWDS-Site - Card: Add header exdent to variant table

### DIFF
--- a/_components/card/card.md
+++ b/_components/card/card.md
@@ -34,14 +34,14 @@ variants:
     description: In combination with `usa-card--flag`, sets the media element on the right. (Flag cards display media on the left by default.)
   - variant: "`.usa-card__media--inset`"
     description: Indents the media element so it doesn't extend to the edge of the card.
-  - variant: "`.usa-card__media--exdent`"
-    description: Extends the media element out over the card border. Useful for light-bordered cards.
-  - variant: "`.usa-card__header--exdent`"
-    description: Extends the header element out over the card border. Useful for light-bordered cards.
   - variant: "`.usa-card__body--exdent`"
     description: Extends the body element out over the card border. Useful for light-bordered cards.
   - variant: "`.usa-card__footer--exdent`"
     description: Extends the footer element out over the card border. Useful for light-bordered cards.
+  - variant: "`.usa-card__header--exdent`"
+    description: Extends the header element out over the card border. Useful for light-bordered cards.
+  - variant: "`.usa-card__media--exdent`"
+    description: Extends the media element out over the card border. Useful for light-bordered cards.
 changelog:
   key: component-card
 ---

--- a/_components/card/card.md
+++ b/_components/card/card.md
@@ -36,6 +36,8 @@ variants:
     description: Indents the media element so it doesn't extend to the edge of the card.
   - variant: "`.usa-card__media--exdent`"
     description: Extends the media element out over the card border. Useful for light-bordered cards.
+  - variant: "`.usa-card__header--exdent`"
+    description: Extends the header element out over the card border. Useful for light-bordered cards.
   - variant: "`.usa-card__body--exdent`"
     description: Extends the body element out over the card border. Useful for light-bordered cards.
   - variant: "`.usa-card__footer--exdent`"

--- a/_data/changelogs/component-card.yml
+++ b/_data/changelogs/component-card.yml
@@ -3,11 +3,10 @@ type: component
 changelogURL:
 items:
   - date: NNNN-NN-NN
-    summary: Added `usa-card__header--exdent` variant to variants table
+    summary: Added `usa-card__header--exdent` variant to variants table.
     affectsGuidance: true
     githubPr: 2228
     githubRepo: uswds-site
-    versionUswds: N.N.N
   - date: 2023-06-09
     summary: Replaced `button` elements with links styled as buttons
     affectsMarkup: true

--- a/_data/changelogs/component-card.yml
+++ b/_data/changelogs/component-card.yml
@@ -2,7 +2,7 @@ title: Card
 type: component
 changelogURL:
 items:
-  - date: NNNN-NN-NN
+  - date: 2023-09-20
     summary: Added `usa-card__header--exdent` variant to variants table.
     affectsGuidance: true
     githubPr: 2228

--- a/_data/changelogs/component-card.yml
+++ b/_data/changelogs/component-card.yml
@@ -2,6 +2,12 @@ title: Card
 type: component
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Added `usa-card__header--exdent` variant to variants table
+    affectsGuidance: true
+    githubPr: 2228
+    githubRepo: uswds-site
+    versionUswds: N.N.N
   - date: 2023-06-09
     summary: Replaced `button` elements with links styled as buttons
     affectsMarkup: true


### PR DESCRIPTION
# Summary

Adds missing `header--exdent` class to card variants table.

## Related issue

Closes #2209 

## Preview link

[Card variants →](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cm-card-header-exdent-guidance/components/card/#using-the-card-component-2:~:text=between%20card%20elements.-,Card%20variants,-Variant)

## Problem statement

The card variants table was missing the `header--exdent` variant despite the design system offering the class and styles.

## Solution

Add `usa-card__header--exdent` variant to table.

### Additional Context
Exdent classes were added in https://github.com/uswds/uswds/pull/3437 _(May 2020)_
- PR mentions `header--exdent` in the **New Variants** section, but it was not listed in the **Variant Options** table
Guidance was updated in #913 and specifically commit [877543c](https://github.com/uswds/uswds-site/commit/877543c099b16e262d1a575bfacf55c174cee9e7) _(May 2020)_

It looks to me like the header exdent was unintentionally left out since the class was added.


## Testing and review

1. View [card guidance page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cm-card-header-exdent-guidance/components/card/#using-the-card-component-2:~:text=between%20card%20elements.-,Card%20variants,-Variant)
2. Confirm `header--exdent` variant is listed
3. Confrim guidance matches other exdent guidance 
4. Confirm its place in table makes sense

### Testing checklist
- [ ] `usa-card__header--exdent` variant present in table
- [ ] Class name matches actual class in the design system
- [ ] Variant guidance is appropriate and understandable
- [ ] Variant is proper place on table
- [ ] Approved changelog

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `main`).
- [ ] Run `npm run prettier:scss` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->