### PR TITLE
Add Americana Stack to implementations

### DIFF
--- a/_data/implementations.yml
+++ b/_data/implementations.yml
@@ -227,3 +227,13 @@
     url: https://github.com/patrickcate
   version:
   notes: "A Vue.js implementation of the U.S. Web Design System."
+
+- name: Americana Stack
+  distribution: Remix
+  id: vue-uswds
+  url: https://github.com/nasa-gcn/americana-stack
+  author:
+    name: NASA's General Coordinates Network (GCN)
+    url: https://gcn.nasa.gov
+  version:
+  notes: "A Remix Stack for US Federal web sites on AWS. Includes US Web Design System, react-uswds, and pre-commit hooks for linting and type checking."

--- a/_data/implementations.yml
+++ b/_data/implementations.yml
@@ -230,7 +230,7 @@
 
 - name: Americana Stack
   distribution: Remix
-  id: vue-uswds
+  id: remix-uswds
   url: https://github.com/nasa-gcn/americana-stack
   author:
     name: NASA's General Coordinates Network (GCN)


### PR DESCRIPTION
Americana Stack is a Remix Stack for US Federal web sites on AWS. Includes US Web Design System, react-uswds, and pre-commit hooks for linting and type checking.