### PR TITLE
USWDS-Site - Changelog:  Vertically center nav elements [#5654]

### DIFF
--- a/_data/changelogs/component-header.yml
+++ b/_data/changelogs/component-header.yml
@@ -3,8 +3,8 @@ type: component
 changelogURL:
 items:
   - date: NNNN-NN-NN
-    summary: Improved the display of header navigation dropdown button for long links.
-    summaryAdditional:  The expander icon will now be vertically centered.
+    summary: Improved the vertical alignment of the expander icon in the mobile menu.
+    summaryAdditional:  The icon will now maintain vertical alignment on menu buttons with long links.
     affectsStyles: true
     githubPr: 5654
     githubRepo: uswds

--- a/_data/changelogs/component-header.yml
+++ b/_data/changelogs/component-header.yml
@@ -3,8 +3,8 @@ type: component
 changelogURL:
 items:
   - date: NNNN-NN-NN
-    summary: Improved the vertical alignment of the expander icon in the mobile menu.
-    summaryAdditional:  The icon will now maintain vertical alignment on menu buttons with long links.
+    summary: Improved the vertical alignment of the expand icon.
+    summaryAdditional:  The icon will now maintain vertical alignment on menu buttons with long link text.
     affectsStyles: true
     githubPr: 5654
     githubRepo: uswds

--- a/_data/changelogs/component-header.yml
+++ b/_data/changelogs/component-header.yml
@@ -4,7 +4,7 @@ changelogURL:
 items:
   - date: NNNN-NN-NN
     summary: Improved the vertical alignment of the expand icon.
-    summaryAdditional:  The icon will now maintain vertical alignment on menu buttons with long link text.
+    summaryAdditional: The icon will now maintain vertical alignment when menu button text breaks to multiple lines.
     affectsStyles: true
     githubPr: 5654
     githubRepo: uswds

--- a/_data/changelogs/component-header.yml
+++ b/_data/changelogs/component-header.yml
@@ -2,6 +2,13 @@ title: Header
 type: component
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Improved the display of header navigation dropdown button for long links.
+    summaryAdditional:  The expander icon will now be vertically centered.
+    affectsStyles: true
+    githubPr: 5654
+    githubRepo: uswds
+    versionUswds: N.N.N
   - date: 2023-11-20
     summary: Removed the role, banner component, and HTTPS sections.
     summaryAdditional:


### PR DESCRIPTION
# Summary

**Improved the display of header navigation dropdown button for long links.** The expander icon will now be vertically centered.

## Related PR

uswds/uswds#5654

## Preview link

[Preview →](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cm-changelog-5654/components/header/)