### PR TITLE
Changelog: Memorable Date remove numeric months [#6028]

### DIFF
--- a/_data/changelogs/component-memorable-date.yml
+++ b/_data/changelogs/component-memorable-date.yml
@@ -2,7 +2,7 @@ title: Memorable date
 type: component
 changelogURL:
 items:
-- date: 2024-08-21
+- date: NNNN-NN-NN
   summary: Removed numeric representation of months from `select`.
   summaryAdditional: Recent usability testing indicated that having both numbers and names to represent months was confusing to screen readers.
   isBreaking: true
@@ -10,7 +10,7 @@ items:
   affectsContent: true
   githubRepo: uswds
   githubPr: 6028
-  versionUswds: 3.6.0
+  versionUswds: N.N.N
 - date: 2023-08-23
   summary: Updated styles to allow the component to wrap to multiple lines at narrow widths.
   summaryAdditional:

--- a/_data/changelogs/component-memorable-date.yml
+++ b/_data/changelogs/component-memorable-date.yml
@@ -3,8 +3,8 @@ type: component
 changelogURL:
 items:
 - date: 2024-08-21
-  summary: Removed numeric representation of months from select.
-  summaryAdditional: Users could not input the month name into the select, only the number. Since we can't have both, use the month name by removing the number.
+  summary: Removed numeric representation of months from `select`.
+  summaryAdditional: Recent usability testing indicated that having both numbers and names to represent months was confusing to screen readers.
   isBreaking: true
   affectsAccessibility: true
   affectsContent: true

--- a/_data/changelogs/component-memorable-date.yml
+++ b/_data/changelogs/component-memorable-date.yml
@@ -2,6 +2,15 @@ title: Memorable date
 type: component
 changelogURL:
 items:
+- date: 2024-08-21
+  summary: Removed numeric representation of months from select.
+  summaryAdditional: Users could not input the month name into the select, only the number. Since we can't have both, use the month name by removing the number.
+  isBreaking: true
+  affectsAccessibility: true
+  affectsContent: true
+  githubRepo: uswds
+  githubPr: 6028
+  versionUswds: 3.6.0
 - date: 2023-08-23
   summary: Updated styles to allow the component to wrap to multiple lines at narrow widths.
   summaryAdditional:

--- a/_data/changelogs/component-memorable-date.yml
+++ b/_data/changelogs/component-memorable-date.yml
@@ -3,11 +3,12 @@ type: component
 changelogURL:
 items:
 - date: NNNN-NN-NN
-  summary: Removed numeric representation of months from `select`.
-  summaryAdditional: Recent usability testing indicated that having both numbers and names to represent months was confusing to screen readers.
+  summary: Removed numeric representation of months from the `select` element.
+  summaryAdditional: Recent usability testing indicated that having both numbers and names to represent months was confusing for screen reader users.
   isBreaking: true
   affectsAccessibility: true
   affectsContent: true
+  affectsMarkup: true
   githubRepo: uswds
   githubPr: 6028
   versionUswds: N.N.N

--- a/_data/changelogs/component-memorable-date.yml
+++ b/_data/changelogs/component-memorable-date.yml
@@ -5,7 +5,6 @@ items:
 - date: NNNN-NN-NN
   summary: Removed numeric representation of months from the `select` element.
   summaryAdditional: Recent usability testing indicated that having both numbers and names to represent months was confusing for screen reader users.
-  isBreaking: true
   affectsAccessibility: true
   affectsContent: true
   affectsMarkup: true


### PR DESCRIPTION
# Summary

Changelog for uswds/uswds#6028

## Related PR

uswds/uswds#6028

## Preview link

[Form component changelog →](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cb-changelog-6028/components/memorable-date/)