### PR TITLE
Form templates: Updated Disabled States guidance

### DIFF
--- a/_includes/forms-guidance.html
+++ b/_includes/forms-guidance.html
@@ -16,6 +16,14 @@
     <li><strong>Use simple vertical layouts.</strong> Keep your form blocks in a vertical pattern. This approach is
       ideal, from an accessibility standpoint, because of limited vision that makes it hard to scan from right to left.
     </li>
+    <li><strong>Keep form elements enabled and offer feedback.</strong> Don’t use disabled or unavailable states. 
+      These states often don’t interact well with assistive technology, and they can confuse users. Instead, keep 
+      elements enabled and use contextual helper text, tooltips, 
+      <a href="https://www.w3.org/WAI/WCAG22/Understanding/error-suggestion.html">helpful error messages</a>, 
+      and inline validation. These approaches can show what caused a problem and guide people to a solution. 
+      For more detail, you can read 
+      <a href="https://github.com/uswds/uswds/wiki/Disabled-States-Research-Findings-2023">USWDS’s 2023 literature review on disabled states</a>.
+    </li>
   </ul>
   <h2 id="identifying-required-fields">Identifying required fields</h2>
   <ul class="usa-content-list">


### PR DESCRIPTION
# Summary

Update Accessibility Guidance section with new Disabled States guidance.

## Related issue

Affects #2246

Does not close it as there are two other PRs for other pages.

Related to #2744 , #2776 

## Preview link: 

Preview link: [Form templates guidance](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/kf-disabledstates-formtemplates/templates/form-templates/)


## Problem statement

Current page does not have guidance for disabled states.
Research and discussion among USWDS team members have resulted in a solution

## Solution

Will be adding accessibility guidance to this page as part of a Phase 1 of Disabled States work.


## Testing and review

- Make sure copy is in the correct place
- Make sure copy has no errors or typos
- Make sure links work

## !ALERT!
We'll need to update the changelog

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `main`).
- [ ] Run `npm run prettier:scss` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->