### PR TITLE
USWDS-Site: Add typography accessibility tests page

### DIFF
--- a/_components/typography/accessibility.md
+++ b/_components/typography/accessibility.md
@@ -1,0 +1,13 @@
+---
+permalink: /components/typography/accessibility-tests/
+layout: styleguide
+component:
+  name: table
+title: Typography accessibility tests
+category: Components
+lead: USWDS typography should pass these manual accessibility tests.
+changelog:
+  key: 'component-typography-accessibility'
+---
+
+{% include accessibility-tests/index.html %}

--- a/_components/typography/accessibility.md
+++ b/_components/typography/accessibility.md
@@ -2,7 +2,7 @@
 permalink: /components/typography/accessibility-tests/
 layout: styleguide
 component:
-  name: table
+  name: typography
 title: Typography accessibility tests
 category: Components
 lead: USWDS typography should pass these manual accessibility tests.

--- a/_components/typography/typography.md
+++ b/_components/typography/typography.md
@@ -11,12 +11,8 @@ title: Typography
 category: Components
 lead: "Government websites need clear and consistent headings, highly legible body paragraphs, clear labels, and easy-to-use input fields. Our default typefaces are designed for legibility and can adapt to a variety of visual tones."
 subnav:
-  - text: Typesetting with USWDS
-    href: '#typesetting-with-uswds'
-  - text: Included typefaces
-    href: '#included-typefaces'
-  - text: Latest updates
-    href: '#changelog'
+- text: Typography accessibility tests
+  href: /components/typography/accessibility-tests/
 tags:
   - type
   - typesetting

--- a/_data/accessibility-tests/typography.yml
+++ b/_data/accessibility-tests/typography.yml
@@ -10,9 +10,9 @@ test_items:
     test_type: general
     version_tested: 3.6.1
     wcag_criterion: 1.4.3
-  - summary: Headings are present, appropriate and follow logical order.
+  - summary: Headings are present, appropriate, and follow logical order.
     summary_additional: |
