### PR TITLE
USWDS - Documentation: Update `npm` References

### DIFF
--- a/pages/about/website-policies-and-notices.md
+++ b/pages/about/website-policies-and-notices.md
@@ -108,7 +108,7 @@ We use open-source software and free or low cost, commercial application program
 
 2.  Software source code previously released under an open source license and then modified by GSA staff is considered a "joint work." It is partially copyrighted, partially public domain, and as a whole is protected by the copyrights of the non-government authors and must be released according to the terms of the original open-source license.
 
-3.  All source code as defined above may be shared with the general public via a highly visible, easily accessible online source code community (such as Github or NPM) that facilitates the code's reuse. Source code won't be released if any of the following conditions are met:
+3.  All source code as defined above may be shared with the general public via a highly visible, easily accessible online source code community (such as Github or npm) that facilitates the code's reuse. Source code won't be released if any of the following conditions are met:
 
 1.  The USWDS core team determines that the code is too crude to merit distribution or provide value to the broader community.
 
@@ -136,7 +136,7 @@ We link to websites created and maintained by other public and/or private organi
 
 ### Social media and collaboration sites
 
-We manage a presence on social media and collaboration sites such as [Github](http://github.com/uswds), [NPM](https://www.npmjs.com/package/uswds), and [Twitter](https://twitter.com/uswds) to share government information, and engage with our audience. We do not collect any personally identifiable information through those sites, and we do not use personal information made available by the third-party sites.
+We manage a presence on social media and collaboration sites such as [Github](http://github.com/uswds), [npm](https://www.npmjs.com/package/uswds), and [Twitter](https://twitter.com/uswds) to share government information, and engage with our audience. We do not collect any personally identifiable information through those sites, and we do not use personal information made available by the third-party sites.
 
 ### If you send us personal information
 

--- a/pages/documentation/getting-started-developers/overview.md
+++ b/pages/documentation/getting-started-developers/overview.md
@@ -26,7 +26,7 @@ As always, we're here for you if you have any questions. Please get in touch via
 ## What you need
 We recommend using the following tools when working with the Design System:
 - Node (use the version specified in the [.nvmrc file](https://github.com/uswds/uswds/blob/main/.nvmrc); if needed, [download the latest version](https://nodejs.org/en/download/) from Node.js)
-- npm
+- Npm
 
 These step-by-step instructions describe how to get started with the Design System using npm (recommended method).
 

--- a/pages/documentation/maturity-model.md
+++ b/pages/documentation/maturity-model.md
@@ -121,7 +121,7 @@ Government websites include components that aren’t included in USWDS yet. Use 
 
 #### 1: Add USWDS code and adjust settings.
 
-- Add USWDS to your project [with NPM]({{ site.baseurl }}/documentation/developers/#install-using-node-and-npm) or by [downloading the source from Github]({{ site.baseurl }}/documentation/developers/#install-the-package-directly-from-github).
+- Add USWDS to your project [with npm]({{ site.baseurl }}/documentation/developers/#install-using-node-and-npm) or by [downloading the source from Github]({{ site.baseurl }}/documentation/developers/#install-the-package-directly-from-github).
 - Compile the Sass source code using the [guidelines in the documentation]({{ site.baseurl }}/documentation/developers/#sass-compilation-requirements) or by using [uswds-compile](https://github.com/uswds/uswds-compile) available via GitHub.
 - Compile the Javascript source code using the [guidelines in the documentation]({{ site.baseurl }}/documentation/developers/#js-customization) or [download a precompiled version]({{ site.baseurl }}/documentation/developers/#install-the-package-directly-from-github).
 - Add USWDS Javascript to your page templates.


### PR DESCRIPTION
# Summary

Updates npm references to all lowercase except for the beginning of sentences.

## Breaking change

This is not a breaking change.

## Related issue

Closes #2624

## Preview link

Getting started for developers →

Maturity model →

Website policies and notices →

## Problem statement

Where possible, avoid beginning sentences with words like "npm" that conventionally begin with a lowercase letter. When it appears at the beginning of a sentence, capitalize the N in npm.

[See this conversation in Slack for more context](https://gsa-tts.slack.com/archives/C050HRGN7/p1713367302497929) (🔒) on the decision about why to capitalize the N in npm at the beginning of a sentence.

## Solution

Update all documentation references of npm to match the preferred pattern.

## Testing and review

1. Inspect the following pages and confirm all references to npm match the expected pattern
    1. Getting started for developers
    2. Maturity model
    3. Website policies and notices
2. Confirm there are no additional references to npm that need to be updated

### For Devs

1. Use VSCode search with `Match case` and `match whole world` to ensure there are no other references of npm that do not match the expected pattern