### PR TITLE
USWDS-Site: Add changelog for Spanish identifier USA.gov link update[#5892] 

### DIFF
--- a/_data/changelogs/component-identifier.yml
+++ b/_data/changelogs/component-identifier.yml
@@ -3,8 +3,8 @@ type: component
 changelogURL:
 items:
   - date: NNNN-NN-NN
-    summary: Updated the USA.gov link for Spanish versions of the identifier.
-    summaryAdditional: The link text now reads "Visite USAGov en Español" and the `href` now points to "https://www.usa.gov/es/".
+    summary: Updated the USA.gov link in Spanish versions of the identifier.
+    summaryAdditional: The link text now reads "Visite USAGov en Español" and the link url is now "https://www.usa.gov/es/".
     affectsContent: true
     githubPr: 5892
     githubRepo: uswds

--- a/_data/changelogs/component-identifier.yml
+++ b/_data/changelogs/component-identifier.yml
@@ -2,6 +2,13 @@ title: Identifier
 type: component
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Updated the USA.gov link for Spanish versions of the identifier.
+    summaryAdditional: The link text now reads "Visite USAGov en Español" and the `href` now points to "https://www.usa.gov/es/".
+    affectsContent: true
+    githubPr: 5892
+    githubRepo: uswds
+    versionUswds: N.N.N
   - date: 2024-08-13
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true


### PR DESCRIPTION
# Summary

Add a changelog for PR uswds/uswds#5892

>[!important]
> We need to update the changelog dates before merge.

## Related issue

Related to uswds/uswds#5892

## Preview link

[Identifier changelog](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-changelog-5892/components/identifier/#latest-updates)
