### PR TITLE
USWDS-Site - Changelog: Remove tabindex from validation checklist items [#5835]

### DIFF
--- a/_data/changelogs/component-validation.yml
+++ b/_data/changelogs/component-validation.yml
@@ -2,6 +2,15 @@ title: Validation
 type: component
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Fixed a bug which caused non-interactive checklist items to receive focus on tab.
+    summaryAdditional:  Now, only the interactive input will receive focus.
+    isBreaking: false
+    affectsAccessibility: true
+    affectsJavascript: true
+    githubPr: 5835
+    githubRepo: uswds
+    versionUswds: N.N.N
   - date: 2024-03-13
     summary: Added known issues section.
     summaryAdditional:


### PR DESCRIPTION
# Summary

Added changelog entry for uswds/uswds#5835

> **Fixed a bug which caused non-interactive checklist items to receive focus on tab.** Now, only the interactive input will receive focus.
> 

## Related PR

uswds/uswds#5835

## Preview link

[Preview →](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cm-changelog-5835/components/validation/#latest-updates)