### PR TITLE
USWDS-Site - Banner: Use and document banner flag as SVG

### DIFF
--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -9,7 +9,9 @@
           <img
             aria-hidden="true"
             class="usa-banner__header-flag"
-            src="{{ site.baseurl }}/assets/img/us_flag_small.png"
+            src="{{ site.baseurl }}/assets/img/us_flag.svg"
+            width="16"
+            height="11"
             alt=""
           />
         </div>


### PR DESCRIPTION
# Summary

**Update banner component example to use vector flag image.** The SVG flag image has been available since USWDS 3.7.0 and is both smaller and more scalable than its PNG predecessor.

## Related issue

Relates to merged pull request in USWDS: https://github.com/uswds/uswds/pull/5542

## Preview link

http://localhost:4000/components/banner/

## Problem statement

For context, refer to: https://github.com/uswds/uswds/pull/5542

## Solution

Updates both the banner of the documentation site itself as well as the component example code.

Also adds explicit `width` and `height` attribute to the image, which is a [best](https://web.dev/articles/optimize-cls?utm_source=lighthouse&utm_medium=devtools#modern-best-practice) [practice](https://www.smashingmagazine.com/2020/03/setting-height-width-images-important-again/) and may trigger errors in some static analysis tools (e.g. [Google Lighthouse](https://github.com/GoogleChrome/lighthouse/blob/1d2a380d3c15e5848381fc1dd625837c5dc28ff6/core/audits/unsized-images.js#L8)). 

## Testing and review

1. Go to http://localhost:4000/components/banner/
2. View component markup
3. Observe `us_flag.svg` and `width` and `height` attributes in component markup