### PR TITLE
USWDS-Site: Fix typos in compile instructions

### DIFF
--- a/pages/documentation/getting-started-developers/phase-two.md
+++ b/pages/documentation/getting-started-developers/phase-two.md
@@ -228,10 +228,10 @@ Function | Description
 `copyFonts` | Copy USWDS fonts to `paths.dist.fonts`
 `copyImages` | Copy USWDS images to `paths.dist.img`
 `copyJS` | Copy USWDS compiled JavaScript to `paths.dist.js`
-`copyTheme` | Copy USWDS theme files (Sass entry point and settings files) from the `uswds` package to `paths.dist.sass`
+`copyTheme` | Copy USWDS theme files (Sass entry point and settings files) from the `uswds` package to `paths.dist.theme`
 `init` | `copyAll` + `compile`
 `updateUswds` | `copyAssets` + `compile`
-`watch` | Compiles, then recompiles when there are changes to Sass files in `paths.dist.sass` and `paths.src.projectSass`
+`watch` | Compiles, then recompiles when there are changes to Sass files in `paths.dist.theme` and `paths.src.projectSass`
 
 For any function you defined as an `export` in your `gulpfile.js`, you can run `npx gulp [function]`.
 

--- a/pages/documentation/getting-started-developers/phase-two.md
+++ b/pages/documentation/getting-started-developers/phase-two.md
@@ -189,12 +189,14 @@ Setting | Default values - Version 2.x | Default values - Version 3.0 | Descript
 `paths.src.fonts` | `"./node_modules/uswds/dist/fonts"` | `"./node_modules/@uswds/uswds/dist/fonts"` | Source location of the USWDS fonts
 `paths.src.img` | `"./node_modules/uswds/dist/img"` | `"./node_modules/@uswds/uswds/dist/img"` | Source location of the USWDS images
 `paths.src.js` | `"./node_modules/uswds/dist/js"` | `"./node_modules/@uswds/uswds/dist/js"` | Source location of the USWDS compiled JavaScript files
-`paths.src.projectSass` | `"./sass"` | `"./sass"` | Source location of any existing project Sass files outside of <br/>`paths.dist.sass`. The `watch` script will watch this <br>directory for changes.
+`paths.src.projectSass` | `"./sass"` | `"./sass"` | Source location of any existing project Sass files outside of <br/>`paths.dist.theme`. The `watch` script will watch this <br>directory for changes.
+`paths.src.projectIcons` | `""` | `""` | Source location of any additional project icons to include in the icon sprite. <br/>(Use _only_ these project icons in the sprite by setting `sprite.projectIconsOnly` to `true`.) |
 `paths.dist.theme` | `"./sass"` | `"./sass"` | Project destination for theme files (Sass entry point and <br>settings)
 `paths.dist.img` | `"./assets/uswds/images"` | `"./assets/uswds/images"` | Project destination for images
 `paths.dist.fonts` | `"./assets/uswds/fonts"` | `"./assets/uswds/fonts"` | Project destination for fonts
 `paths.dist.js` | `"./assets/uswds/js"` | `"./assets/uswds/js"` | Project destination for compiled JavaScript
 `paths.dist.css` | `"./assets/uswds/css"` | `"./assets/uswds/css"` | Project destination for compiled CSS
+`sprite.projectIconsOnly` | `false` | `false` | Include _only_ the icons in `paths.src.projectIcons` in the icon sprite
 
 </div>
 

--- a/pages/ui-components/packages.md
+++ b/pages/ui-components/packages.md
@@ -48,7 +48,7 @@ With packages and Sass module syntax in USWDS 3.0, you can be confident that pac
 ### The uswds-core package
 The `uswds-core` package is a new package in USWDS 3.0. `uswds-core` is the engine of the design system, and includes all the functions, mixins, placeholders, tokens, and fonts necessary to write USWDS Sass.
 
-Any custom Sass you write needs to `@use "uswds-core"` at the top of the file to load the USWDS design language. We suggest using `@uswds "uswds-core" as *` to add USWDS to the global namespace. For example:
+Any custom Sass you write needs to `@use "uswds-core"` at the top of the file to load the USWDS design language. We suggest using `@use "uswds-core" as *` to add USWDS to the global namespace. For example:
 
 ```scss
 /* custom-styles.scss */


### PR DESCRIPTION
# Summary

- Fixed typos and outdated references on the Phase 2: Compile and Packages pages.
- Added documentation for `projectIcons` and `projectIconsOnly` settings for `uswds-compile`

## Related issue

Closes #2288 

## Preview link

- Phase 2: compile page
- Packages page

## Problem statement
There are a few outdated references and typos in our documentation. 

## Solution

## Testing and review
1. Confirm that the information in the settings table matches the uswds-compile readme. 
1. Confirm that all issues outlined in issue #2288 have been fixed.