-      When you view text content on a page,
+      When you view text on a page,
       headings summarize the content under them and are uniquely styled.
       `H1`-`H4` levels are nested in a logical order (e.g., levels don't get skipped).
     test_status: conditional

--- a/_data/accessibility-tests/typography.yml
+++ b/_data/accessibility-tests/typography.yml
@@ -6,7 +6,7 @@ test_items:
     summary_additional: |
       When you view text on a page and use ANDI or color contrast analyzer to look at the hex colors,
       the font color meets WCAG color contrast of at least 4.5:1.
-      Large text has a color contrast ratio of at least 3:1. 
+      Large text has a color contrast ratio of at least 3:1.
     test_status: conditional
     test_type: general
     version_tested: 3.6.1
@@ -15,7 +15,7 @@ test_items:
     summary_additional: |
       When you view text on a page,
       headings summarize the content under them and are uniquely styled.
-      `H1`-`H4` levels are nested in a logical order (e.g., levels don't get skipped).
+      `H1`-`H6` levels are nested in a logical order (e.g., levels don't get skipped).
     test_status: conditional
     test_type: general
     version_tested: 3.6.1

--- a/_data/accessibility-tests/typography.yml
+++ b/_data/accessibility-tests/typography.yml
@@ -1,5 +1,5 @@
-title:
-component_status:
+title: Typography
+component_status: pass
 test_items:
 # General tests
   - summary: Text meets color contrast requirements.

--- a/_data/accessibility-tests/typography.yml
+++ b/_data/accessibility-tests/typography.yml
@@ -5,7 +5,8 @@ test_items:
   - summary: Text meets color contrast requirements.
     summary_additional: |
       When you view text on a page and use ANDI or color contrast analyzer to look at the hex colors,
-      the font color meets WCAG color contrast of 4.5:1.
+      the font color meets WCAG color contrast of at least 4.5:1.
+      Large text has a color contrast ratio of at least 3:1. 
     test_status: conditional
     test_type: general
     version_tested: 3.6.1

--- a/_data/accessibility-tests/typography.yml
+++ b/_data/accessibility-tests/typography.yml
@@ -5,8 +5,7 @@ test_items:
   - summary: Text meets color contrast requirements.
     summary_additional: |
       When you view text on a page and use ANDI or color contrast analyzer to look at the hex colors,
-      contrast between the text and background is at least 4.5:1.
-      Large-scale text has a contrast ratio of at least 3:1.
+      the font color meets WCAG color contrast of 4.5:1.
     test_status: conditional
     test_type: general
     version_tested: 3.6.1

--- a/_data/accessibility-tests/typography.yml
+++ b/_data/accessibility-tests/typography.yml
@@ -4,29 +4,30 @@ test_items:
 # General tests
   - summary: Text meets color contrast requirements.
     summary_additional: |
-      When you view text on the page and use ANDI or color contrast analyzer to look at the hex colors,
-      contrast between the text and background colors is at least 4.5:1.
+      When you view text on a page and use ANDI or color contrast analyzer to look at the hex colors,
+      contrast between the text and background is at least 4.5:1.
+      Large-scale text has a contrast ratio of at least 3:1.
     test_status: conditional
     test_type: general
     version_tested: 3.6.1
     wcag_criterion: 1.4.3
-  - summary: Text can be resized without cutting off content.
+  - summary: Headings are present, appropriate and follow logical order.
     summary_additional: |
-      When you view text on a page and use a browser extension to scale your text up to 200%,
-      the text format stays consistent, and words don't get obscured.
-    test_status: pass
-    test_type: general
-    version_tested: 3.6.1
-    wcag_criterion: 1.4.4
-  - summary: Headings are appropriate and follow logical order.
-    summary_additional: |
-      When you view text on a page,
-      the headings summarize the content under them and are uniquely styled.
+      When you view text content on a page,
+      headings summarize the content under them and are uniquely styled.
       `H1`-`H4` levels are nested in a logical order (e.g., levels don't get skipped).
     test_status: conditional
     test_type: general
     version_tested: 3.6.1
     wcag_criterion: 2.4.6
 # Zoom/screen magnification tests
+  - summary: Text can be resized without loss of information.
+    summary_additional: |
+      When you zoom to 200%,
+      the text format stays consistent, and words don't get obscured.
+    test_status: pass
+    test_type: zoom
+    version_tested: 3.6.1
+    wcag_criterion: 1.4.4
 # Keyboard navigation tests
 # Screen reader tests

--- a/_data/accessibility-tests/typography.yml
+++ b/_data/accessibility-tests/typography.yml
@@ -1,0 +1,32 @@
+title:
+component_status:
+test_items:
+# General tests
+  - summary: Text meets color contrast requirements.
+    summary_additional: |
+      When you view text on the page and use ANDI or color contrast analyzer to look at the hex colors,
+      contrast between the text and background colors is at least 4.5:1.
+    test_status: conditional
+    test_type: general
+    version_tested: 3.6.1
+    wcag_criterion: 1.4.3
+  - summary: Text can be resized without cutting off content.
+    summary_additional: |
+      When you view text on a page and use a browser extension to scale your text up to 200%,
+      the text format stays consistent, and words don't get obscured.
+    test_status: pass
+    test_type: general
+    version_tested: 3.6.1
+    wcag_criterion: 1.4.4
+  - summary: Headings are appropriate and follow logical order.
+    summary_additional: |
+      When you view text on a page,
+      the headings summarize the content under them and are uniquely styled.
+      `H1`-`H4` levels are nested in a logical order (e.g., levels don't get skipped).
+    test_status: conditional
+    test_type: general
+    version_tested: 3.6.1
+    wcag_criterion: 2.4.6
+# Zoom/screen magnification tests
+# Keyboard navigation tests
+# Screen reader tests

--- a/_data/changelogs/component-typography-accessibility.yml
+++ b/_data/changelogs/component-typography-accessibility.yml
@@ -5,5 +5,5 @@ items:
   - date: NNNN-NN-NN
     summary: Added accessibility tests page.
     affectsGuidance: true
-    githubPr:
+    githubPr: 2540
     githubRepo: uswds-site

--- a/_data/changelogs/component-typography-accessibility.yml
+++ b/_data/changelogs/component-typography-accessibility.yml
@@ -2,7 +2,7 @@ title: Typography accessibility tests
 type: component
 changelogURL:
 items:
-  - date: NNNN-NN-NN
+  - date: 2024-03-20
     summary: Added accessibility tests page.
     affectsGuidance: true
     githubPr: 2540

--- a/_data/changelogs/component-typography-accessibility.yml
+++ b/_data/changelogs/component-typography-accessibility.yml
@@ -1,0 +1,9 @@
+title: Typography accessibility tests
+type: component
+changelogURL:
+items:
+  - date: NNNN-NN-NN
+    summary: Added accessibility tests page.
+    affectsGuidance: true
+    githubPr:
+    githubRepo: uswds-site

--- a/_data/changelogs/component-typography.yml
+++ b/_data/changelogs/component-typography.yml
@@ -4,6 +4,11 @@ type: component
 changelogURL:
 
 items:
+  - date: NNNN-NN-NN
+    summary: Added WCAG compliance tag and accessibility test status section.
+    affectsGuidance: true
+    githubPr:
+    githubRepo: uswds-site
   - date: 2023-06-09
     summary: Stopped using font smoothing.
     summaryAdditional: No longer use font smoothing for dark backgrounds and disabled buttons.

--- a/_data/changelogs/component-typography.yml
+++ b/_data/changelogs/component-typography.yml
@@ -7,7 +7,7 @@ items:
   - date: NNNN-NN-NN
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
-    githubPr:
+    githubPr: 2540
     githubRepo: uswds-site
   - date: 2023-06-09
     summary: Stopped using font smoothing.

--- a/_data/changelogs/component-typography.yml
+++ b/_data/changelogs/component-typography.yml
@@ -4,7 +4,7 @@ type: component
 changelogURL:
 
 items:
-  - date: NNNN-NN-NN
+  - date: 2024-03-20
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 2540

--- a/_data/changelogs/component-typography.yml
+++ b/_data/changelogs/component-typography.yml
@@ -5,7 +5,7 @@ changelogURL:
 
 items:
   - date: 2024-03-20
-    summary: Added WCAG compliance tag and accessibility test status section.
+    summary: Added WCAG compliance tag.
     affectsGuidance: true
     githubPr: 2540
     githubRepo: uswds-site

--- a/_includes/accessibility-tests/checklist-feedback.html
+++ b/_includes/accessibility-tests/checklist-feedback.html
@@ -1,13 +1,13 @@
 ## Share your feedback
 
 <ul class="usa-button-group">
-  <li class="usa-button-group__item">
+  <li class="usa-button-group__item margin-bottom-0">
     <a href="{{ site.github_issue_feature_url }}"
       class="usa-button display-block">
       Propose a new test
     </a>
   </li>
-  <li class="usa-button-group__item">
+  <li class="usa-button-group__item margin-bottom-0">
     <a href="{{ site.github_issue_bug_url }}"
       class="usa-button usa-button--secondary display-block">
       Report an error

--- a/_includes/accessibility-tests/compliance-tag.html
+++ b/_includes/accessibility-tests/compliance-tag.html
@@ -1,4 +1,7 @@
 <!-- Add compliance tag -->
+{% assign component_name = page.component.name | default: page.title | downcase %}
+{% assign component_key = component_name | slugify %}
+{% assign component = site.data.accessibility-tests[component_key] %}
 {% assign status_label =  "Did not pass WCAG 2.1 AA" %}
 {% if component.component_status == "pass" %}
   {% assign status_label =  "Passed WCAG 2.1 AA" %}

--- a/_includes/accessibility-tests/index.html
+++ b/_includes/accessibility-tests/index.html
@@ -27,9 +27,6 @@
 {% assign fail_icon = 'cancel' %}
 {% assign conditional_icon = 'info' %}
 
-<!--Add WCAG compliance status tag-->
-{% include accessibility-tests/compliance-tag.html %}
-
 <!--Add test results summary-->
 {% include accessibility-tests/test-results-summary.html page='checklist' %}
 

--- a/_includes/component.html
+++ b/_includes/component.html
@@ -15,9 +15,6 @@
 </div>
 {% endif %}
 
-<!-- Add wcag compliance status tag -->
-{% include accessibility-tests/compliance-tag.html %}
-
 {% if page.parent == null and content.size > 1 %}
 <h2 class="site-component-section-title">About the {{ componentName }} {{ page.type }}</h2>
 <div class="font-lang-md measure-5 margin-top-3 margin-bottom-6">

--- a/_layouts/styleguide.html
+++ b/_layouts/styleguide.html
@@ -32,6 +32,9 @@ layout: default
 
         {% include lead.html text=page.lead %}
 
+        <!-- Add wcag compliance status tag -->
+        {% include accessibility-tests/compliance-tag.html %}
+
         {{ content }}
 
         {% include changelog.html %}


### PR DESCRIPTION
# Summary
- Added typography accessibility tests page.
- Moved compliance-tag.html reference to styleguide.html
     - This allowed the compliance tag to be added to pages with the styleguide layout. 
     - Note: This is the same change added to #2538

> [!Important]
> We need to confirm the changelog dates before merge.

## Resources
- [Creating accessibility checklists process doc](https://docs.google.com/document/d/14WTCsdzgwpoz_Miztd66RmEGfwwSEUFCVN1DkSQITTE/edit) (Google docs 🔒)
- [Accessibility checklist spreadsheet](https://docs.google.com/spreadsheets/d/1fAJaObQHv7aIaeUpH4fTLmauhmugMtNCrbpZe4BJcPY/edit#gid=97481116) (Google sheets 🔒)

## Related issue
Closes #2533 

## Preview link
- [Typography - accessibility test page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-typography-checklist/components/typography/accessibility-tests/)
- [Typography main page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-typography-checklist/components/typography/)

## Testing and review
1. Confirm that both the main component page and the accessibility tests page has the correct compliance tag at the top.
    1. Confirm that the compliance tag does NOT show up on pages that do not have a related a11y tests page.
1. Confirm that the main component page links to the accessibility tests page in the side navigation.
1. Check that accessibility tests page provides the correct counts for each test status type.
1. Confirm the test checklist summaries and data are accurate.  
1. Confirm no visual issues.
1. Confirm there is an appropriate changelog entry on both the main component page and the accessibility tests page.