### PR TITLE
USWDS-Site: Fix snyk errors 

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2707,8 +2707,8 @@ ignore:
         expires: '2022-01-27T21:29:25.295Z'
     - '*':
         reason: No available upgrade or patch
-        expires: 2024-06-12T20:02:08.857Z
-        created: 2024-05-13T20:02:08.898Z
+        expires: 2024-07-13T20:15:21.547Z
+        created: 2024-06-13T20:15:21.582Z
   SNYK-JS-AXIOS-1579269:
     - uswds > @frctl/fractal > @frctl/web > browser-sync > localtunnel > axios:
         reason: None given
@@ -3498,8 +3498,8 @@ ignore:
   SNYK-JS-UNSETVALUE-2400660:
     - '*':
         reason: No available upgrade or patch
-        expires: 2024-06-12T20:02:01.250Z
-        created: 2024-05-13T20:02:01.295Z
+        expires: 2024-07-13T20:15:18.231Z
+        created: 2024-06-13T20:15:18.259Z
   SNYK-JS-DECODEURICOMPONENT-3149970:
     - '*':
         reason: No available upgrade or patch
@@ -3523,18 +3523,18 @@ ignore:
   SNYK-JS-INFLIGHT-6095116:
     - '*':
         reason: No available upgrade or patch
-        expires: 2024-06-12T20:02:13.020Z
-        created: 2024-05-13T20:02:13.068Z
+        expires: 2024-07-13T20:15:24.634Z
+        created: 2024-06-13T20:15:24.673Z
   SNYK-JS-BRACES-6838727:
     - '*':
         reason: No available upgrade or patch
-        expires: 2024-06-12T20:01:26.723Z
-        created: 2024-05-13T20:01:26.749Z
+        expires: 2024-07-13T20:15:07.415Z
+        created: 2024-06-13T20:15:07.454Z
   SNYK-JS-MICROMATCH-6838728:
     - '*':
         reason: No available upgrade or patch
-        expires: 2024-06-12T20:01:29.889Z
-        created: 2024-05-13T20:01:29.912Z
+        expires: 2024-07-13T20:15:10.249Z
+        created: 2024-06-13T20:15:10.286Z
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   'npm:minimatch:20160620':


### PR DESCRIPTION
## Summary
Updated snyk ignore files

## Problem statement
`npx snyk test` is throwing the following error:

```
Issues with no direct upgrade or patch:
  ✗ Regular Expression Denial of Service (ReDoS) [High Severity][https://security.snyk.io/vuln/SNYK-JS-ANSIREGEX-1583908] in ansi-regex@2.1.1
    introduced by @uswds/compile@1.1.0 > gulp@4.0.2 > gulp-cli@2.3.0 > yargs@7.1.2 > string-width@1.0.2 > strip-ansi@3.0.1 > ansi-regex@2.1.1 and 4 other path(s)
  This issue was fixed in versions: 3.0.1, 4.1.1, 5.0.1, 6.0.1
  ✗ Uncontrolled resource consumption [High Severity][https://security.snyk.io/vuln/SNYK-JS-BRACES-6838727] in braces@2.3.2
    introduced by @uswds/compile@1.1.0 > gulp@4.0.2 > glob-watcher@5.0.5 > chokidar@2.1.8 > braces@2.3.2 and 6 other path(s)
  This issue was fixed in versions: 3.0.3
  ✗ Missing Release of Resource after Effective Lifetime [Medium Severity][https://security.snyk.io/vuln/SNYK-JS-INFLIGHT-6095116] in inflight@1.0.6
    introduced by @uswds/compile@1.1.0 > del@6.1.1 > rimraf@3.0.2 > glob@7.2.3 > inflight@1.0.6 and 1 other path(s)
  No upgrade or patch available
  ✗ Inefficient Regular Expression Complexity [High Severity][https://security.snyk.io/vuln/SNYK-JS-MICROMATCH-6838728] in micromatch@3.1.10
    introduced by @uswds/compile@1.1.0 > gulp@4.0.2 > glob-watcher@5.0.5 > anymatch@2.0.0 > micromatch@3.1.10 and 5 other path(s)
  This issue was fixed in versions: 4.0.6
  ✗ Prototype Pollution [High Severity][https://security.snyk.io/vuln/SNYK-JS-UNSETVALUE-2400660] in unset-value@1.0.0
    introduced by @uswds/compile@1.1.0 > gulp@4.0.2 > glob-watcher@5.0.5 > chokidar@2.1.8 > braces@2.3.2 > snapdragon@0.8.2 > base@0.11.2 > cache-base@1.0.1 > unset-value@1.0.0 and 30 other path(s)
  This issue was fixed in versions: 2.0.1
```

## Solution
Updated snyk ignore. Ran the following in the command line:

```
npx snyk ignore --id="SNYK-JS-BRACES-6838727" --reason="No available upgrade or patch"
npx snyk ignore --id="SNYK-JS-MICROMATCH-6838728" --reason="No available upgrade or patch"
npx snyk ignore --id="SNYK-JS-UNSETVALUE-2400660" --reason="No available upgrade or patch"
npx snyk ignore --id="SNYK-JS-ANSIREGEX-1583908" --reason="No available upgrade or patch"
npx snyk ignore --id="SNYK-JS-INFLIGHT-6095116" --reason="No available upgrade or patch" 
```

## Testing and review
To test, run `npx snyk test` and check for errors.

## Reference
[Ignoring Snyk alerts](https://docs.google.com/document/d/1RX6uYky-P37jysuBy6LEBhuMCQlMAvHU0mRJUow345o/edit) (Google docs :lock:)