### PR TITLE
USWDS-Site - HTML-Proofer: Fix Performance.gov CX link 

### DIFF
--- a/pages/design-principles/design-principles.md
+++ b/pages/design-principles/design-principles.md
@@ -297,7 +297,7 @@ The following are practical actions you can take:
 - [Guide to the Digital Analytics Program (DAP)](https://digital.gov/services/dap/) [digital.gov]
 - [Getting started with Search.gov [youtube.com]](https://www.youtube.com/watch?v=p-y9T23ziEg) [search.gov]
 - [Office of Evaluation Sciences](https://oes.gsa.gov/) [oes.gsa.gov]
-- [Improving Customer Experience: Cross-Agency Priority Goal](https://www.performance.gov/CAP/cx/) [performance.gov]
+- [Delivering Excellent, Equitable, and Secure Federal Services and Customer Experience](https://www.performance.gov/pma/cx/) [performance.gov]
 - [Tips for Starting Your Customer Experience Journey](https://www.performance.gov/cx/blog/tips-for-starting-your-customer-experience-journey/) [performance.gov]
 - [OMB Circular A-11 Section 280: Managing Customer Experience and Improving Service Delivery](https://www.performance.gov/cx/assets/files/a11_2021-FY22.pdf) [performance.gov]
 - [USDA's guidance on conducting a regular customer experience (or A-11) survey](https://www.usda.gov/digital-strategy/research/plays#research2) [usda.gov]


### PR DESCRIPTION
# Summary
Replaced the Performance.gov CX link and link description. 

The previous page ([Improving Customer Experience: Cross-Agency Priority Goal](https://www.performance.gov/CAP/cx/)) returns a 404. 

This page conveys a similar message to the original: [Delivering Excellent, Equitable, and Secure Federal Services and Customer Experience](https://www.performance.gov/pma/cx/)

More discussion about the decision in this [Slack thread](https://gsa-tts.slack.com/archives/C050HRGN7/p1702065728604979) (:lock:).

## Preview link

[Design principles page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-html-proofer-cap/design-principles/#government-resources-4)

## Testing and review
- Confirm that replacing the link is appropriate and makes sense
- Confirm the updated page content renders as expected
- Confirm html proofer check passes