### PR TITLE
USWDS-Site - HTMLProofer: Update links to target redirects

### DIFF
--- a/_data/changelogs/docs-accessibility.yml
+++ b/_data/changelogs/docs-accessibility.yml
@@ -2,7 +2,7 @@ title: Accessibility
 type: documentation
 changelogURL:
 items:
-  - date: NNNN-NN-NN
+  - date: 2024-03-29
     summary: Updated all page content.
     summaryAdditional:
     affectsGuidance: true

--- a/_data/changelogs/docs-sample-contract-language.yml
+++ b/_data/changelogs/docs-sample-contract-language.yml
@@ -1,0 +1,9 @@
+title: Sample contract language
+type: documentation
+changelogURL: 
+items:
+  - date: NNNN-NN-NN
+    summary: Updated Federal Web Council representative link.
+    affectsGuidance: true
+    githubPr: 2604
+    githubRepo: uswds-site

--- a/_data/changelogs/docs-sample-contract-language.yml
+++ b/_data/changelogs/docs-sample-contract-language.yml
@@ -1,8 +1,8 @@
 title: Sample contract language
 type: documentation
-changelogURL: 
+changelogURL:
 items:
-  - date: NNNN-NN-NN
+  - date: 2024-04-09
     summary: Updated Federal Web Council representative link.
     affectsGuidance: true
     githubPr: 2604

--- a/pages/documentation/sample-contract-language.md
+++ b/pages/documentation/sample-contract-language.md
@@ -7,6 +7,8 @@ lead: How to document requirements related to website modernization in contracts
 redirect_from:
   - /contract-language
   - /contracts
+changelog:
+  key: docs-sample-contract-language
 ---
 
 The [21st Century Integrated Digital Experience Act](https://digital.gov/resources/21st-century-integrated-digital-experience-act/)

--- a/pages/documentation/sample-contract-language.md
+++ b/pages/documentation/sample-contract-language.md
@@ -26,7 +26,7 @@ Use the approaches below as a starting point for any solicitations with requirem
 
 21st Century IDEA codifies high-level requirements for federal websites and digital services. Additionally, many agencies have more specific requirements in their digital strategy and other guidelines.
 
-Consult with your agency’s Chief Information Officer and [Federal Web Council representative](https://digital.gov/resources/federal-web-council/#current-council-members) regarding agency requirements for websites and digital services, including 21st Century IDEA.
+Consult with your agency’s Chief Information Officer and [Federal Web Council representative](https://digital.gov/resources/an-introduction-to-the-digital-experience-council/#who-makes-up-the-digital-experience-council) regarding agency requirements for websites and digital services, including 21st Century IDEA.
 
 Then work with your contracting officer (CO) to determine your acquisition strategy, including customizing the draft language below to meet your needs and requirements.
 

--- a/pages/documentation/showcase.md
+++ b/pages/documentation/showcase.md
@@ -145,7 +145,7 @@ If your project is currently using USWDS and you would like to see it included i
 - [U.S. Department of Agriculture (USDA)](https://www.usda.gov/)
 - [U.S. Department of Justice - Civil Rights Division](https://civilrights.justice.gov/)
 - [U.S. Department of Labor](https://www.dol.gov/)
-- [U.S. Department of the Treasury](https://treasury.gov)
+- [U.S. Department of the Treasury](https://home.treasury.gov/)
 - [U.S. Department of Veterans Affairs](https://va.gov)
 - [U.S. Digital Service](https://www.usds.gov/)
 - [U.S. Emerging Citizen Technology Atlas](https://emerging.digital.gov/)


### PR DESCRIPTION
# Summary

Updated treasury.gov and digital.gov links. Now, links no longer redirect or cause `htmlproofer` errors.

> [!Important]
> We should confirm the changelog date in `_data/changelogs/docs-sample-contract-language.yml` before merge. 

## Related issue

Closes #2603 

## Preview link

[Showcase page →](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cm-update-links-april-2024/documentation/showcase/)

>[!NOTE]
>Not a user facing change due to redirect already bringing users here. Opted to not create a changelog for showcase.

[Sample contract language page →](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cm-update-links-april-2024/documentation/sample-contract-language/)


## Problem statement

HTMLProofer flagged two new issues caused by the target pages updating. The `treasury.gov` error was caused by a redirect to `home.treasure.gov` while the `digital.gov` link was caused by the hash target no longer existing.

## Solution

Update links to reflect the current state of their target pages.

| Old link | new link |
|--------|--------|
| <https://treasury.gov> | <https://home.treasury.gov/> |
|<https://digital.gov/resources/federal-web-council/#current-council-members> | <https://digital.gov/resources/an-introduction-to-the-digital-experience-council/#who-makes-up-the-digital-experience-council> |

## Testing and review

1. Confirm links work.
2. Confirm there are no additional redirects.
3. Confirm digital.gov hash link takes you to the appropriate heading.
4. Running `npm run proof` does not flag any errors.
5. Changelog is meaningful and accurate.
