### PR TITLE
USWDS-Site - Changelog: Add entry for validation & text input

### DIFF
--- a/_components/text-input/guidance/usability.md
+++ b/_components/text-input/guidance/usability.md
@@ -2,4 +2,3 @@
 - **Consider the mobile context.** Text inputs are among the easiest type of input for desktop users but are more difficult for mobile users.
 - **Wait to validate.** Only show error validation messages or stylings after a user has interacted with a particular field.
 - **Avoid placeholder text.** Avoid using placeholder text that appears within a text field before a user starts typing. If placeholder text is no longer visible after a user clicks into the field, users will no longer have that text available when they need to review their entries. (People who have cognitive or visual disabilities have additional problems with placeholder text.)
-.

--- a/_data/changelogs/component-text-input.yml
+++ b/_data/changelogs/component-text-input.yml
@@ -5,6 +5,21 @@ type: component
 changelogURL:
 
 items:
+  - date: NNNN-NN-NN
+    summary: Textarea supports validation.
+    summaryAdditional:
+    isBreaking: false
+    affectsAccessibility:
+    affectsAssets:
+    affectsContent:
+    affectsGuidance:
+    affectsJavascript: true
+    affectsMarkup: true
+    affectsSettings: true
+    affectsStyles:
+    githubPr: 5233
+    githubRepo: uswds
+    versionUswds: 3.8.0
   - date: 2023-11-16
     summary: Updated the listed values for `.usa-input--[width]`.
     affectsGuidance: true

--- a/_data/changelogs/component-text-input.yml
+++ b/_data/changelogs/component-text-input.yml
@@ -6,7 +6,7 @@ changelogURL:
 
 items:
   - date: NNNN-NN-NN
-    summary: Textarea supports validation.
+    summary: Added `textarea` support to the validation component. 
     summaryAdditional:
     isBreaking: false
     affectsAccessibility:

--- a/_data/changelogs/component-text-input.yml
+++ b/_data/changelogs/component-text-input.yml
@@ -6,16 +6,11 @@ changelogURL:
 
 items:
   - date: NNNN-NN-NN
-    summary: Added `textarea` support to the validation component. 
+    summary: Added `textarea` support to the validation component.
     summaryAdditional:
     isBreaking: false
-    affectsAccessibility:
-    affectsAssets:
-    affectsContent:
-    affectsGuidance:
     affectsJavascript: true
     affectsMarkup: true
-    affectsSettings: true
     affectsStyles:
     githubPr: 5233
     githubRepo: uswds

--- a/_data/changelogs/component-validation.yml
+++ b/_data/changelogs/component-validation.yml
@@ -2,6 +2,20 @@ title: Validation
 type: component
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Validation support added to textarea.
+    isBreaking: false
+    affectsAccessibility: false
+    affectsAssets:
+    affectsContent:
+    affectsGuidance:
+    affectsJavascript: true
+    affectsMarkup: true
+    affectsSettings: true
+    affectsStyles:
+    githubPr: 5233
+    githubRepo: uswds
+    versionUswds: 3.8.0
   - date: 2022-12-21
     summary: Clarified implementation guidance and removed the `#` from the example `data-validation-element` value.
     summaryAdditional:

--- a/_data/changelogs/component-validation.yml
+++ b/_data/changelogs/component-validation.yml
@@ -3,16 +3,11 @@ type: component
 changelogURL:
 items:
   - date: NNNN-NN-NN
-    summary: Added `textarea` support to the validation component. 
+    summary: Added `textarea` support to the validation component.
     isBreaking: false
     affectsAccessibility: false
-    affectsAssets:
-    affectsContent:
-    affectsGuidance:
     affectsJavascript: true
     affectsMarkup: true
-    affectsSettings: true
-    affectsStyles:
     githubPr: 5233
     githubRepo: uswds
     versionUswds: 3.8.0

--- a/_data/changelogs/component-validation.yml
+++ b/_data/changelogs/component-validation.yml
@@ -3,7 +3,7 @@ type: component
 changelogURL:
 items:
   - date: NNNN-NN-NN
-    summary: Validation support added to textarea.
+    summary: Added `textarea` support to the validation component. 
     isBreaking: false
     affectsAccessibility: false
     affectsAssets:


### PR DESCRIPTION
# Summary

Added changelog entries for Validation & Text Input component.

## Related issue

Related to uswds/uswds#5233 & #2477.

## Preview link

Preview link:
- [Validation](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/jm-changelog-validation-text-input/components/validation/)
- [Text input](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/jm-changelog-validation-text-input/components/text-input/)