### PR TITLE
USWDS-Site - Changelog: Add entry for "full" display utility classes

### DIFF
--- a/_data/changelogs/component-header.yml
+++ b/_data/changelogs/component-header.yml
@@ -2,6 +2,14 @@ title: Header
 type: component
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Updated the padding on `.usa-nav__submenu` elements so that they align with other header elements.
+    summaryAdditional:
+    isBreaking: false
+    affectsStyles: true
+    githubPr: 5649
+    githubRepo: uswds
+    versionUswds: N.N.N
   - date: 2023-11-20
     summary: Removed the role, banner component, and HTTPS sections.
     summaryAdditional:

--- a/_data/changelogs/utilities-display.yml
+++ b/_data/changelogs/utilities-display.yml
@@ -2,6 +2,14 @@ title: Display utility
 type: utility
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Fixed a bug that prevented the CSS from generating `.left-full`, `.right-full`, and `.top-full` utility classes.
+    summaryAdditional:
+    isBreaking:
+    affectsStyles: true
+    githubPr: 5633
+    githubRepo: uswds
+    versionUswds: N.N.N
   - date: 2022-06-08
     summary: Updated demonstration of `display:none`.
     summaryAdditional:


### PR DESCRIPTION
# Summary
Add changelog entry for new `.left-full`, `.right-full`, and `.top-full` utility classes.

## Related PR

https://github.com/uswds/uswds/pull/5633

## Preview link
[Display utilities changelog](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-changelog-5633/utilities/display/#changelog)