### PR TITLE
USWDS-Site - Changelog: File input custom text data attributes [#5508] 

### DIFF
--- a/_components/file-input/file-input.md
+++ b/_components/file-input/file-input.md
@@ -5,6 +5,28 @@ component:
   package: usa-file-input
   dependencies:
 lead: File input allows users to attach one or multiple files.
+implementation:
+  initProps:
+    - property: "`data-change-file-text`"
+      default: 	'"Change files"'
+    - property: "`data-change-file-text-singular`"
+      default: 	'"Change file"'
+    - property: "`data-choose-text`"
+      default: 	'"choose from folder"'
+    - property: "`data-drag-text`"
+      default: 	'"Drag files here or"'
+    - property: "`data-drag-text-singular`"
+      default: 	'"Drag file here or"'
+    - property: "`data-error-message`"
+      default: 	'"This is not a valid file type."'
+    - property: "`data-no-file-text`"
+      default: 	'"No files selected."'
+    - property: "`data-no-file-text-singular`"
+      default: 	'"No file selected."'
+    - property: "`data-selected-file-text`"
+      default: 	'"files selected"'
+    - property: "`data-selected-file-text-singular`"
+      default: 	'"file selected"'
 permalink: /components/file-input/
 redirect_from:
 - /form-controls/08-file-input/

--- a/_components/file-input/guidance/implementation.md
+++ b/_components/file-input/guidance/implementation.md
@@ -2,4 +2,8 @@
 - **Interaction.** When a user selects or drags documents to the file input, the file name and a thumbnail preview are listed.
 - **Using the `accept` attribute.** You can allow certain files by placing an accept attribute on the `<input/>`. If a file type is not accepted, the file will not be attached and the file input will display a message. [Learn more about the accept attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept) [mozilla.org].
 - **Internet Explorer/Edge.** These browsers do not support dragging items to a file input. Instructions to drag files are removed for these browsers.
-- **Customizing the error message.** Add the data attribute `data-errorMessage` to `usa-file-input` to include a custom error message.
+- **Customizing the component text.** Add the following data attributes to `usa-file-input` to customize the component text:
+{% include settings-table-flex.html
+  content=page.implementation.initProps
+  section="component properties"
+%}

--- a/_data/changelogs/component-file-input.yml
+++ b/_data/changelogs/component-file-input.yml
@@ -2,9 +2,16 @@ title: File input
 type: component
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Added optional custom text data attributes.
+    summaryAdditional: These attributes make it simpler to translate component text into other languages.
+    affectsGuidance: true
+    githubPr: 5508
+    githubRepo: uswds
+    versionUswds: N.N.N
   - date: 2023-06-09
     summary: Removed disabled file input variant preview.
-    summaryAdditional: 
+    summaryAdditional:
     affectsGuidance: true
     githubPr: 2114
     githubRepo: uswds-site


### PR DESCRIPTION
# Summary
- Add documentation for new data attributes
- Add changelog entry for new file input data attributes

## Related PR

https://github.com/uswds/uswds/pull/5508

## Preview link
- [File input properties table](http://localhost:4000/components/file-input/#using-the-file-input-component)
- [File input changelog](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-changelog-5508/components/file-input/#changelog)