### PR TITLE
USWDS-Site - HTMLProofer: Update script to ignore 2019-2021 blog posts

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2707,8 +2707,8 @@ ignore:
         expires: '2022-01-27T21:29:25.295Z'
     - '*':
         reason: No available upgrade or patch
-        expires: 2024-08-14T20:04:23.858Z
-        created: 2024-07-15T20:04:23.890Z
+        expires: 2024-09-21T17:52:30.448Z
+        created: 2024-08-22T17:52:30.489Z
   SNYK-JS-AXIOS-1579269:
     - uswds > @frctl/fractal > @frctl/web > browser-sync > localtunnel > axios:
         reason: None given
@@ -3498,8 +3498,8 @@ ignore:
   SNYK-JS-UNSETVALUE-2400660:
     - '*':
         reason: No available upgrade or patch
-        expires: 2024-08-14T20:06:06.287Z
-        created: 2024-07-15T20:06:06.319Z
+        expires: 2024-09-21T17:53:23.888Z
+        created: 2024-08-22T17:53:23.925Z
   SNYK-JS-DECODEURICOMPONENT-3149970:
     - '*':
         reason: No available upgrade or patch
@@ -3523,18 +3523,18 @@ ignore:
   SNYK-JS-INFLIGHT-6095116:
     - '*':
         reason: No available upgrade or patch
-        expires: 2024-08-14T20:05:23.703Z
-        created: 2024-07-15T20:05:23.742Z
+        expires: 2024-09-21T17:53:02.616Z
+        created: 2024-08-22T17:53:02.660Z
   SNYK-JS-BRACES-6838727:
     - '*':
         reason: No available upgrade or patch
-        expires: 2024-08-14T20:04:58.069Z
-        created: 2024-07-15T20:04:58.101Z
+        expires: 2024-09-21T17:52:52.884Z
+        created: 2024-08-22T17:52:52.930Z
   SNYK-JS-MICROMATCH-6838728:
     - '*':
         reason: No available upgrade or patch
-        expires: 2024-08-14T20:05:45.788Z
-        created: 2024-07-15T20:05:45.818Z
+        expires: 2024-09-21T17:53:15.173Z
+        created: 2024-08-22T17:53:15.213Z
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   'npm:minimatch:20160620':

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "federalist": "npx gulp build",
     "lint": "npx gulp lintJS lintSass && npm run prettier:scss",
     "prestart": "npx gulp build",
-    "proof": "bundle exec htmlproofer --enforce-https=false --allow-missing-href=true --ignore-status-codes 0,403,429,503,302 --swap-urls 'https\\://designsystem.digital.gov/:/' --ignore-urls '/github.com/uswds/uswds/issues/' --ignore-files '/whats-new/updates/2017/,/whats-new/updates/2018/,/whats-new/updates/2019/,/whats-new/updates/2020/,/whats-new/updates/2021/,/documentation/code-guidelines/' ./_site",
+    "proof": "bundle exec htmlproofer --enforce-https=false --allow-missing-href=true --ignore-status-codes 0,403,429,503,302 --swap-urls 'https\\://designsystem.digital.gov/:/' --ignore-urls '/github.com/uswds/uswds/issues/' --ignore-files '/whats-new/updates/(2017|2018|2019|2020|2021)/,/documentation/code-guidelines/' ./_site",
     "serve": "npm run build:all-assets && bundle exec jekyll serve --drafts --future --incremental --livereload --host=localhost",
     "serve:package": "npm run build:uswds && npm run serve",
     "serve:local": "export LIBRARY_BASE_URL=\"http://localhost:3000\" && npm run serve",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "federalist": "npx gulp build",
     "lint": "npx gulp lintJS lintSass && npm run prettier:scss",
     "prestart": "npx gulp build",
-    "proof": "bundle exec htmlproofer --enforce-https=false --allow-missing-href=true --ignore-status-codes 0,403,429,503,302 --swap-urls 'https\\://designsystem.digital.gov/:/' --ignore-urls '/github.com/uswds/uswds/issues/' --ignore-files '/whats-new/updates/2017/,/whats-new/updates/2018/,/documentation/code-guidelines/' ./_site",
+    "proof": "bundle exec htmlproofer --enforce-https=false --allow-missing-href=true --ignore-status-codes 0,403,429,503,302 --swap-urls 'https\\://designsystem.digital.gov/:/' --ignore-urls '/github.com/uswds/uswds/issues/' --ignore-files '/whats-new/updates/2017/,/whats-new/updates/2018/,/whats-new/updates/2019/,/whats-new/updates/2020/,/whats-new/updates/2021/,/documentation/code-guidelines/' ./_site",
     "serve": "npm run build:all-assets && bundle exec jekyll serve --drafts --future --incremental --livereload --host=localhost",
     "serve:package": "npm run build:uswds && npm run serve",
     "serve:local": "export LIBRARY_BASE_URL=\"http://localhost:3000\" && npm run serve",


### PR DESCRIPTION
# Summary

Updated the html proofer script to ignore blog posts that are 3 years old or older

**note:** This PR also updates Snyk ignore to avoid CI failure

## Related issue

Closes #2788
Closes #2790

## Problem statement

HTML Proofer began flagging a broken link from a 2021 blog post.

## Solution

In #2618 we added an alert to outdated blog posts. We deemed 3+ years to be outdated and mention that these pages may have outdated information as well as broken links.

Since the broken link that was flagged in #2788 does not have a suitable replacement, I've added the blog posts from 2021 and later to our HTML Proofer ignore script.

## Major changes

- Blog posts from 2021 and before are no longer scanned for broken links.
- Snyk ignore updated for another this month


## Testing and review

1. Confirm CircleCI checks pass
2. Run `npm run proof` script and confirm it runs without errors
3. Confirm this approach is acceptable for the future of this repo