### PR TITLE
USWDS-Site - Changelog: Set tooltip opacity to 0 [#5475]

### DIFF
--- a/_data/changelogs/component-tooltip.yml
+++ b/_data/changelogs/component-tooltip.yml
@@ -7,7 +7,7 @@ changelogURL:
 items:
   - date: NNNN-NN-NN
     summary: "Restored the `opacity: 0` style rule to the tooltip's initial state."
-    summaryAdditional:
+    summaryAdditional: This prevents the component from flickering if its position needs to be recalculated.
     affectsStyles: true
     githubPr: 5475
     githubRepo: uswds

--- a/_data/changelogs/component-tooltip.yml
+++ b/_data/changelogs/component-tooltip.yml
@@ -5,6 +5,13 @@ type: component
 changelogURL:
 
 items:
+  - date: NNNN-NN-NN
+    summary: "Restored `opacity: 0` to the initial tooltip body styles."
+    summaryAdditional:
+    affectsStyles: true
+    githubPr: 5475
+    githubRepo: uswds
+    versionUswds: N.N.N
   - date: 2023-06-09
     summary: Fixed a bug that removed default positioning.
     summaryAdditional: If the `data-position` attribute is not specified, the tooltip position will now default to "top".

--- a/_data/changelogs/component-tooltip.yml
+++ b/_data/changelogs/component-tooltip.yml
@@ -6,7 +6,7 @@ changelogURL:
 
 items:
   - date: NNNN-NN-NN
-    summary: "Restored `opacity: 0` to the initial tooltip body styles."
+    summary: "Restored the `opacity: 0` style rule to the tooltip's initial state."
     summaryAdditional:
     affectsStyles: true
     githubPr: 5475


### PR DESCRIPTION
# Summary

Add changelog entry for tooltip opacity fix

## Related PR

https://github.com/uswds/uswds/pull/5475

## Preview link

[Tooltip changelog](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-changelog-5475/components/tooltip/#changelog)