### PR TITLE
USWDS-Site - Changelog: Create entry removing site alert top margin [#5550]

### DIFF
--- a/_data/changelogs/component-site-alert.yml
+++ b/_data/changelogs/component-site-alert.yml
@@ -3,7 +3,7 @@ type: component
 changelogURL:
 items:
   - date: NNNN-NN-NN
-    summary: Removed the top margin on `usa-alert`.
+    summary: Removed the top margin on the component.
     summaryAdditional:
     affectsStyles: true
     githubPr: 5550

--- a/_data/changelogs/component-site-alert.yml
+++ b/_data/changelogs/component-site-alert.yml
@@ -3,7 +3,7 @@ type: component
 changelogURL:
 items:
   - date: NNNN-NN-NN
-    summary: Removed the top margin on the component.
+    summary: Removed the component's top margin.
     summaryAdditional:
     affectsStyles: true
     githubPr: 5550

--- a/_data/changelogs/component-site-alert.yml
+++ b/_data/changelogs/component-site-alert.yml
@@ -2,6 +2,13 @@ title: Site alert
 type: component
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Removed the top margin on `usa-alert`.
+    summaryAdditional:
+    affectsStyles: true
+    githubPr: 5550
+    githubRepo: uswds
+    versionUswds: N.N.N
   - date: 2023-03-09
     summary: Updated padding settings to accept any valid spacing token.
     summaryAdditional:


### PR DESCRIPTION
# Summary
Add changelog entry for removing site alert top margin.

## Related PR
https://github.com/uswds/uswds/pull/5550

## Preview link
[Site alert changelog](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-changelog-5550/components/site-alert/#changelog)