### PR TITLE
USWDS-Site - Changelog: Add entry for button group wrapping lines

### DIFF
--- a/_data/changelogs/component-button-group.yml
+++ b/_data/changelogs/component-button-group.yml
@@ -2,6 +2,21 @@ title: Button group
 type: component
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Button group improved support for wrapping text.
+    summaryAdditional:  Improves support to button groups with wrapping lines of text.
+    isBreaking: false
+    affectsAccessibility:
+    affectsAssets:
+    affectsContent:
+    affectsGuidance:
+    affectsJavascript:
+    affectsMarkup: false
+    affectsSettings: false
+    affectsStyles: true
+    githubPr: 5657
+    githubRepo: uswds
+    versionUswds: 3.8.0
   - date: 2022-08-05
     summary: Styled aria-disabled to match disabled.
     summaryAdditional: Now disabled styling is applied whether you use `disabled` (disabled and hidden from screen readers) or `aria-disabled` (disabled and visible to screen readers).

--- a/_data/changelogs/component-button-group.yml
+++ b/_data/changelogs/component-button-group.yml
@@ -3,8 +3,8 @@ type: component
 changelogURL:
 items:
   - date: NNNN-NN-NN
-    summary: Button group improved support for wrapping text.
-    summaryAdditional:  Improves support to button groups with wrapping lines of text.
+    summary: Improved the appearance of button groups when text wraps to multiple lines.
+    summaryAdditional:  Now, every button in the group will be the same height. 
     isBreaking: false
     affectsAccessibility:
     affectsAssets:


### PR DESCRIPTION
# Summary

Changelog entry for uswds/uswds#5657.

## Related issue

uswds/uswds#5657.

## Preview link

[Preview link →](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/jm-changelog-button-group/components/button-group/#latest-updates)
