### PR TITLE
USWDS-Site: Add note about pinning dependencies

### DIFF
--- a/pages/documentation/getting-started-developers/phase-one.md
+++ b/pages/documentation/getting-started-developers/phase-one.md
@@ -61,23 +61,25 @@ Now, you can install USWDS — and any other Node package — from the command l
 
 npm does the work of installing packages and, behind the scenes, automatically installing all the software each package needs to run (also known as a package’s dependencies). The final software is saved into a new directory called `node_modules`.
 
-Install USWDS from the command line, and save it as a dependency in your package.json as follows:
+Install USWDS from the command line, and save it as a dependency in your `package.json` as follows:
 
 {:.site-terminal}
 ```bash
-npm install @uswds/uswds --save
+npm install @uswds/uswds --save-exact
 
 # [a lot of notices]
 # + uswds@{{ site.uswds_version }} [or another version number]
 # [a few more notifications]
 ```
 
-npm will show some notifications, install USWDS, and display the version number of the USWDS package. You’ll also see the following information in your package.json:
+We recommend using the `--save-exact` flag when installing `@uswds/uswds` because it prevents updates from being pulled into your project until you manually update the version. This reduces the risk of a update unexpectedly breaking or changing your project.
+
+Once you run this command, npm will show some notifications, install USWDS, and display the version number of the USWDS package. You’ll also see the following information in your package.json:
 
 {:.site-terminal}
 ```json
 "dependencies": {
-  "@uswds/uswds": "^{{ site.uswds_version }}" [or another version number]
+  "@uswds/uswds": "{{ site.uswds_version }}" [or another version number]
 }
 ```
 

--- a/pages/documentation/getting-started-developers/phase-one.md
+++ b/pages/documentation/getting-started-developers/phase-one.md
@@ -61,7 +61,7 @@ Now, you can install USWDS — and any other Node package — from the command l
 
 npm does the work of installing packages and, behind the scenes, automatically installing all the software each package needs to run (also known as a package’s dependencies). The final software is saved into a new directory called `node_modules`.
 
-Install USWDS from the command line, and save it as a dependency in your `package.json` as follows:
+To install USWDS from the command line and save it as a dependency in your `package.json`, run the following command:
 
 {:.site-terminal}
 ```bash
@@ -72,7 +72,7 @@ npm install @uswds/uswds --save-exact
 # [a few more notifications]
 ```
 
-We recommend using the `--save-exact` flag when installing `@uswds/uswds` because it prevents updates from being pulled into your project until you manually update the version. This reduces the risk of a update unexpectedly breaking or changing your project.
+We recommend using the `--save-exact` flag when installing `@uswds/uswds` because it allows you to control when USWDS updates get pulled into your project. This flag pins the dependency to an exact version until you manually update it, which reduces the risk of a USWDS update unexpectedly breaking or changing your project.
 
 Once you run this command, npm will show some notifications, install USWDS, and display the version number of the USWDS package. You’ll also see the following information in your package.json:
 


### PR DESCRIPTION
# Summary

Updated installation instructions to use the `--save--exact` flag and added a note about pinning dependencies.

## Related issue

Closes #2231

## Preview link

[Phase 1: Install page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-pin-install/documentation/getting-started/developers/phase-one-install/#step-3-install-uswds)

## Problem statement

In the [migration page](https://designsystem.digital.gov/documentation/migration/#2-install-the-uswds-30-package), we recommend installing USWDS with the `--save-exact` flag. However, in the [getting started for developers guide](https://designsystem.digital.gov/documentation/getting-started/developers/phase-one-install/#step-3-install-uswds), we recommend using the `--save` flag. 

This inconsistency can cause confusion to users. Additionally, because we allow breaking changes in minor releases, it feels wise to advise users to pin their USWDS dependency in order to lower risk for their project.

## Solution

Adding the flag to our installation guide with a note about what it means will add clarity to our instructions.

## Testing and review
- Confirm that we want to recommend `--save-exact` flag
- Confirm that the content update makes sense, conveys what we want it to, and is free of spelling and grammatical errors.
- Confirm that all references to installing USWDS throughout the site are consistent about pinning dependencies
