### PR TITLE
USWDS-Site - Changelog: Add entry for high contrast date picker fix [#5701]

### DIFF
--- a/_data/changelogs/component-date-picker.yml
+++ b/_data/changelogs/component-date-picker.yml
@@ -2,6 +2,14 @@ title: Date picker
 type: component
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Adds focus styles to calendar button in high contrast mode. 
+    summaryAdditional: Now, the calendar icon changes to the `highlight` high contrast token.
+    affectsAccessibility: true
+    affectsStyles: true
+    githubPr: 5701
+    githubRepo: uswds
+    versionUswds: 3.8.0
   - date: 2023-11-20
     summary: Added known issues section.
     summaryAdditional:

--- a/_data/changelogs/component-date-picker.yml
+++ b/_data/changelogs/component-date-picker.yml
@@ -3,8 +3,8 @@ type: component
 changelogURL:
 items:
   - date: NNNN-NN-NN
-    summary: Adds focus styles to calendar button in high contrast mode. 
-    summaryAdditional: Now, the calendar icon changes to the `highlight` high contrast token.
+    summary: Added focus styles to calendar button in high contrast mode. 
+    summaryAdditional: Now, the calendar icon changes to the `highlight` high contrast token on focus.
     affectsAccessibility: true
     affectsStyles: true
     githubPr: 5701

--- a/_data/issues/date-picker.yml
+++ b/_data/issues/date-picker.yml
@@ -9,10 +9,3 @@ items:
   affectsScreenReaders: true
   githubRepo: uswds
   githubNumber: 5534
-- date: 2023-09-29
-  summary: The focus indicator is not visible around the calendar icon in high contrast mode.
-  summaryAdditional:
-  affectsKeyboard: true
-  affectsHighContrast: true
-  githubRepo: uswds
-  githubNumber: 5535


### PR DESCRIPTION
# Summary

Adds changelog entry for uswds/uswds#5701 and removes the known issue resolved by PR.

## Changelog

>  **Adds focus styles to calendar button in high contrast mode.** Now, the calendar icon changes to the `highlight` high contrast token.

## Removed known issue

> The focus indicator is not visible around the calendar icon in high contrast mode. More information on GitHub: [uswds#5535](https://github.com/uswds/uswds/pull/5535)

## Preview link

[Date picker changelog →](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cm-changelog-5701/components/date-picker/#latest-updates)