### PR TITLE
USWDS-Site - Footer changelog: Update to include layout grid

### DIFF
--- a/_data/changelogs/component-footer.yml
+++ b/_data/changelogs/component-footer.yml
@@ -4,7 +4,7 @@ changelogURL:
 items:
   - date: 2023-12-08
     summary: Removed the `usa-layout-grid` dependency.
-    summaryAdditional: This update reduces the footer package size. If you notice changes in your layout after making this update, your Sass might be missing the usa-layout-grid package. You can include it by adding `@forward usa-layout-grid` to your [Sass entry point](https://designsystem.digital.gov/documentation/migration/#using-component-packages).
+    summaryAdditional: This update reduces the footer package size. If you notice changes in your layout after making this update, add the `usa-layout-grid` package to your [Sass entry point](https://designsystem.digital.gov/documentation/migration/#using-component-packages).
     affectsStyles: true
     githubPr: 5289
     githubRepo: uswds

--- a/_data/changelogs/component-footer.yml
+++ b/_data/changelogs/component-footer.yml
@@ -4,7 +4,7 @@ changelogURL:
 items:
   - date: 2023-12-08
     summary: Removed the `usa-layout-grid` dependency.
-    summaryAdditional: This update reduces the footer package size.
+    summaryAdditional: This update reduces the footer package size. If you notice changes in your layout after making this update, your Sass might be missing the usa-layout-grid package. You can include it by adding `@forward usa-layout-grid` to your [Sass entry point](https://designsystem.digital.gov/documentation/migration/#using-component-packages).
     affectsStyles: true
     githubPr: 5289
     githubRepo: uswds


### PR DESCRIPTION
# Summary

Updated changelog entry for uswds/uswds#5289 to include a note about layout grid.

## Preview link

[Footer changelog →](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cm-changelog-footer-grid/components/footer/#latest-updates)

## Problem statement

Users who import footer but not `layout-grid` may experience visual regressions if they've:
- Modified standard breakpoint utility classes in the markup of the footer
- Use `layout-grid` utilities elsewhere on the site

## Solution

Update changelog to alert users of this change:

> **This update reduces the footer package size**. Thanks @danbrady! (#5289) <br><br> If you notice changes in your layout after making this update, your Sass might be missing the `usa-layout-grid` package. You can include it by adding `@forward usa-layout-grid` to your [Sass entry point](https://designsystem.digital.gov/documentation/migration/#using-component-packages).

## Testing and review

1. Inspect updated changelog
2. Confirm it is appearing appropriately
3. Approve spelling and grammar
