### PR TITLE
USWDS-Site: Add changelog for text-decoration style fix for pagination component [#5970]

### DIFF
--- a/_data/changelogs/component-pagination.yml
+++ b/_data/changelogs/component-pagination.yml
@@ -2,6 +2,15 @@ title: Pagination
 type: component
 changelogURL:
 items:
+- date: NNNN-NN-NN
+  summary: Updated text-decoration style on pagination links so page numbers are underlined.
+  summaryAdditional: Users should confirm the pagination page numbers are underlined.
+  isBreaking: true
+  affectsAccessibility: true
+  affectsStyles: true
+  githubPr: 5970
+  githubRepo: uswds
+  versionUswds: N.N.N
 - date: 2023-08-23
   summary: Updated styles to respect the value of `$theme-pagination-background-color`.
   summaryAdditional: Users should confirm that pagination colors display as expected.

--- a/_data/changelogs/component-pagination.yml
+++ b/_data/changelogs/component-pagination.yml
@@ -4,8 +4,7 @@ changelogURL:
 items:
 - date: NNNN-NN-NN
   summary: Updated text-decoration style on pagination links so page numbers are underlined.
-  summaryAdditional: Users should confirm the pagination page numbers are underlined.
-  isBreaking: true
+  summaryAdditional: Link styles are now visually consistent with usa-link.
   affectsAccessibility: true
   affectsStyles: true
   githubPr: 5970

--- a/_data/changelogs/component-pagination.yml
+++ b/_data/changelogs/component-pagination.yml
@@ -3,8 +3,8 @@ type: component
 changelogURL:
 items:
 - date: NNNN-NN-NN
-  summary: Updated text-decoration style on pagination links so page numbers are underlined.
-  summaryAdditional: Link styles are now visually consistent with usa-link.
+  summary: Added text underline styles to pagination links.
+  summaryAdditional: Pagination links are now visually consistent with other USWDS text links.
   affectsAccessibility: true
   affectsStyles: true
   githubPr: 5970


### PR DESCRIPTION
# Summary

**This PR provides a changelog entry for the updates made to the pagination component.** The text-decoration styles has been removed so that the pagination page numbers show up as links.

## Related issue

[USWDS - Pagination: Updated text-decoration value to better show pagination links #5970](https://github.com/uswds/uswds/pull/5970)

## Preview link

Preview link:
[Pagination - Latest Updates](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/rc-changelog-pagination-5970/components/pagination/)