### PR TITLE
USWDS-Site - Banner: Update markup

### DIFF
--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -1,12 +1,22 @@
-<section class="usa-banner site-banner" aria-label="Official website of the United States government,,,,,,">
+<section
+  class="usa-banner site-banner"
+  aria-label="Official website of the United States government,,,,,,"
+>
   <div class="usa-accordion">
     <header class="usa-banner__header">
       <div class="usa-banner__inner">
         <div class="grid-col-auto">
-          <img aria-hidden="true" class="usa-banner__header-flag" src="{{ site.baseurl }}/assets/img/us_flag_small.png" alt="U.S. flag" width="16" height="11">
+          <img
+            aria-hidden="true"
+            class="usa-banner__header-flag"
+            src="{{ site.baseurl }}/assets/img/us_flag_small.png"
+            alt=""
+          />
         </div>
         <div class="grid-col-fill tablet:grid-col-auto" aria-hidden="true">
-          <p class="usa-banner__header-text">An official website of the United States government</p>
+          <p class="usa-banner__header-text">
+            An official website of the United States government
+          </p>
           <p class="usa-banner__header-action">Here’s how you know</p>
         </div>
         <button
@@ -19,26 +29,61 @@
         </button>
       </div>
     </header>
-    <div class="usa-banner__content usa-accordion__content" id="gov-banner">
+    <div
+      class="usa-banner__content usa-accordion__content"
+      id="gov-banner"
+    >
       <div class="grid-row grid-gap-lg">
         <div class="usa-banner__guidance tablet:grid-col-6">
-          <img class="usa-banner__icon usa-media-block__img" src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg" role="img" alt="" aria-hidden="true">
+          <img
+            class="usa-banner__icon usa-media-block__img"
+            src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg"
+            role="img"
+            alt=""
+            aria-hidden="true"
+          />
           <div class="usa-media-block__body">
             <p>
-              <strong>Official websites use .gov</strong>
-              <br>
-              A <strong>.gov</strong> website belongs to an official government organization in the United States.
+              <strong>Official websites use .gov</strong><br />A
+              <strong>.gov</strong> website belongs to an official government
+              organization in the United States.
             </p>
           </div>
         </div>
         <div class="usa-banner__guidance tablet:grid-col-6">
-          <img class="usa-banner__icon usa-media-block__img" src="{{ site.baseurl }}/assets/img/icon-https.svg" role="img" alt="" aria-hidden="true">
+          <img
+            class="usa-banner__icon usa-media-block__img"
+            src="{{ site.baseurl }}/assets/img/icon-https.svg"
+            role="img"
+            alt=""
+            aria-hidden="true"
+          />
           <div class="usa-media-block__body">
             <p>
-              <strong>Secure .gov websites use HTTPS</strong>
-              <br>
-              A <strong>lock</strong> ( <span class="icon-lock"><svg xmlns="http://www.w3.org/2000/svg" width="52" height="64" viewBox="0 0 52 64" class="usa-banner__lock-image" role="img" aria-labelledby="banner-lock-description" focusable="false"><title id="banner-lock-title">Lock</title><desc id="banner-lock-description">Locked padlock</desc><path fill="#000000" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"/></svg></span> ) or <strong>https://</strong> means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites.
-
+              <strong>Secure .gov websites use HTTPS</strong><br />A
+              <strong>lock</strong> (
+              <span class="icon-lock"
+                ><svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="52"
+                  height="64"
+                  viewBox="0 0 52 64"
+                  class="usa-banner__lock-image"
+                  role="img"
+                  aria-labelledby="banner-lock-description"
+                  focusable="false"
+                >
+                  <title id="banner-lock-title">Lock</title>
+                  <desc id="banner-lock-description">Locked padlock icon</desc>
+                  <path
+                    fill="#000000"
+                    fill-rule="evenodd"
+                    d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"
+                  />
+                </svg> </span
+              >) or <strong>https://</strong> means you’ve safely connected to
+              the .gov website. Share sensitive information only on official,
+              secure websites.
             </p>
           </div>
         </div>


### PR DESCRIPTION
# Summary

Updated banner markup to reflect the latest changes as of `3.6.0`

## Related issue

Closes #2305 

## Preview link

[Site →](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cm-update-banner-code-3.6.0/)

## Problem statement

There are minor changes to the banner markup that the banner on our site does not reflect.

## Solution

Replace markup with component example code from our site.

## Major changes

- HTML is formatted a bit better
- Removes defined icon sizes from the American flag
- Slight changes to alt text

## Testing and review

1. Inspect banner for visual regressions.
2. Run manual and automated accessibility tests to ensure there are no regressions.

### Testing checklist

- [ ] No visual regressions
- [ ] No errors with screen readers
- [ ] No errors with automated testing
