### PR TITLE
USWDS-Site - Changelog: Add entry for $theme-card-padding-y fix [#5571]

### DIFF
--- a/_data/changelogs/component-card.yml
+++ b/_data/changelogs/component-card.yml
@@ -2,6 +2,13 @@ title: Card
 type: component
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Fixed a bug that prevented `$theme-card-padding-y` from accepting expected token values.
+    affectsSettings: true
+    affectsStyles: true
+    githubPr: 5571
+    githubRepo: uswds
+    versionUswds: N.N.N
   - date: 2023-09-29
     summary: Fixed a margin bug on header-first variants that caused exdent card media to overlap headers.
     affectsStyles: true

--- a/_data/changelogs/docs-settings.yml
+++ b/_data/changelogs/docs-settings.yml
@@ -2,9 +2,16 @@ title: Settings
 type: utility
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Fixed a bug that prevented `$theme-card-padding-y` from accepting expected token values.
+    affectsSettings: true
+    affectsStyles: true
+    githubPr: 5571
+    githubRepo: uswds
+    versionUswds: N.N.N
   - date: 2023-08-23
     summary: Updated default disabled color settings values and added `$theme-color-disabled-lighter` and `$theme-color-disabled-darker`.
-    summaryAdditional: If your project customizes disabled color settings, you probably need to update your configuration. 
+    summaryAdditional: If your project customizes disabled color settings, you probably need to update your configuration.
     isBreaking: true
     affectsSettings: true
     affectsStyles: true


### PR DESCRIPTION
# Summary
Add changelog entry for `$theme-card-padding-y` fix.

## Related PR
https://github.com/uswds/uswds/pull/5571

## Preview link
- [Card changelog](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-changelog-5571/components/card/#changelog)
- [Settings changelog](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-changelog-5571/documentation/settings/#changelog)