### PR TITLE
USWDS-Site - Research page: Add link to fed recruitment page

### DIFF
--- a/_data/changelogs/about-research.yml
+++ b/_data/changelogs/about-research.yml
@@ -2,6 +2,11 @@ title: Research
 type: documentation
 changelogURL:
 items:
+  - date: 2024-03-18
+    summary: Added link to the Recruitment for Feds page
+    affectsGuidance: true
+    githubPr: 2527
+    githubRepo: uswds-site
   - date: 2023-11-15
     summary: Replaced page content.
     affectsGuidance: true

--- a/pages/about/research/overview.md
+++ b/pages/about/research/overview.md
@@ -80,7 +80,7 @@ Explore some of our past research work:
 Find details on how to participate and what to expect.
 
 {:.usa-list}
-- For federal government employees (_coming soon_)
+- [For federal government employees]({{ site.baseurl }}/about/research/recruitment/general-fed)
 - [For people in the general public]({{ site.baseurl }}/about/research/recruitment/general-public)
 
 ## Research ethics


### PR DESCRIPTION
# Summary
Replaced the "For federal government employees (coming soon)" text on the [research page](https://designsystem.digital.gov/about/research/) with a link to the newly released [fed recruitment page](https://designsystem.digital.gov/about/research/recruitment/general-fed/). 

## Related issue
Closes #2528 

## Preview link

[Research page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-link-fed-research/about/research/#how-to-participate-in-research)

## Problem statement

The [recruitment for feds page](https://designsystem.digital.gov/about/research/recruitment/general-fed/) needs to be linked from the [main research page](https://designsystem.digital.gov/about/research/) where it says 'How to participate in research > For federal government employees"

## Testing and review

1. Confirm that the updated text looks correct
2. Confirm that the new link points to the correct page