### PR TITLE
USWDS-Site - Display/:Fixes the typo for .z-100

### DIFF
--- a/_utilities/display.md
+++ b/_utilities/display.md
@@ -673,7 +673,7 @@ utilities:
       </div>
       <div class="bg-gray-70 border border-ink radius-lg width-card-lg padding-2 padding-top-5 minh-10 margin-left-0 display-flex flex-justify flex-align-start margin-top-neg-3 z-100 position-relative shadow-3">
         <span class="utility-class">.z-100</span>
-        <span class="utility-value">400</span>
+        <span class="utility-value">100</span>
       </div>
       <div class="bg-gray-90 border border-ink radius-lg width-card-lg padding-2 padding-top-5 minh-10 margin-left-0 display-flex flex-justify flex-align-start margin-top-neg-3 z-0 position-relative shadow-3">
         <span class="utility-class">.z-0</span>

--- a/pages/design-tokens/z-index.md
+++ b/pages/design-tokens/z-index.md
@@ -46,7 +46,7 @@ subnav:
       </div>
       <div class="bg-gray-70 border border-ink radius-lg padding-2 padding-top-5 minh-10 margin-left-0 display-flex flex-justify flex-align-start margin-top-neg-3 z-100 position-relative z-index-3">
         <code class="bg-white">100</code>
-        <span class="utility-value">400</span>
+        <span class="utility-value">100</span>
       </div>
       <div class="bg-gray-90 border border-ink radius-lg padding-2 padding-top-5 minh-10 margin-left-0 display-flex flex-justify flex-align-start margin-top-neg-3 z-0 position-relative z-index-3">
         <code class="bg-white">0</code>


### PR DESCRIPTION
# Summary

Fixes the typo for .z-100. Previously was `400`, changed text to `100`.

![image](https://github.com/uswds/uswds-site/assets/51383133/b2b18d8b-3b33-4490-8317-e9f576b54b21)