### PR TITLE
USWDS-Site - HTML-Proofer: Replace broken w3 COGA Gap Analysis link

### DIFF
--- a/pages/design-tokens/color/overview.md
+++ b/pages/design-tokens/color/overview.md
@@ -203,7 +203,7 @@ If we use color intentionally, consistently, and sensitively, it can make a big 
 - W3C: Contrast levels for readability
   [https://www.w3.org/WAI/test-evaluate/preliminary/#contrast](https://www.w3.org/WAI/test-evaluate/preliminary/#contrast){:.display-block}
 - W3C: Gap analysis of the state of accessibility for people with learning disabilities and cognitive disabilities
-  [https://w3c.github.io/wcag/coga/gap-analysis.html](https://w3c.github.io/wcag/coga/gap-analysis.html){:.display-block}
+  [https://www.w3.org/TR/coga-gap-analysis/](https://www.w3.org/TR/coga-gap-analysis/){:.display-block}
 - W3C: Low vision needs
   [https://www.w3.org/TR/low-vision-needs/](https://www.w3.org/TR/low-vision-needs/){:.display-block}
 


### PR DESCRIPTION
# Summary

Replaced broken w3 COGA Gap Analysis link.

**Note:** No changelog was created since this change restores expected functionality. 

## Related issue

Closes #2753

## Preview link

[Color token overview →](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cm-w3-gap-analysis-link/design-tokens/color/overview/#further-reading-2)

## Problem statement

HTML-Proofer caught a newly broken link to w3c github pages.

## Solution

Replace the link with the relevant w3.org link

## Testing and review

1. Visit [color token landing page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cm-w3-gap-analysis-link/design-tokens/color/overview/#further-reading-2)
2. Confirm that the W3C: Gap analysis link works as expected. 
3. Compare it's content to the [Wayback Machine](https://web.archive.org/web/20221206142807/https://w3c.github.io/wcag/coga/gap-analysis.html) of the previous link.
4. Confirm the content matches
5. Confirm `npm run proof` runs without failure.
