### PR TITLE
USWDS-Site - Changelog: Add entry for footer grid fix

### DIFF
--- a/_data/changelogs/component-footer.yml
+++ b/_data/changelogs/component-footer.yml
@@ -2,6 +2,13 @@ title: Footer
 type: component
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Resolved style specificity issues between `usa-footer` and `usa-layout-grid`.
+    summaryAdditional:  This resolves visual regressions potentially caused by removing layout grid dependency.
+    affectsStyles: true
+    githubPr: 5675
+    githubRepo: uswds
+    versionUswds: N.N.N
   - date: 2023-12-08
     summary: Removed the `usa-layout-grid` dependency.
     summaryAdditional: This update reduces the footer package size. If you notice changes in your layout after making this update, add the `usa-layout-grid` package to your [Sass entry point](https://designsystem.digital.gov/documentation/migration/#using-component-packages).

--- a/_data/changelogs/component-footer.yml
+++ b/_data/changelogs/component-footer.yml
@@ -3,8 +3,8 @@ type: component
 changelogURL:
 items:
   - date: NNNN-NN-NN
-    summary: Resolved style specificity issues between `usa-footer` and `usa-layout-grid`.
-    summaryAdditional:  This resolves visual regressions potentially caused by removing layout grid dependency.
+    summary: Fixed a bug that caused some grid utility classes to be ignored when used inside `usa-footer`.
+    summaryAdditional:  
     affectsStyles: true
     githubPr: 5675
     githubRepo: uswds


### PR DESCRIPTION
# Summary

Adds changelog entry for uswds/uswds#5675

>  **Resolved style specificity issues between `usa-footer` and `usa-layout-grid`.** This resolves visual regressions potentially caused by removing layout grid dependency.

## Preview link

[Footer changelog →](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cm-changelog-5675/components/footer/#latest-updates)