### PR TITLE
USWDS-Site: Add known issues section to time picker page

### DIFF
--- a/_data/changelogs/component-time-picker.yml
+++ b/_data/changelogs/component-time-picker.yml
@@ -1,10 +1,12 @@
 title: Time picker
 type: component
-# Provide url for the package CHANGELOG.md. Note: Not all pages will have a related CHANGELOG.md file.
 changelogURL:
-
 items:
-  # 3.0 release
+  - date: NNNN-NN-NN
+    summary: Added known issues section.
+    affectsGuidance: true
+    githubPr: 2715
+    githubRepo: uswds-site
   - date: 2022-04-28
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true

--- a/_data/issues/time-picker.yml
+++ b/_data/issues/time-picker.yml
@@ -1,0 +1,9 @@
+title: Time picker
+alert_type: info
+items:
+- date: NNNN-NN-NN
+  summary: Screen reader users reported that instructions on the time picker component were verbose and confusing.
+  summary_additional:
+  issue_repo: uswds
+  issue_number: 5905
+

--- a/_data/issues/time-picker.yml
+++ b/_data/issues/time-picker.yml
@@ -1,7 +1,7 @@
 title: Time picker
 alert_type: info
 items:
-- date: NNNN-NN-NN
+- date: 2024-04-30
   summary: Screen reader users reported that instructions on the time picker component were verbose and confusing.
   summary_additional:
   issue_repo: uswds

--- a/_data/issues/time-picker.yml
+++ b/_data/issues/time-picker.yml
@@ -2,8 +2,7 @@ title: Time picker
 alert_type: info
 items:
 - date: 2024-04-30
-  summary: Screen reader users reported that instructions on the time picker component were verbose and confusing.
-  summary_additional:
+  summary: Screen reader users reported that they were confused by the component's instructions.
   issue_repo: uswds
   issue_number: 5905
 


### PR DESCRIPTION
# Summary

Added a known issues section to the time picker component page.

> [!Important]
> We should update the changelog dates before merge

## Related Issue
Closes #2683 

## Preview link

[Time picker page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-known-issues-time-picker/components/time-picker/)

## Testing and review

- Confirm a known issues section appears on the memorable date page
- Confirm the info alert is present at the top of the memorable date page
- On the known issues list item:
  - Confirm that the issue descriptions are accurate
  - Confirm that GitHub links work as expected
  - Confirm there are no spelling or grammar issues
- Confirm the changelog entry is present and accurate


