### PR TITLE
USWDS- Site: Fix snyk and html-proofer errors

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2707,8 +2707,8 @@ ignore:
         expires: '2022-01-27T21:29:25.295Z'
     - '*':
         reason: No available upgrade or patch
-        expires: 2023-11-24T20:25:43.881Z
-        created: 2023-10-25T20:25:43.913Z
+        expires: 2023-12-29T16:20:10.048Z
+        created: 2023-11-29T16:20:10.096Z
   SNYK-JS-AXIOS-1579269:
     - uswds > @frctl/fractal > @frctl/web > browser-sync > localtunnel > axios:
         reason: None given
@@ -3498,8 +3498,8 @@ ignore:
   SNYK-JS-UNSETVALUE-2400660:
     - '*':
         reason: No available upgrade or patch
-        expires: 2023-11-24T20:25:58.002Z
-        created: 2023-10-25T20:25:58.034Z
+        expires: 2023-12-29T16:20:21.051Z
+        created: 2023-11-29T16:20:21.094Z
   SNYK-JS-DECODEURICOMPONENT-3149970:
     - '*':
         reason: No available upgrade or patch

--- a/_components/header/header.html
+++ b/_components/header/header.html
@@ -134,11 +134,11 @@ in_page_nav: false
 <h2>Further reading</h2>
 <ul>
   <li>
-    <a href="https://www.nngroup.com/articles/menu-design/">https://www.nngroup.com/articles/menu-design/</a>
+    <a href="https://www.nngroup.com/articles/menu-design/">Menu design resource from Nielsen Norman</a>
   </li>
   <li>
     <a
-      href="https://help.usertesting.com/hc/en-us/articles/115003372331-What-is-Tree-Testing">https://help.usertesting.com/hc/en-us/articles/115003372331-What-is-Tree-Testing</a>
+      href="https://help.usertesting.com/hc/en-us/articles/11880459763869">Tree Testing resource from UserTesting.com</a>
   </li>
 </ul>
 


### PR DESCRIPTION
## Summary
Fixed snyk and html-proofer build errors. Also added descriptive link text according to recommendations from @sarah-sch.

## Preview link
- [Header component page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-snyk-nov/components/header/)

## Problem statement
1. `npx snyk test` was throwing errors.
2. `npm run proof` threw an error for a 404 link. 

## Solution
1. Updated to ignore the following items: 
    - SNYK-JS-UNSETVALUE-2400660
    - SNYK-JS-ANSIREGEX-1583908

    Ran the following in the command line:
    ```
    npx snyk ignore --id="SNYK-JS-UNSETVALUE-2400660" --reason="No available upgrade or patch"
    npx snyk ignore --id="SNYK-JS-ANSIREGEX-1583908" --reason="No available upgrade or patch"
    ```
2. Replaced the current [404 link](https://help.usertesting.com/hc/en-us/articles/115003372331-What-is-Tree-Testing) with its redirect. Also added descriptive link text according to recommendations from @sarah-sch. 

## Testing and review
- To test, run `npx snyk test` and `npm run proof` and check for errors.
- Confirm the updated link text is descriptive, accurate and free from error.

## Reference
[Ignoring Snyk alerts](https://docs.google.com/document/d/1RX6uYky-P37jysuBy6LEBhuMCQlMAvHU0mRJUow345o/edit) (Google docs :lock:)