### PR TITLE
USWDS-Site: Update hash url to 3.8.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -44,7 +44,7 @@ jekyll_get:
     json: "https://api.github.com/repos/uswds/uswds/contents/SECURITY.md"
     decode_content: true
   - data: hash
-    json: "https://api.github.com/repos/uswds/uswds/contents/security/uswds-3.6.1-zip-hash.txt?ref=main"
+    json: "https://api.github.com/repos/uswds/uswds/contents/security/uswds-3.8.0-zip-hash.txt?ref=main"
     decode_content: true
 
 repos:


### PR DESCRIPTION
# Summary

Updated the hash url in `_config.yml` to point to the 3.8.0 release hash. 

## Related issue

Closes #2614 

## Preview link

[Download page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-hash-url/download/)

## Problem statement
Our site data points to the 3.6.1 hash.txt file in [_config.yml](https://github.com/uswds/uswds-site/blob/main/_config.yml#L47). This reference should point to 3.8.0.

## Solution
This PR updated the url to reflect the correct USWDS release. I also added a task to the [release process doc](https://docs.google.com/document/d/1Ux0TJf_wi3Sfikg_lZL0yXQhaY_stTr8-B_eAUY9B1U/edit) (Google docs :lock:) so that this isn't neglected in the future.

> [!Note]
> It would be great if we could reuse `uswds_version` in the url definition for the hash reference. However,  I could not find a way to do this with YAML. The closest I could get is YAML anchors/aliases, but I could not use it inside the url string. If you know of a method to do this, please let me know!

## Testing and review

1. Confirm that the hash on the [download page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-hash-url/download/) matches the one listed for the [3.8.0 release](https://github.com/uswds/uswds/releases). 