### PR TITLE
USWDS-Site: Fix snyk errors

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2707,8 +2707,8 @@ ignore:
         expires: '2022-01-27T21:29:25.295Z'
     - '*':
         reason: No available upgrade or patch
-        expires: 2024-02-16T21:14:59.383Z
-        created: 2024-01-17T21:14:59.405Z
+        expires: 2024-03-21T16:21:14.318Z
+        created: 2024-02-20T16:21:14.362Z
   SNYK-JS-AXIOS-1579269:
     - uswds > @frctl/fractal > @frctl/web > browser-sync > localtunnel > axios:
         reason: None given
@@ -3498,8 +3498,8 @@ ignore:
   SNYK-JS-UNSETVALUE-2400660:
     - '*':
         reason: No available upgrade or patch
-        expires: 2024-02-16T21:14:56.411Z
-        created: 2024-01-17T21:14:56.451Z
+        expires: 2024-03-21T16:21:11.452Z
+        created: 2024-02-20T16:21:11.490Z
   SNYK-JS-DECODEURICOMPONENT-3149970:
     - '*':
         reason: No available upgrade or patch
@@ -3523,8 +3523,8 @@ ignore:
   SNYK-JS-INFLIGHT-6095116:
     - '*':
         reason: No available upgrade or patch
-        expires: 2024-02-16T21:15:02.889Z
-        created: 2024-01-17T21:15:02.911Z
+        expires: 2024-03-21T16:21:17.293Z
+        created: 2024-02-20T16:21:17.327Z
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   'npm:minimatch:20160620':


### PR DESCRIPTION
## Summary
Updated snyk ignore files

## Problem statement
`npx snyk test` is throwing the following error:

```
Issues with no direct upgrade or patch:
  ✗ Regular Expression Denial of Service (ReDoS) [High Severity][https://security.snyk.io/vuln/SNYK-JS-ANSIREGEX-1583908] in ansi-regex@2.1.1
    introduced by @uswds/compile@1.1.0 > gulp@4.0.2 > gulp-cli@2.3.0 > yargs@7.1.2 > string-width@1.0.2 > strip-ansi@3.0.1 > ansi-regex@2.1.1 and 4 other path(s)
  This issue was fixed in versions: 3.0.1, 4.1.1, 5.0.1, 6.0.1
  ✗ Missing Release of Resource after Effective Lifetime [Medium Severity][https://security.snyk.io/vuln/SNYK-JS-INFLIGHT-6095116] in inflight@1.0.6
    introduced by @uswds/compile@1.1.0 > del@6.1.1 > rimraf@3.0.2 > glob@7.2.3 > inflight@1.0.6 and 1 other path(s)
  No upgrade or patch available
  ✗ Prototype Pollution [High Severity][https://security.snyk.io/vuln/SNYK-JS-UNSETVALUE-2400660] in unset-value@1.0.0
    introduced by @uswds/compile@1.1.0 > gulp@4.0.2 > glob-watcher@5.0.5 > chokidar@2.1.8 > braces@2.3.2 > snapdragon@0.8.2 > base@0.11.2 > cache-base@1.0.1 > unset-value@1.0.0 and 30 other path(s)
  This issue was fixed in versions: 2.0.1
```

## Solution
Updated snyk ignore. Ran the following in the command line:

```
npx snyk ignore --id="SNYK-JS-UNSETVALUE-2400660" --reason="No available upgrade or patch"
npx snyk ignore --id="SNYK-JS-ANSIREGEX-1583908" --reason="No available upgrade or patch"
npx snyk ignore --id="SNYK-JS-INFLIGHT-6095116" --reason="No available upgrade or patch" 
```

## Testing and review
To test, run `npx snyk test` and check for errors.

## Reference
[Ignoring Snyk alerts](https://docs.google.com/document/d/1RX6uYky-P37jysuBy6LEBhuMCQlMAvHU0mRJUow345o/edit) (Google docs :lock:)