### PR TITLE
USWDS-Site - Changelog: Create entry for X social media icon [#5589]

### DIFF
--- a/_data/changelogs/component-icon.yml
+++ b/_data/changelogs/component-icon.yml
@@ -5,6 +5,7 @@ items:
   - date: NNNN-NN-NN
     summary: Added the X social media icon. 
     summaryAdditional: We also preserved the legacy Twitter icon to allow teams to make the decision on when to update their social media information.
+    affectsAssets: true
     githubPr: 5589
     githubRepo: uswds
     versionUswds: N.N.N

--- a/_data/changelogs/component-icon.yml
+++ b/_data/changelogs/component-icon.yml
@@ -2,6 +2,12 @@ title: Icon
 type: component
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Added the X social media icon. 
+    summaryAdditional: We also preserved the legacy Twitter icon to allow teams to make the decision on when to update their social media information.
+    githubPr: 5589
+    githubRepo: uswds
+    versionUswds: N.N.N
   - date: 2023-10-20
     summary: Added note about icon color contrast.
     affectsGuidance: true


### PR DESCRIPTION
# Summary

Changelog entry for https://github.com/uswds/uswds/pull/5589

> **Added the X social media icon.** We also preserved the legacy Twitter icon to allow teams to make the decision on when to update their social media information.

## Related PR

https://github.com/uswds/uswds/pull/5589

## Preview link

[Preview Icon page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/dw-add-x-icon/components/icon/) →