### PR TITLE
USWDS-Site: Documentation updates for 3.8.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
   my-executor:
     resource_class: large
     docker:
-      - image: cimg/ruby:3.1.2-browsers
+      - image: cimg/ruby:3.2.5-browsers
 
 jobs:
   install_ruby_deps:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,7 @@ GEM
     zeitwerk (2.6.14)
 
 PLATFORMS
+  arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
 

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 title: U.S. Web Design System (USWDS)
 description: USWDS makes it easier to build accessible, mobile-friendly government websites.
 google_analytics_ua: UA-48605964-43
-uswds_version: 3.8.1
+uswds_version: 3.8.2
 uswds_email: uswds@gsa.gov
 federalist_base: "https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds"
 federalist_component_preview: "iframe.html?id="
@@ -44,7 +44,7 @@ jekyll_get:
     json: "https://api.github.com/repos/uswds/uswds/contents/SECURITY.md"
     decode_content: true
   - data: hash
-    json: "https://api.github.com/repos/uswds/uswds/contents/security/uswds-3.8.1-zip-hash.txt?ref=main"
+    json: "https://api.github.com/repos/uswds/uswds/contents/security/uswds-3.8.2-zip-hash.txt?ref=main"
     decode_content: true
 
 repos:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@uswds/compile": "^1.1.0",
-        "@uswds/uswds": "3.8.1"
+        "@uswds/uswds": "github:uswds/uswds#release-3.8.2"
       },
       "devDependencies": {
         "@18f/identity-stylelint-config": "^2.0.0",
@@ -613,10 +613,9 @@
     },
     "node_modules/@uswds/uswds": {
       "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.8.1.tgz",
-      "integrity": "sha512-bKG/B9mJF1v0yoqth48wQDzST5Xyu3OxxpePIPDyhKWS84oDrCehnu3Z88JhSjdIAJMl8dtjtH8YvdO9kZUpAg==",
+      "resolved": "git+ssh://git@github.com/uswds/uswds.git#4c812f61c5e617c6b67b00a3b59d058cc19d2a9d",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "classlist-polyfill": "1.2.0",
         "object-assign": "4.1.1",
         "receptor": "1.0.0",
         "resolve-id-refs": "0.1.0"
@@ -2124,11 +2123,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/classlist-polyfill": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
-      "integrity": "sha512-GzIjNdcEtH4ieA2S8NmrSxv7DfEV5fmixQeyTmqmRmRJPGpRBaSnA2a0VrCjyT8iW8JjEdMbKzDotAJf+ajgaQ=="
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@uswds/compile": "^1.1.0",
-        "@uswds/uswds": "github:uswds/uswds#release-3.8.2"
+        "@uswds/uswds": "3.8.2"
       },
       "devDependencies": {
         "@18f/identity-stylelint-config": "^2.0.0",
@@ -612,9 +612,9 @@
       }
     },
     "node_modules/@uswds/uswds": {
-      "version": "3.8.1",
-      "resolved": "git+ssh://git@github.com/uswds/uswds.git#4c812f61c5e617c6b67b00a3b59d058cc19d2a9d",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.8.2.tgz",
+      "integrity": "sha512-8sTx/GqlbTwSIK+0AFOGrYdaW1rKVB7Bp0+v9AMVt3I5vPK7CL0+I6vlclSf3U7ysJZeTTdkNS8q89sIAeL+AA==",
       "dependencies": {
         "object-assign": "4.1.1",
         "receptor": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,6 @@
   "snyk": true,
   "dependencies": {
     "@uswds/compile": "^1.1.0",
-    "@uswds/uswds": "github:uswds/uswds#release-3.8.2"
+    "@uswds/uswds": "3.8.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -102,6 +102,6 @@
   "snyk": true,
   "dependencies": {
     "@uswds/compile": "^1.1.0",
-    "@uswds/uswds": "3.8.1"
+    "@uswds/uswds": "github:uswds/uswds#release-3.8.2"
   }
 }


### PR DESCRIPTION
# Summary

Updated `uswds_version` and the package hash url in `config.yml` to point to 3.8.2.

>[!important]
> We should update the uswds version to 3.8.2 in the package.json before merge.

## Related issue

N/A

## Preview link

[Home page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/release-3.8.2/)

## Testing and review
- Confirm that the "Download" button in the header shows the correct version number
- On the download page, confirm:
    - The version number is correct
    - The listed SHA-256 hash matches the release hash
- Confirm that the package.json uses uswds version 3.8.2