### PR TITLE
USWDS-Site - Bugfix: Fix markup in dependency table

### DIFF
--- a/_includes/component-package.html
+++ b/_includes/component-package.html
@@ -15,7 +15,7 @@
     {%- if package.dependencies -%}
     <strong>Dependencies: </strong>
       {%- for dependency in package.dependencies -%}
-      <code>{{ dependency }}</code class="text-no-wrap">{% if forloop.last != true %}, {% endif %}
+      <code class="text-no-wrap">{{ dependency }}</code>{% if forloop.last != true %}, {% endif %}
       {%- endfor -%}
     {%- endif -%}
   </li>


### PR DESCRIPTION
Closes #2362. Fixes incorrect markup in component package section.

Before/After
<img width="1000" alt="image" src="https://github.com/uswds/uswds-site/assets/3385219/7ec50a3f-f63d-4bf0-9769-ecc5918e3b54">

**Preview links**

| Current | Feature branch |
|:--------|:--------|
| [Default] | [Preview] |

[Default]: https://designsystem.digital.gov/components/table/#table-package
[Preview]: https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/jm-bugfix-component-markup-fix/components/table/#table-package
