### PR TITLE
USWDS-Site - Changelog: Safari header bug [#5443]

### DIFF
--- a/_data/changelogs/component-header.yml
+++ b/_data/changelogs/component-header.yml
@@ -2,6 +2,14 @@ title: Header
 type: component
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Fixed a Safari-only bug that caused the mobile menu to unexpectedly close at a narrow range of window widths.
+    summaryAdditional:
+    affectsJavascript: true
+    affectsStyles: true
+    githubPr: 5443
+    githubRepo: uswds
+    versionUswds: N.N.N
   - date: 2023-07-14
     summary: Added header variants table to guidance page.
     affectsGuidance: true

--- a/_data/changelogs/component-table.yml
+++ b/_data/changelogs/component-table.yml
@@ -7,7 +7,7 @@ items:
   - date: NNNN-NN-NN
     summary: Fixed a Safari-only bug that caused the header to unexpectedly close at a narrow range of window widths.
     summaryAdditional:
-    isBreaking: false
+    affectsJavascript: true
     affectsStyles: true
     githubPr: 5443
     githubRepo: uswds

--- a/_data/changelogs/component-table.yml
+++ b/_data/changelogs/component-table.yml
@@ -4,14 +4,6 @@ type: component
 changelogURL:
 
 items:
-  - date: NNNN-NN-NN
-    summary: Fixed a Safari-only bug that caused the header to unexpectedly close at a narrow range of window widths.
-    summaryAdditional:
-    affectsJavascript: true
-    affectsStyles: true
-    githubPr: 5443
-    githubRepo: uswds
-    versionUswds: N.N.N
   - date: 2023-07-17
     summary: Restored standard and striped table component previews to guidance page.
     summaryAdditional:

--- a/_data/changelogs/component-table.yml
+++ b/_data/changelogs/component-table.yml
@@ -4,6 +4,14 @@ type: component
 changelogURL:
 
 items:
+  - date: NNNN-NN-NN
+    summary: Fixed a Safari-only bug that caused the header to unexpectedly close at a narrow range of window widths.
+    summaryAdditional:
+    isBreaking: false
+    affectsStyles: true
+    githubPr: 5443
+    githubRepo: uswds
+    versionUswds: N.N.N
   - date: 2023-07-17
     summary: Restored standard and striped table component previews to guidance page.
     summaryAdditional:


### PR DESCRIPTION
# Summary

Add changelog entry for Safari header bug fix.

## Related PR

https://github.com/uswds/uswds/pull/5443

## Preview link

[Header changelog](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-changelog-5443/components/header/#changelog)