### PR TITLE
USWDS-Site - Flex: Fix aria-controls to restore expand/collapse of the code example accordion for flex-align-self

### DIFF
--- a/_utilities/flex.md
+++ b/_utilities/flex.md
@@ -552,7 +552,7 @@ utilities:
         </div>
     {% endfor %}
     <div class="usa-accordion usa-accordion--bordered site-accordion-code margin-top-4 margin-bottom-1">
-      <button type="button" class="usa-accordion__button" aria-controls="code-flex-align" aria-expanded="true">Code</button>
+      <button type="button" class="usa-accordion__button" aria-controls="code-flex-align-self" aria-expanded="true">Code</button>
       <div id="code-flex-align-self" class="usa-accordion__content">
 <div markdown="1" class="font-mono-xs">
 {% highlight html linenos %}


### PR DESCRIPTION
Fix `aria-controls` for `code-flex-align-self` to restore the accordion functionality for this code section.

# Summary

The `aria-controls` for the code segment demonstrating `flex-align-self` was missing the `self` which caused the collapse/expand functionality of the accordion component to not work. Accordion functionality was restored by fixing the `aria-controls` attribute to be `code-flex-align-self`.


## Problem statement

1. Desired state: When viewing the code example for flex align self, clicking the +/- on the accordion component expands or collapses the code example within the accordion component.
2. Actual state: When viewing the code example for flex align self, clicking the +/- on the accordion component has no effect on whether or not the code example accordion component expands or collapses.

## Solution

1. The solution was to fix the `aria-controls` for the +/- button to match the `<div>` it's meant to control
2. This approach was chosen because it's the correct fix.
3. I tested this by making the change in the browser and confirming that the functionality of the accordion component was restored and it was.
4. No other known solution paths