### PR TITLE
USWDS-Site - Changelog: Breadcrumb text wrap [#5497]

### DIFF
--- a/_data/changelogs/component-breadcrumb.yml
+++ b/_data/changelogs/component-breadcrumb.yml
@@ -2,6 +2,12 @@ title: Breadcrumb
 type: component
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Fixed a bug that prevented text from wrapping to a new line in the `.usa-breadcrumb--wrap` variant.
+    affectsStyles: true
+    githubPr: 5497
+    githubRepo: uswds
+    versionUswds: N.N.N
   - date: 2022-04-28
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true


### PR DESCRIPTION
# Summary

Add changelog entry for text wrap in the breadcrumb component.

## Related PR

https://github.com/uswds/uswds/pull/5497

## Preview link

[Breadcrumb changelog](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-changelog-5497/components/breadcrumb/#changelog)

