### PR TITLE
USWDS-Site: Update snyk ignore

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2707,8 +2707,8 @@ ignore:
         expires: '2022-01-27T21:29:25.295Z'
     - '*':
         reason: No available upgrade or patch
-        expires: 2023-12-29T16:20:10.048Z
-        created: 2023-11-29T16:20:10.096Z
+        expires: 2023-12-30T19:33:21.268Z
+        created: 2023-11-30T19:33:21.304Z
   SNYK-JS-AXIOS-1579269:
     - uswds > @frctl/fractal > @frctl/web > browser-sync > localtunnel > axios:
         reason: None given
@@ -3498,8 +3498,8 @@ ignore:
   SNYK-JS-UNSETVALUE-2400660:
     - '*':
         reason: No available upgrade or patch
-        expires: 2023-12-29T16:20:21.051Z
-        created: 2023-11-29T16:20:21.094Z
+        expires: 2023-12-30T19:33:21.268Z
+        created: 2023-11-30T19:33:21.304Z
   SNYK-JS-DECODEURICOMPONENT-3149970:
     - '*':
         reason: No available upgrade or patch
@@ -3520,6 +3520,11 @@ ignore:
         reason: No available upgrade or patch
         expires: 2023-11-10T19:28:02.827Z
         created: 2023-10-11T19:28:02.917Z
+  SNYK-JS-INFLIGHT-6095116:
+    - '*':
+        reason: No available upgrade or patch
+        expires: 2023-12-30T19:33:21.268Z
+        created: 2023-11-30T19:33:21.304Z
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   'npm:minimatch:20160620':


### PR DESCRIPTION
## Summary
Added inflight to the snyk ignore. Also updated the snyk ignores from [yesterday](https://github.com/uswds/uswds-site/pull/2380) so that the open vulnerabilities would be on the same schedule. 

## Problem statement
`npx snyk test` is throwing the following error:

```
  ✗ Missing Release of Resource after Effective Lifetime [High Severity][https://security.snyk.io/vuln/SNYK-JS-INFLIGHT-6095116] in inflight@1.0.6
    introduced by @uswds/compile@1.1.0 > del@6.1.1 > rimraf@3.0.2 > glob@7.2.3 > inflight@1.0.6 and 1 other path(s)
  No upgrade or patch available
```

## Solution
Updated to ignore SNYK-JS-INFLIGHT-6095116. Ran the following in the command line:

```
npx snyk ignore --id="SNYK-JS-INFLIGHT-6095116" --reason="No available upgrade or patch"
```

## Testing and review
- To test, run `npx snyk test` and check for errors.

## Reference
[Ignoring Snyk alerts](https://docs.google.com/document/d/1RX6uYky-P37jysuBy6LEBhuMCQlMAvHU0mRJUow345o/edit) (Google docs :lock:)