### PR TITLE
USWDS-Site - Dependencies: Security updates

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2707,8 +2707,8 @@ ignore:
         expires: '2022-01-27T21:29:25.295Z'
     - '*':
         reason: No available upgrade or patch
-        expires: 2024-03-21T16:21:14.318Z
-        created: 2024-02-20T16:21:14.362Z
+        expires: 2024-04-20T20:42:53.360Z
+        created: 2024-03-21T20:42:53.389Z
   SNYK-JS-AXIOS-1579269:
     - uswds > @frctl/fractal > @frctl/web > browser-sync > localtunnel > axios:
         reason: None given
@@ -3498,8 +3498,8 @@ ignore:
   SNYK-JS-UNSETVALUE-2400660:
     - '*':
         reason: No available upgrade or patch
-        expires: 2024-03-21T16:21:11.452Z
-        created: 2024-02-20T16:21:11.490Z
+        expires: 2024-04-20T20:43:05.674Z
+        created: 2024-03-21T20:43:05.713Z
   SNYK-JS-DECODEURICOMPONENT-3149970:
     - '*':
         reason: No available upgrade or patch
@@ -3523,8 +3523,8 @@ ignore:
   SNYK-JS-INFLIGHT-6095116:
     - '*':
         reason: No available upgrade or patch
