### PR TITLE
USWDS-Site - HTML proofer: Remove Akamai HTTP/2 link

### DIFF
--- a/pages/documentation/guidance/performance/http2.md
+++ b/pages/documentation/guidance/performance/http2.md
@@ -50,7 +50,6 @@ Before upgrading, you should check to see if your server already supports HTTP/2
 
 Upgrading to HTTP/2 requires that you have administrative access to either the server or CDN that hosts your website and its assets. If your site is on a CDN not directly under your control, here are instructions for enabling HTTP/2 on some of the most common CDNs:
 
-- [Akamai](https://http2.akamai.com/)
 - [Cloudflare](https://developers.cloudflare.com/cache/how-to/enable-http2-to-origin/)
 - [Amazon CloudFront](https://aws.amazon.com/about-aws/whats-new/2016/09/amazon-cloudfront-now-supports-http2/)
 


### PR DESCRIPTION
# Summary
Removed the Akamai  link from the [HTTP/2 performance page](https://designsystem.digital.gov/performance/http2/#how-to-upgrade-to-http2) because it now returns a `Moved Permanently (status code 301)` error. 

I could not find a equivalent page on Akamai with the content found in the [Wayback Machine](https://web.archive.org/web/20231101075143/https://http2.akamai.com/) (Nov 2023). 

## Preview link

Preview link: [HTTP/2 page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-html-proofer-akamai/performance/http2/#how-to-upgrade-to-http2)

## Testing and review
- Confirm that removing the link makes sense
- Confirm the updated page content renders as expected
- Confirm html proofer check passes