### PR TITLE
USWDS-Site: Update snyk ignore (September)

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2707,8 +2707,8 @@ ignore:
         expires: '2022-01-27T21:29:25.295Z'
     - '*':
         reason: No available upgrade or patch
-        expires: 2023-09-22T22:01:48.066Z
-        created: 2023-08-23T22:01:48.119Z
+        expires: 2023-10-25T16:51:12.021Z
+        created: 2023-09-25T16:51:12.075Z
   SNYK-JS-AXIOS-1579269:
     - uswds > @frctl/fractal > @frctl/web > browser-sync > localtunnel > axios:
         reason: None given
@@ -3498,8 +3498,8 @@ ignore:
   SNYK-JS-UNSETVALUE-2400660:
     - '*':
         reason: No available upgrade or patch
-        expires: 2023-09-22T22:02:17.127Z
-        created: 2023-08-23T22:02:17.175Z
+        expires: 2023-10-25T16:51:43.738Z
+        created: 2023-09-25T16:51:43.788Z
   SNYK-JS-DECODEURICOMPONENT-3149970:
     - '*':
         reason: No available upgrade or patch


### PR DESCRIPTION
## Problem statement
`npx snyk test` was throwing errors.

## Solution
This PR updates snyk to ignore the following items: 
- SNYK-JS-UNSETVALUE-2400660
- SNYK-JS-ANSIREGEX-1583908

Ran the following in the command line:
```
npx snyk ignore --id="SNYK-JS-UNSETVALUE-2400660" --reason="No available upgrade or patch"
npx snyk ignore --id="SNYK-JS-ANSIREGEX-1583908" --reason="No available upgrade or patch"
```

## Testing and review
To test, run `npx snyk test` and check for errors.

## Reference
[Ignore vulnerabilities using Snyk CLI](https://docs.snyk.io/snyk-cli/test-for-vulnerabilities/ignore-vulnerabilities-using-snyk-cli)