### PR TITLE
USWDS-Site: Update uswds_version to 3.8.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 title: U.S. Web Design System (USWDS)
 description: USWDS makes it easier to build accessible, mobile-friendly government websites.
 google_analytics_ua: UA-48605964-43
-uswds_version: 3.7.1
+uswds_version: 3.8.0
 uswds_email: uswds@gsa.gov
 federalist_base: "https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds"
 federalist_component_preview: "iframe.html?id="


### PR DESCRIPTION
# Summary

Updated the `uswds_version` in `config.yml` to 3.8.0

> [!Note]
> This task is already documented in 2.3 of the [Release process doc](https://docs.google.com/document/d/1Ux0TJf_wi3Sfikg_lZL0yXQhaY_stTr8-B_eAUY9B1U/edit#heading=h.lpffzr7li3xp) (Google Docs :lock:). I also added a confirmation task in 3.15 so that this is less likely to be missed in the future.

## Related issue

Closes #2570 

## Preview link

[Home page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-update-version-3.8.0/)

## Testing and review
1. Confirm that `config.yml` shows the current USWDS version for `uswds_version`. 
1. Confirm the current USWDS version is shown in the download button in the page header
