### PR TITLE
USWDS-Site - Monthly call: Add script text to November 2023 MC entry

### DIFF
--- a/_data/monthly-calls.yml
+++ b/_data/monthly-calls.yml
@@ -11,7 +11,6 @@ videos:
     date: November 2023
     id: EQ8Nb60xgXA?si=eHcGR5WjpOVeDc07
     event_link: https://digital.gov/event/2023/11/16/uswds-monthly-call-november-2023/
-    missing_script: true
     slides:
       link: https://s3.amazonaws.com/digitalgov/static/uswds-monthly-call-november-2023.pptx
       size: 6.3


### PR DESCRIPTION
# Summary

Updated the November 2023 monthly call description so that it says "November 2023 script and more at Digital.gov" instead of "November 2023 event page at Digital.gov".

## Preview link

[Monthly calls page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-nov-mc-script/about/monthly-calls/)

## Problem statement
We needed to publish the [November 2023 monthly call description](https://designsystem.digital.gov/about/monthly-calls/) before the script was uploaded to the digital.gov counterpart. Because of this, we added a "missing_script" setting that updated the "script and more at Digital.gov" text to instead say "event page at Digital.gov". 

## Solution

Now that the script has been added to the digital.gov page, this PR removes the "missing_script" data field. This should update the November 2023 monthly call description so that it says "November 2023 script and more at Digital.gov" instead of "November 2023 event page at Digital.gov".

## Testing and review
Confirm that the November 2023 monthly call description has a bullet point that says "November 2023 script and more at Digital.gov" instead of "November 2023 event page at Digital.gov".