### PR TITLE
USWDS-Site - Responsive variants: Correct padding-y-2 example

### DIFF
--- a/_includes/utilities/responsive-variants.html
+++ b/_includes/utilities/responsive-variants.html
@@ -8,8 +8,8 @@
 <pre class=" font-mono-xs margin-0 padding-0 bg-transparent">
 @media screen and (min-width: 640px) {
   .tablet\:padding-y-2 {
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding-top: 1rem;
+    padding-bottom: 1rem;
   }
 }
 </pre>


### PR DESCRIPTION
# Summary

Corrected `padding-y-2` example to display the proper output. The setting outputs `padding-top` and `padding-bottom` and not `padding-left/right`

As discovered in this [slack thread](https://gsa-tts.slack.com/archives/C050HRGN7/p1700063752861839?thread_ts=1700062601.785029&cid=C050HRGN7) 🔒 by @caleywoods. Thanks Caley!

## Preview link

[Responsive variants →](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cm-responsive-example-fix/utilities/margin-and-padding/#responsive-variants-2)

## Problem statement

Responsive variant currently displays incorrect values in it's output example.

## Solution

Update to match actual output.

## Testing and review

1. Visit any utility page with a responsive variants section
   - [Margin and padding](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cm-responsive-example-fix/utilities/margin-and-padding/#responsive-variants-2) for example
2. Check responsive variant example output
3. Confirm it displays `padding-top` && `padding-bottom` correctly.
4. Confirm this is the change we'd like

Alternatively, we could change it to `padding-x-2` and keep the padding output the same.