### PR TITLE
USWDS-Site - Changelog: Add entry of links styled as buttons [USWDS#5435]

### DIFF
--- a/_data/changelogs/component-button.yml
+++ b/_data/changelogs/component-button.yml
@@ -2,6 +2,12 @@ title: Button
 type: component
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Created storybook preview for links styled as buttons
+    affectsContent: true
+    githubPr: 5435
+    githubRepo: uswds
+    versionUswds: N.N.N
   - date: 2023-06-09
     summary: Fixed a bug that caused the button `type` attribute to render empty.
     affectsAccessibility: true

--- a/_data/changelogs/component-button.yml
+++ b/_data/changelogs/component-button.yml
@@ -4,7 +4,6 @@ changelogURL:
 items:
   - date: NNNN-NN-NN
     summary: Created storybook preview for links styled as buttons
-    affectsContent: true
     githubPr: 5435
     githubRepo: uswds
     versionUswds: N.N.N


### PR DESCRIPTION
# Summary

Add changelog entry for links styled as buttons

## Related PR

https://github.com/uswds/uswds/pull/5435

## Preview link

[Button changelog →](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cm-changelog-5435/components/button/#latest-updates)
