### PR TITLE
USWDS-Site: Add changelog for date range picker aria-disabled updates [#6013]

### DIFF
--- a/_data/changelogs/component-date-picker.yml
+++ b/_data/changelogs/component-date-picker.yml
@@ -3,12 +3,11 @@ type: component
 changelogURL:
 items:
   - date: NNNN-NN-NN
-    summary: Added readonly attribute to aria-disabled.
-    summaryAdditional: Now, the input element and calendar icon remain discoverable but disabled behaviors are replicated.
+    summary: Enhanced `aria-disabled` behaviors to match `disabled` behaviors.
+    summaryAdditional: Now, the input element and calendar icon remain discoverable to screen readers but cannot be interacted with.
     affectsAccessibility: true
     affectsJavascript: true
-    affectsMarkup: true
-    githubPr: #6013
+    githubPr: 6013
     githubRepo: uswds
     versionUswds: N.N.N
   - date: 2024-03-13

--- a/_data/changelogs/component-date-picker.yml
+++ b/_data/changelogs/component-date-picker.yml
@@ -3,8 +3,8 @@ type: component
 changelogURL:
 items:
   - date: NNNN-NN-NN
-    summary: Enhanced `aria-disabled` behaviors to match `disabled` behaviors.
-    summaryAdditional: Now, the input element and calendar icon remain discoverable to screen readers but prevent the user from selecting or inputting a date.
+    summary: Added `aria-disabled` to the list of expected attributes. 
+    summaryAdditional: Now, the component will disable toggle when the `aria-disabled` attribute is present.
     affectsAccessibility: true
     affectsJavascript: true
     githubPr: 6013

--- a/_data/changelogs/component-date-picker.yml
+++ b/_data/changelogs/component-date-picker.yml
@@ -2,6 +2,15 @@ title: Date picker
 type: component
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Added readonly attribute to aria-disabled.
+    summaryAdditional: Now, the input element and calendar icon remain discoverable but disabled behaviors are replicated.
+    affectsAccessibility: true
+    affectsJavascript: true
+    affectsMarkup: true
+    githubPr: #6013
+    githubRepo: uswds
+    versionUswds: N.N.N
   - date: 2024-03-13
     summary: Added known issues section.
     summaryAdditional:

--- a/_data/changelogs/component-date-picker.yml
+++ b/_data/changelogs/component-date-picker.yml
@@ -4,7 +4,7 @@ changelogURL:
 items:
   - date: NNNN-NN-NN
     summary: Enhanced `aria-disabled` behaviors to match `disabled` behaviors.
-    summaryAdditional: Now, the input element and calendar icon remain discoverable to screen readers but cannot be interacted with.
+    summaryAdditional: Now, the input element and calendar icon remain discoverable to screen readers but prevent the user from selecting or inputting a date.
     affectsAccessibility: true
     affectsJavascript: true
     githubPr: 6013

--- a/_data/changelogs/component-date-range-picker.yml
+++ b/_data/changelogs/component-date-range-picker.yml
@@ -7,7 +7,7 @@ items:
     summaryAdditional: Now, the component will disable toggle when the `aria-disabled` attribute is present.
     affectsAccessibility: true
     affectsJavascript: true
-    githubPr: 2817
+    githubPr: 6013
     githubRepo: uswds
     versionUswds: N.N.N
   - date: 2024-06-07

--- a/_data/changelogs/component-date-range-picker.yml
+++ b/_data/changelogs/component-date-range-picker.yml
@@ -7,7 +7,7 @@ items:
     summaryAdditional: Now, the component will disable toggle when the `aria-disabled` attribute is present.
     affectsAccessibility: true
     affectsJavascript: true
-    githubPr:
+    githubPr: 2817
     githubRepo: uswds
     versionUswds: N.N.N
   - date: 2024-06-07

--- a/_data/changelogs/component-date-range-picker.yml
+++ b/_data/changelogs/component-date-range-picker.yml
@@ -2,6 +2,14 @@ title: Date range picker
 type: component
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Added `aria-disabled` to the list of expected attributes. 
+    summaryAdditional: Now, the component will disable toggle when the `aria-disabled` attribute is present.
+    affectsAccessibility: true
+    affectsJavascript: true
+    githubPr:
+    githubRepo: uswds
+    versionUswds: N.N.N
   - date: 2024-06-07
     summary: Added known issues section.
     summaryAdditional:


### PR DESCRIPTION
# Summary

**This PR provides a changelog entry for the updates made to the date range picker component.** The `readonly` attribute has been added to `aria-disabled` to mimic the disabled behaviors while remaining discoverable for accessibility purposes.

## Related issue

[USWDS - Date Picker: Updated toggleCalendar function to account for aria-disabled attribute + readonly #6013](https://github.com/uswds/uswds/pull/6013)

## Preview link

[USWDS-Site: Date Range Picker](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/rc-changelog-date-range-picker/components/date-range-picker/)

## Testing and review

1. Ensure changelog entry shows up under "Latest Updates" on Date Range Picker component page.
<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `main`).
- [ ] Run `npm run prettier:scss` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->