### PR TITLE
USWDS-Site - POAM: July '24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,12 +36,12 @@
         "jquery": "^3.7.1",
         "node-notifier": "^10.0.1",
         "pa11y-ci": "^2.4.2",
-        "postcss": "^8.4.38",
+        "postcss": "^8.4.39",
         "postcss-csso": "^6.0.1",
         "prettier": "^2.8.8",
-        "sass": "^1.77.5",
+        "sass": "^1.77.6",
         "simplecrawler": "^1.1.9",
-        "snyk": "^1.1291.1",
+        "snyk": "^1.1292.1",
         "stylelint": "^15.11.0",
         "vinyl-buffer": "^1.0.1",
         "vinyl-source-stream": "^2.0.0"
@@ -9138,9 +9138,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.38",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
-      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+      "version": "8.4.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.39.tgz",
+      "integrity": "sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==",
       "funding": [
         {
           "type": "opencollective",
@@ -9157,7 +9157,7 @@
       ],
       "dependencies": {
         "nanoid": "^3.3.7",
-        "picocolors": "^1.0.0",
+        "picocolors": "^1.0.1",
         "source-map-js": "^1.2.0"
       },
       "engines": {
@@ -10264,9 +10264,9 @@
       "dev": true
     },
     "node_modules/sass": {
-      "version": "1.77.5",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.5.tgz",
-      "integrity": "sha512-oDfX1mukIlxacPdQqNb6mV2tVCrnE+P3nVYioy72V5tlk56CPNcO4TCuFcaCRKKfJ1M3lH95CleRS+dVKL2qMg==",
+      "version": "1.77.6",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.6.tgz",
+      "integrity": "sha512-ByXE1oLD79GVq9Ht1PeHWCPMPB8XHpBuz1r85oByKHjZY6qV6rWnQovQzXJXuQ/XyE1Oj3iPk3lo28uzaRA2/Q==",
       "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -11062,9 +11062,9 @@
       }
     },
     "node_modules/snyk": {
-      "version": "1.1291.1",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1291.1.tgz",
-      "integrity": "sha512-a+phPmN0HrXzf81fx2qcaAnbZ7rK3WG1OhOHXoBHvRUIlAKIsoAozDSlWPSs0OuQI1hpQL/15O7xUFo3kDwrew==",
+      "version": "1.1292.1",
+      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1292.1.tgz",
+      "integrity": "sha512-wRJ6twqbr2KGf0Y8EmnuOKDawNbzNSGebEvmXVRIz0MZgvZhiK9FZQHiwfWr/XTXSx7mAp3zrsKcLsOGFkg6fQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -85,19 +85,19 @@
     "jquery": "^3.7.1",
     "node-notifier": "^10.0.1",
     "pa11y-ci": "^2.4.2",
-    "postcss": "^8.4.38",
+    "postcss": "^8.4.39",
     "postcss-csso": "^6.0.1",
     "prettier": "^2.8.8",
-    "sass": "^1.77.5",
+    "sass": "^1.77.6",
     "simplecrawler": "^1.1.9",
-    "snyk": "^1.1291.1",
+    "snyk": "^1.1292.1",
     "stylelint": "^15.11.0",
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0"
   },
   "overrides": {
     "glob-parent": "6.0.2",
-    "postcss": "^8.4.38"
+    "postcss": "^8.4.39"
   },
   "snyk": true,
   "dependencies": {


### PR DESCRIPTION
# Summary

Installed available minor and patch updates for direct dependencies.

> [!IMPORTANT]
> Waiting for new version of Compile to resolve dependency vulnerabilities

## Related issue

[USWDS-Team - POAM: July 2024](https://github.com/uswds/uswds-team/issues/370)

## Preview link

Preview link →

## Testing and review

1. Run ﻿npm install.
1. Run `﻿npm run` build and confirm there are no build errors.
1. Run ﻿`npm start` and confirm there are no build errors.
1. Run `npm test` and confirm there are no errors
1. No perceived visual regressions.

## Dependency updates

| Dependency name | Previous version | Updated version |
| --- | --- | --- |
| postcss | ^8.4.38 | ^8.4.39 |
| sass | ^1.77.5 | ^1.77.6 |
| snyk | ^1.1291.1 | ^1.1292.1 |
