### PR TITLE
USWDS-Site - Ruby: Add `arm64-darwin-23` to PLATFORMS

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
# Summary

Added newer MacOS to `Gemfile.lock`. This showcases which systems we've successfully ran `bundle install` on .

## Related issue

Closes #2575 

## Preview link

Gemfile.lock →

## Problem statement

Our `PLATFORMS` section is missing a newer version of the MacOS which I'm currently developing on.

Running `bundle install` or `npm run start` causes the `Gemfile.lock` to be updated with this platform but is not being tracked.

## Solution

`Commit` this change to the design system

## Testing and review

1. Pull down branch
2. Run bundle install
4. Run `npm run start`
5. Confirm there are no installation errors or changes to `Gemfile.lock`
