### PR TITLE
USWDS-Site: Remove open government link

### DIFF
--- a/_data/changelogs/about-policies.yml
+++ b/_data/changelogs/about-policies.yml
@@ -2,6 +2,11 @@ title: Website policies
 type: documentation
 changelogURL:
 items:
+  - date: 2023-12-01
+    summary: Removed open government link.
+    affectsGuidance: true
+    githubPr: 2384
+    githubRepo: uswds-site
   - date: 2021-10-19
     summary: Added policies page.
     summaryAdditional:

--- a/pages/about/website-policies-and-notices.md
+++ b/pages/about/website-policies-and-notices.md
@@ -176,8 +176,6 @@ Federal agencies are required to provide the following links to agency-level inf
 
 -   [Office of the Inspector General](https://www.gsaig.gov/)
 
--   Open government initiatives (pending updated link)
-
 -   [Orders and directives](https://www.gsa.gov/directives-library)
 
 -   [Plain language](https://www.gsa.gov/governmentwide-initiatives/plain-language)


### PR DESCRIPTION
# Summary

Removed the open government link from the website policies page. 

## Related issue

Closes #2133

## Preview link

[Website policies page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-open-govt-link/about/website-policies-notices/#required-content-notice)

## Problem statement

The GSA open government link on the [website policies page](https://designsystem.digital.gov/about/website-policies-notices/#required-content-notice) returned a 404 so in the doc updates for 3.5.0 we added "pending" copy while we waited to find a replacement link ([PR #2096](https://github.com/uswds/uswds-site/pull/2096/files#diff-a066b23cde022edc6967714a5bcfb4fb28c2aa3e56dc5fd0dedc08d4a761b905R179)). However, we have not been able to find a suitable replacement for this link. 

![image](https://github.com/uswds/uswds-site/assets/93996430/9ecd032b-f72b-4635-950f-3e79775b57c6)


## Solution

Per the guidance on [digital.gov](https://digital.gov/resources/required-web-content-and-links/#about-page), it is not necessary for USWDS (as a "secondary" site) to include a link to the open government page. Because of this, we removed the link from the page. 

More details on the solution can be found in [this Slack conversation](https://gsa-tts.slack.com/archives/C050HRGN7/p1701281376307389?thread_ts=1701280311.922679&cid=C050HRGN7) ( :lock: ).

![image](https://github.com/uswds/uswds-site/assets/93996430/edee96a9-9654-4f1f-908e-0d55d5622df3)

## Testing and review

- Confirm that the open government text has been removed
- Confirm that there are no regressions on other content
- Confirm changelog is accurate and free from error