-        expires: 2024-03-21T16:21:17.293Z
-        created: 2024-02-20T16:21:17.327Z
+        expires: 2024-04-20T20:44:51.599Z
+        created: 2024-03-21T20:44:51.627Z
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   'npm:minimatch:20160620':

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       "devDependencies": {
         "@18f/identity-stylelint-config": "^2.0.0",
         "ansi-colors": "^4.1.3",
-        "axe-core": "^4.8.3",
+        "axe-core": "^4.8.4",
         "browserify": "^17.0.0",
         "chalk": "^4.1.2",
         "cheerio": "^1.0.0-rc.12",
@@ -23,7 +23,7 @@
         "del": "^6.1.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-import": "^2.29.1",
-        "express": "^4.18.2",
+        "express": "^4.19.1",
         "fancy-log": "^2.0.0",
         "gulp": "^4.0.2",
         "gulp-cli": "^2.3.0",
@@ -36,12 +36,12 @@
         "jquery": "^3.7.1",
         "node-notifier": "^10.0.1",
         "pa11y-ci": "^2.4.2",
-        "postcss": "^8.4.32",
+        "postcss": "^8.4.38",
         "postcss-csso": "^6.0.1",
         "prettier": "^2.8.8",
-        "sass": "^1.69.5",
+        "sass": "^1.72.0",
         "simplecrawler": "^1.1.9",
-        "snyk": "^1.1266.0",
+        "snyk": "^1.1285.0",
         "stylelint": "^15.11.0",
         "vinyl-buffer": "^1.0.1",
         "vinyl-source-stream": "^2.0.0"
@@ -2494,9 +2494,9 @@
       "integrity": "sha512-Y8L5rp6jo+g9VEPgvqNfEopjTR4OTYct8lXlS8iVQdmnjDvbdbzYe9rjtFCB9egC86JoNCU61WRY+ScjkZpnIg=="
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
@@ -3851,9 +3851,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.3",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.3.tgz",
-      "integrity": "sha512-6VyCijWQ+9O7WuVMTRBTl+cjNNIzD5cY5mQ1WM8r/LEkI2u8EYpOotESNwzNlyCn3g+dmjKYI6BmNneSr/FSRw==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.1.tgz",
+      "integrity": "sha512-K4w1/Bp7y8iSiVObmCrtq8Cs79XjJc/RU2YYkZQ7wpUu5ZyZ7MtPHkqoMz4pf+mgXfNvo2qft8D9OnrH2ABk9w==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.8",
@@ -3861,7 +3861,7 @@
         "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -9118,9 +9118,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.35",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
-      "integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
+      "version": "8.4.38",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
       "funding": [
         {
           "type": "opencollective",
@@ -9138,7 +9138,7 @@
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "source-map-js": "^1.2.0"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -9258,6 +9258,14 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+    },
+    "node_modules/postcss/node_modules/source-map-js": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -10242,9 +10250,9 @@
       "dev": true
     },
     "node_modules/sass": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.71.1.tgz",
-      "integrity": "sha512-wovtnV2PxzteLlfNzbgm1tFXPLoZILYAMJtvoXXkD7/+1uP41eKkIt1ypWq5/q2uT94qHjXehEYfmjKOvjL9sg==",
+      "version": "1.72.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.72.0.tgz",
+      "integrity": "sha512-Gpczt3WA56Ly0Mn8Sl21Vj94s1axi9hDIzDFn9Ph9x3C3p4nNyvsqJoQyVXKou6cBlfFWEgRW4rT8Tb4i3XnVA==",
       "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -11037,9 +11045,9 @@
       }
     },
     "node_modules/snyk": {
-      "version": "1.1283.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1283.0.tgz",
-      "integrity": "sha512-uxdxDDK0hz52H6oqrMj0sfKuB4x1k4ErrlGlrqXB/CADxN4nMg7RvDJqs7st+425YoM+bkKaM04UlD2rHsUqBQ==",
+      "version": "1.1285.0",
+      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1285.0.tgz",
+      "integrity": "sha512-VpU1fvHVeUX8Q0rW6aAY37w9ddvG3tVBMgZRohTGDSxfhheGWl0yA82brQhV+i6y0gLZJnsg77Rfg/BIsidVeg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "devDependencies": {
     "@18f/identity-stylelint-config": "^2.0.0",
     "ansi-colors": "^4.1.3",
-    "axe-core": "^4.8.3",
+    "axe-core": "^4.8.4",
     "browserify": "^17.0.0",
     "chalk": "^4.1.2",
     "cheerio": "^1.0.0-rc.12",
@@ -72,7 +72,7 @@
     "del": "^6.1.1",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import": "^2.29.1",
-    "express": "^4.18.2",
+    "express": "^4.19.1",
     "fancy-log": "^2.0.0",
     "gulp": "^4.0.2",
     "gulp-cli": "^2.3.0",
@@ -85,19 +85,19 @@
     "jquery": "^3.7.1",
     "node-notifier": "^10.0.1",
     "pa11y-ci": "^2.4.2",
-    "postcss": "^8.4.32",
+    "postcss": "^8.4.38",
     "postcss-csso": "^6.0.1",
     "prettier": "^2.8.8",
-    "sass": "^1.69.5",
+    "sass": "^1.72.0",
     "simplecrawler": "^1.1.9",
-    "snyk": "^1.1266.0",
+    "snyk": "^1.1285.0",
     "stylelint": "^15.11.0",
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0"
   },
   "overrides": {
     "glob-parent": "6.0.2",
-    "postcss": "^8.4.32"
+    "postcss": "^8.4.38"
   },
   "snyk": true,
   "dependencies": {


### PR DESCRIPTION
**Snyk updates**

Snyk ignored three gulp related vulns.

Issues with no direct upgrade or patch:

```bash
❌ Regular Expression Denial of Service (ReDoS) [High Severity][https://security.snyk.io/vuln/SNYK-JS-ANSIREGEX-1583908] in ansi-regex@2.1.1 
❌ Missing Release of Resource after Effective Lifetime [Medium Severity][https://security.snyk.io/vuln/SNYK-JS-INFLIGHT-6095116] in inflight@1.0.6 
❌ Prototype Pollution [High Severity][https://security.snyk.io/vuln/SNYK-JS-UNSETVALUE-2400660] in unset-value@1.0.0
```

The second one `SNYK-JS-INFLIGHT` seems new.

**Dependency updates**

| Dependency | Old      | New      |
| ---------- | -------- | -------- |
| axe-core   | 4.8.3    | 4.8.4    |
| express    | 4.18.2   | 4.19.1   |
| postcss    | 8.4.32   | 8.4.38   |
| sass       | 1.69.5   | 1.72.0   |
| snyk       | 1.1266.0 | 1.1285.0 |
