### PR TITLE
USWDS-Site - HTML-Proofer: Fix error on design principles page

### DIFF
--- a/pages/design-principles/design-principles.md
+++ b/pages/design-principles/design-principles.md
@@ -241,7 +241,6 @@ The following are practical actions you can take:
 - [Federal Front Door research findings](https://labs.usa.gov/) [labs.usa.gov]
 - [Sharing Quality Services Cross-Agency Performance goal](https://trumpadministration.archives.performance.gov/CAP/sharing-quality-services/) [performance.gov]
 - [Eight Principles of Mobile-Friendliness](https://digital.gov/resources/mobile/principles/) [digital.gov]
-- [Test on real devices with the Federal Crowdsource Mobile Testing Program](https://digital.gov/services/mobile-application-testing-program/) [digital.gov]
 
 #### Non-government resources
 


### PR DESCRIPTION
# Summary

Removed the link to the Federal Crowdsource Mobile Testing Program on the [design principles page](https://designsystem.digital.gov/design-principles/#government-resources-3) because the page is returning a 404. An alternative link on digital.gov (that matches the wayback machine from 2022) states that the program is no longer active.

- [Wayback machine for broken link](https://web.archive.org/web/20220211172854/https://digital.gov/services/mobile-application-testing-program/) (Feb 2022)
- Alternative [Federal Crowdsource Mobile Testing Program page](https://digital.gov/services/service_mobile-testing-program/)  on digital.gov

    ![image](https://github.com/uswds/uswds-site/assets/93996430/257a9d9a-fc02-4218-ad78-4e6aae1191b8)


## Preview link

Preview link: [Design principles](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-html-proofer-mobile-testing/design-principles/#government-resources-3)

[Before:](https://designsystem.digital.gov/design-principles/#government-resources-3)

![image](https://github.com/uswds/uswds-site/assets/93996430/2bcbba24-4906-4327-bb6e-20c965eb5899)

[After:](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-html-proofer-mobile-testing/design-principles/#government-resources-3)

![image](https://github.com/uswds/uswds-site/assets/93996430/c47c6291-38cf-421c-a6bf-3586c0571c09)

## Testing and review

- Confirm that removing the link makes sense 
- Confirm the update page content renders as expected
- Confirm html proofer errors pass
