### PR TITLE
USWDS-Site - Changelog:  Restore footer’s layout-grid dependency [#5930]

### DIFF
--- a/_data/changelogs/component-footer.yml
+++ b/_data/changelogs/component-footer.yml
@@ -2,6 +2,13 @@ title: Footer
 type: component
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Restored layout-grid dependency in footer package and removed layout-grid styles from footer stylesheet.
+    summaryAdditional:  This update prevents visual regression in other components with layout-grid utility classes in their markup.
+    affectsStyles: true
+    githubPr: 5930
+    githubRepo: uswds
+    versionUswds: N.N.N
   - date: 2024-03-11
     summary: Fixed a bug that caused some grid utility classes to be ignored when used inside `usa-footer`.
     summaryAdditional:

--- a/_data/changelogs/component-footer.yml
+++ b/_data/changelogs/component-footer.yml
@@ -3,8 +3,8 @@ type: component
 changelogURL:
 items:
   - date: NNNN-NN-NN
-    summary: Restored layout-grid dependency in footer package and removed layout-grid styles from footer stylesheet.
-    summaryAdditional:  This update prevents visual regression in other components with layout-grid utility classes in their markup.
+    summary: Restored the `usa-layout-grid` dependency in the footer package and removed layout grid styles from the footer stylesheet. 
+    summaryAdditional:  This update prevents visual regressions in footer and other components with layout grid utility classes in their markup.
     affectsStyles: true
     githubPr: 5930
     githubRepo: uswds

--- a/_data/packages.yml
+++ b/_data/packages.yml
@@ -120,6 +120,7 @@
   sourceSize: 7
   dependencies:
     - "uswds-fonts"
+    - "usa-layout-grid"
     - "usa-input"
     - "usa-form"
     - "usa-label"


### PR DESCRIPTION
# Summary

Added changelog item and restored `usa-layout-grid` dependency to `_data/packages.yml` footer package.

## Related PR

uswds/uswds#5930

## Preview link

[Footer component page →](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cm-changelog-5930/components/footer/#package)

[Component packages page →](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cm-changelog-5930/components/packages/)

## Testing and review

1. Confirm `usa-layout-grid` package is listed as a dependency on the component package page packages table for `usa-footer`.
2. Confirm `usa-layout-grid` package is listed as a dependency on the footer component page.
3. Approve changelog data and description.