### PR TITLE
USWDS-Site: Add February Monthly call

### DIFF
--- a/_data/changelogs/about-monthly-calls.yml
+++ b/_data/changelogs/about-monthly-calls.yml
@@ -2,6 +2,21 @@ title: Monthly calls
 type: documentation
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Added February 2024 monthly call.
+    affectsGuidance: true
+    githubPr: 2556
+    githubRepo: uswds-site
+  - date: 2024-02-09
+    summary: Added January 2024 monthly call.
+    affectsGuidance: true
+    githubPr: 2465
+    githubRepo: uswds-site
+  - date: 2023-12-11
+    summary: Added November 2023 monthly call.
+    affectsGuidance: true
+    githubPr: 2393
+    githubRepo: uswds-site
   - date: 2023-11-06
     summary: Added monthly calls page.
     affectsGuidance: true

--- a/_data/monthly-calls.yml
+++ b/_data/monthly-calls.yml
@@ -1,16 +1,27 @@
 videos:
+  - title: How to suggest a new component for the U.S. Web Design System
+    subtitle:
+    description:
+    date: February 2024
+    id:
+    event_link: https://digital.gov/event/2024/02/15/uswds-monthly-call-february-2024/
+    slides:
+      link: https://s3.amazonaws.com/digitalgov/static/USWDS%20Monthly%20Call%20Feb%202024.pptx
+      size: 5.8
+      pages: 81
+    questions_link: https://github.com/uswds/uswds/discussions/5821
   - title: Component-based accessibility tests
     subtitle: Manual accessibility tests for the whole team
     description: |
-      We shared new component-based accessibility test pages (formerly called “critical checklists”) for 
-      the [accordion](https://designsystem.digital.gov/components/accordion/accessibility-tests/), 
-      [button](https://designsystem.digital.gov/components/button/accessibility-tests/), and 
-      [link](https://designsystem.digital.gov/components/link/accessibility-tests/) 
-      components. We also discussed the months of work that led to their 
-      launch. The process started with internal manual accessibility testing of USWDS components. We 
-      then prototyped the pages that explain how we tested and what we found in those tests. Later, 
-      usability testing with participants from the USWDS community shaped the iterative development of 
-      these pages. We look forward to updating the community as we roll out accessibility tests for more 
+      We shared new component-based accessibility test pages (formerly called “critical checklists”) for
+      the [accordion](https://designsystem.digital.gov/components/accordion/accessibility-tests/),
+      [button](https://designsystem.digital.gov/components/button/accessibility-tests/), and
+      [link](https://designsystem.digital.gov/components/link/accessibility-tests/)
+      components. We also discussed the months of work that led to their
+      launch. The process started with internal manual accessibility testing of USWDS components. We
+      then prototyped the pages that explain how we tested and what we found in those tests. Later,
+      usability testing with participants from the USWDS community shaped the iterative development of
+      these pages. We look forward to updating the community as we roll out accessibility tests for more
       USWDS components.
     date: January 2024
     id: xP4IWCdzWmA

--- a/pages/about/monthly-calls.md
+++ b/pages/about/monthly-calls.md
@@ -49,6 +49,9 @@ Register for [upcoming calls on Digital.gov](https://digital.gov/events/). All U
       <li><a href="{{ video.event_link }}">{{ video.date }} script and more at Digital.gov</a></li>
     {% endif %}
   {% endif %}
+  {% if video.questions_link %}
+      <li><a href="{{ video.questions_link }}"> Q&A from the {{ video.date }} USWDS monthly call</a></li>
+  {% endif %}
 </ul>
 {% endif %}
 


### PR DESCRIPTION
# Summary

Added the monthly call video and details for February 2024. 

> [!Important]
> The data currently in this PR is incomplete. Do not merge in its current state.

## Related issue

Closes #2551 
Closes #2529

## Preview link

[Monthly calls page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-mc-qa/about/monthly-calls/)

## Testing and review
- Confirm that the information in the update is accurate
- Confirm no spelling or grammatical errors
- Confirm that the links all work as expected.
