### PR TITLE
USWDS-Site - Changelog: Nested input masks [#5518]

### DIFF
--- a/_data/changelogs/component-input-mask.yml
+++ b/_data/changelogs/component-input-mask.yml
@@ -2,6 +2,13 @@ title: Input mask
 type: component
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Fixed a bug that caused input mask to break when it is not a direct child of a form.
+    summaryAdditional: Nested input masks will now initialize and work properly.
+    affectsJavascript: true
+    githubPr: 5518
+    githubRepo: uswds
+    versionUswds: N.N.N
   - date: 2024-03-13
     summary: Added known issues section.
     summaryAdditional:


### PR DESCRIPTION
# Summary

Created changelog for uswds/uswds#5518

> **Fixed a bug that caused input mask to break when it is not a direct child of a form.** Nested input masks will now initialize and work properly.

## Related PR

uswds/uswds#5518

## Preview link

[Input mask changelog →](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cm-changelog-5518/components/input-mask/#latest-updates)