### PR TITLE
USWDS-Site: Fix snyk errors

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2707,8 +2707,8 @@ ignore:
         expires: '2022-01-27T21:29:25.295Z'
     - '*':
         reason: No available upgrade or patch
-        expires: 2024-05-24T16:48:39.047Z
-        created: 2024-04-24T16:48:39.087Z
+        expires: 2024-06-12T20:02:08.857Z
+        created: 2024-05-13T20:02:08.898Z
   SNYK-JS-AXIOS-1579269:
     - uswds > @frctl/fractal > @frctl/web > browser-sync > localtunnel > axios:
         reason: None given
@@ -3498,8 +3498,8 @@ ignore:
   SNYK-JS-UNSETVALUE-2400660:
     - '*':
         reason: No available upgrade or patch
-        expires: 2024-05-24T16:48:35.643Z
-        created: 2024-04-24T16:48:35.683Z
+        expires: 2024-06-12T20:02:01.250Z
+        created: 2024-05-13T20:02:01.295Z
   SNYK-JS-DECODEURICOMPONENT-3149970:
     - '*':
         reason: No available upgrade or patch
@@ -3523,8 +3523,18 @@ ignore:
   SNYK-JS-INFLIGHT-6095116:
     - '*':
         reason: No available upgrade or patch
-        expires: 2024-05-24T16:48:41.940Z
-        created: 2024-04-24T16:48:41.985Z
+        expires: 2024-06-12T20:02:13.020Z
+        created: 2024-05-13T20:02:13.068Z
+  SNYK-JS-BRACES-6838727:
+    - '*':
+        reason: No available upgrade or patch
+        expires: 2024-06-12T20:01:26.723Z
+        created: 2024-05-13T20:01:26.749Z
+  SNYK-JS-MICROMATCH-6838728:
+    - '*':
+        reason: No available upgrade or patch
+        expires: 2024-06-12T20:01:29.889Z
+        created: 2024-05-13T20:01:29.912Z
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   'npm:minimatch:20160620':


### PR DESCRIPTION
## Summary
Updated snyk ignore files

## Problem statement
`npx snyk test` is throwing the following error:

```
Issues with no direct upgrade or patch:
  ✗ Uncontrolled resource consumption [High Severity][https://security.snyk.io/vuln/SNYK-JS-BRACES-6838727] in braces@2.3.2
    introduced by @uswds/compile@1.1.0 > del@6.1.1 > globby@11.1.0 > fast-glob@3.3.2 > micromatch@4.0.5 > braces@3.0.2 and 7 other path(s)
  No upgrade or patch available
  ✗ Inefficient Regular Expression Complexity [High Severity][https://security.snyk.io/vuln/SNYK-JS-MICROMATCH-6838728] in micromatch@3.1.10
    introduced by @uswds/compile@1.1.0 > del@6.1.1 > globby@11.1.0 > fast-glob@3.3.2 > micromatch@4.0.5 and 6 other path(s)
  No upgrade or patch available
```

## Solution
Updated snyk ignore. Ran the following in the command line:

```
npx snyk ignore --id="SNYK-JS-BRACES-6838727" --reason="No available upgrade or patch"
npx snyk ignore --id="SNYK-JS-MICROMATCH-6838728" --reason="No available upgrade or patch"
```

To keep all snyk ignores on the same schedule, I also ran the following:
```
npx snyk ignore --id="SNYK-JS-UNSETVALUE-2400660" --reason="No available upgrade or patch"
npx snyk ignore --id="SNYK-JS-ANSIREGEX-1583908" --reason="No available upgrade or patch"
npx snyk ignore --id="SNYK-JS-INFLIGHT-6095116" --reason="No available upgrade or patch" 
```

## Testing and review
To test, run `npx snyk test` and check for errors.

## Reference
[Ignoring Snyk alerts](https://docs.google.com/document/d/1RX6uYky-P37jysuBy6LEBhuMCQlMAvHU0mRJUow345o/edit) (Google docs :lock:)