### PR TITLE
USWDS-Site - Showcase: Adding pgbd.gov to Showcase

### DIFF
--- a/pages/documentation/showcase.md
+++ b/pages/documentation/showcase.md
@@ -117,6 +117,7 @@ If your project is currently using USWDS and you would like to see it included i
 - [The Opportunity Project](http://opportunity.census.gov/)
 - [Pandemic Oversight](https://www.pandemicoversight.gov/)
 - [Pathogen Detection - NCBI](https://www.ncbi.nlm.nih.gov/pathogens/)
+- [Pension Benefit Guaranty Corporation](https://www.pbgc.gov/)
 - [Performance.gov](https://www.performance.gov/)
 - [PIV Usage Guidelines](https://www.idmanagement.gov/university/piv/)
 - [Plainlanguage.gov](https://plainlanguage.gov/)


### PR DESCRIPTION
# Summary
Adding pbgc.gov to the Showcase page.

## Related issue
Closes #2766 

## Preview link

[Preview link. ](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/brunerae-pbgc-showcase/documentation/showcase/)
<!-- If available, provide a link to a demo of the solution in action. -->

## Testing and review

1. Navigate to Showcase
2. Ensure that Pension Benefit Guaranty Corporation is listed
3. Click on link and ensure you're taken to https://www.pbgc.gov/