### PR TITLE
USWDS-Site - HTML-proofer: Fix broken links

### DIFF
--- a/_data/implementations.yml
+++ b/_data/implementations.yml
@@ -163,7 +163,7 @@
   author:
     name: GSA IT (Mark Vogelgesang)
     url: https://github.com/GSA/
-  notes: "Allows users to toggle between native Salesforce components/functionality along with custom components built using USWDS. Meets GSA's Guidelines for Digital Presence as well as tenants of [21st Century IDEA](https://digital.gov/resources/21st-century-integrated-digital-experience-act/)."
+  notes: "Allows users to toggle between native Salesforce components/functionality along with custom components built using USWDS. Meets GSA's Guidelines for Digital Presence as well as tenets of [21st Century IDEA](https://digital.gov/resources/21st-century-integrated-digital-experience-act/)."
 
 - name: USWDS WebJar
   distribution: WebJars

--- a/_data/implementations.yml
+++ b/_data/implementations.yml
@@ -163,7 +163,7 @@
   author:
     name: GSA IT (Mark Vogelgesang)
     url: https://github.com/GSA/
-  notes: "Allows users to toggle between native Salesforce components/functionality along with custom components built using USWDS. Meets GSA's Guidelines for Digital Presence as well as tenants of [21st Century IDEA](https://digital.gov/resources/21st-century-integrated-digital-experience-act/). View live implementation at [https://labs.gsa.gov](https://labs.gsa.gov)."
+  notes: "Allows users to toggle between native Salesforce components/functionality along with custom components built using USWDS. Meets GSA's Guidelines for Digital Presence as well as tenants of [21st Century IDEA](https://digital.gov/resources/21st-century-integrated-digital-experience-act/)."
 
 - name: USWDS WebJar
   distribution: WebJars

--- a/_next/04-00-looking-ahead.md
+++ b/_next/04-00-looking-ahead.md
@@ -69,7 +69,7 @@ We’ll provide regular updates on our progress in [monthly calls](https://digit
 * footnotes will be placed here. This line is necessary
 {:footnotes }
 
-[^8]: Dotgov Data - List of federal .gov domains. (n.d.). Retrieved January 06, 2021, from <https://home.dotgov.gov/data/>
+[^8]: Dotgov Data - List of federal .gov domains. (n.d.). Retrieved January 06, 2021, from <https://get.gov/about/data/>
 
 </div>
     </div>

--- a/css/_uswds-theme-custom-styles.scss
+++ b/css/_uswds-theme-custom-styles.scss
@@ -3732,7 +3732,7 @@ $do-dont-top-bar-width: 1;
 
   .usa-accordion__button,
   .usa-accordion__content {
-    @include u-font("lang","sm");
+    @include u-font("lang", "sm");
   }
 
   .usa-accordion__content {
@@ -3770,14 +3770,14 @@ $do-dont-top-bar-width: 1;
   }
 
   &__text {
-    @include u-font("lang","sm");
+    @include u-font("lang", "sm");
     @include u-margin-bottom(1);
     @include u-margin-top(0);
     @include u-line-height("sans", 6);
 
     &--status {
       @include u-margin-y(1);
-      @include u-font("lang","xs");
+      @include u-font("lang", "xs");
       @include u-line-height("lang", 4);
     }
 
@@ -3846,7 +3846,6 @@ $do-dont-top-bar-width: 1;
   }
 }
 
-
 .site-checklist-tag {
   @include u-border("1px", "gray-10");
   @include u-font("lang", "3xs");
@@ -3912,7 +3911,6 @@ $do-dont-top-bar-width: 1;
     color: color("blue-cool-60");
   }
 }
-
 
 .site-compliance-tag {
   @include u-font("lang", "xs");

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "federalist": "npx gulp build",
     "lint": "npx gulp lintJS lintSass && npm run prettier:scss",
     "prestart": "npx gulp build",
-    "proof": "bundle exec htmlproofer --allow-hash-href=true --enforce-https=false --allow-missing-href=true --ignore-empty-alt=true --ignore-status-codes 0,403,429,503,302 --swap-urls 'https\\://designsystem.digital.gov/:/' --ignore-files \"//select-a-language//,//2017//,//2018//,//2019//,//code-guidelines//\" ./_site",
+    "proof": "bundle exec htmlproofer --allow-hash-href=true --enforce-https=false --allow-missing-href=true --ignore-empty-alt=true --ignore-status-codes 0,403,429,503,302 --swap-urls 'https\\://designsystem.digital.gov/:/' --ignore-urls '/github.com/uswds/uswds/issues/' --ignore-files \"//select-a-language//,//2017//,//2018//,//2019//,//code-guidelines//\" ./_site",
     "serve": "npm run build:all-assets && bundle exec jekyll serve --drafts --future --incremental --livereload --host=localhost",
     "serve:package": "npm run build:uswds && npm run serve",
     "serve:local": "export LIBRARY_BASE_URL=\"http://localhost:3000\" && npm run serve",

--- a/pages/documentation/guidance/accessibility.md
+++ b/pages/documentation/guidance/accessibility.md
@@ -126,10 +126,11 @@ We recommend a mix of automated, semi-automated, and manual testing in addition 
 
 ### Government usability testing resources
 
-- [Usability testing on Digital.gov](https://digital.gov/topics/usability-testing/) [digital.gov]
+- [Usability resources on Digital.gov](https://digital.gov/topics/usability/) [digital.gov]
 - [Getting started with usability testing](https://digital.gov/2015/03/19/getting-started-with-usability-testing/) [digital.gov]
 - [Testing for plain-language usability](https://www.plainlanguage.gov/guidelines/test/usability-testing/) [plainlanguage.gov]
 - [18F's collection of human-centered design tools](https://methods.18f.gov/) [18f.gov]
+- [18F's usability testing guide](https://methods.18f.gov/validate/usability-testing/) [18f.gov]
 
 ## Accessibility resources
 


### PR DESCRIPTION
# Summary

Updated links to resolve HTML proofer errors.


## Preview link
- [Accessibility page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-html-proofer-jan24/documentation/accessibility/#government-usability-testing-resources)
- [Implementations page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-html-proofer-jan24/documentation/implementations/)
- [Next - looking ahead page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-html-proofer-jan24/next/looking-ahead/)

## Problem statement

Received the following HTML proofer error:

```
For the Links > External check, the following failures were found:

* At ./_site/documentation/accessibility/index.html:2896:

  External link https://digital.gov/topics/usability-testing/ failed (status code 404)

* At ./_site/documentation/implementations/index.html:3078:

  External link https://labs.gsa.gov failed: Moved Permanently (status code 301)

* At ./_site/next/looking-ahead/index.html:362:

  External link https://home.dotgov.gov/data/ failed (status code 404)
```

## Solution

- Removed link to labs.gsa.gov because it is returning a privacy error. 
- Updated the digital.gov link to the more generic "usability" topic
- Added a link to 18f's usability testing page
- Updated old .Gov data link
    - For reference, here is the [Wayback machine link](https://web.archive.org/web/20221027081018/https://home.dotgov.gov/data/) for https://home.dotgov.gov/data/

## Testing and review

- Confirm that the updates make sense
- Confirm the new links work