### PR TITLE
USWDS-Site - Changelog: Identifier screen reader update [#5491]

### DIFF
--- a/_data/changelogs/component-identifier.yml
+++ b/_data/changelogs/component-identifier.yml
@@ -3,10 +3,11 @@ type: component
 changelogURL:
 items:
   - date: NNNN-NN-NN
-    summary: Updated the screen reader readout to say "Official" instead of "An official".
-    summaryAdditional: Users should update their markup to improve the screen reader experience.
+    summary: Updated the screen reader readout in English versions of the component.
+    summaryAdditional: When read out on a screen reader, the statement "An official website of [Agency name]" can sound like "UNofficial website of [Agency name]". Users should update their markup to improve the screen reader experience.
     isBreaking: true
-    affectsContent: true
+    affectsAccessibility: true
+    affectsMarkup: true
     githubPr: 5491
     githubRepo: uswds
     versionUswds: N.N.N

--- a/_data/changelogs/component-identifier.yml
+++ b/_data/changelogs/component-identifier.yml
@@ -2,6 +2,14 @@ title: Identifier
 type: component
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Updated the screen reader readout to say "Official" instead of "An official".
+    summaryAdditional: Users should update their markup to improve the screen reader experience.
+    isBreaking: true
+    affectsContent: true
+    githubPr: 5491
+    githubRepo: uswds
+    versionUswds: N.N.N
   - date: 2023-06-09
     summary: Updated Accessibility statement link text.
     summaryAdditional: Updated the identifier to use the text "Accessibility statement" (EN) / "Declaración de accesibilidad" (ES) for the required link to an accessibility statement.


### PR DESCRIPTION
# Summary

Add changelog entry for identifier screen reader copy edit.

## Related PR

https://github.com/uswds/uswds/pull/5491

## Preview link

[Identifier changelog](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-changelog-5491/components/identifier/#changelog)