### PR TITLE
USWDS-site: Replace nunjucks reference

### DIFF
--- a/_components/pagination/guidance/implementation.md
+++ b/_components/pagination/guidance/implementation.md
@@ -1,4 +1,4 @@
-Unlike many USWDS components, Pagination includes behaviors we cannot build into the HTML, CSS, and JavaScript we ship with the design system. Developers will need to build these behaviors into their Pagination templates. We've outlined these behaviors below, and included them in the [Twig templates for Pagination in our source code](https://github.com/uswds/uswds/blob/develop/packages/usa-pagination/src/usa-pagination.twig).
+Unlike many USWDS components, Pagination includes behaviors we cannot build into the HTML, CSS, and JavaScript we ship with the design system. Developers will need to build these behaviors into their Pagination templates. We've outlined these behaviors below, and included them in the [Twig templates for Pagination](https://github.com/uswds/uswds/blob/develop/packages/usa-pagination/src/usa-pagination.twig) in our source code.
 
 {:.usa-content-list}
 - **Set the current page item.** Use the `usa-current` class to highlight the currently active page.

--- a/_components/pagination/guidance/implementation.md
+++ b/_components/pagination/guidance/implementation.md
@@ -1,4 +1,4 @@
-Unlike many USWDS components, Pagination includes behaviors we cannot build into the HTML, CSS, and JavaScript we ship with the design system. Developers will need to build these behaviors into their Pagination templates. We've outlined these behaviors below, and included them in the Nunjucks templates for Pagination in our source code.
+Unlike many USWDS components, Pagination includes behaviors we cannot build into the HTML, CSS, and JavaScript we ship with the design system. Developers will need to build these behaviors into their Pagination templates. We've outlined these behaviors below, and included them in the [Twig templates for Pagination in our source code](https://github.com/uswds/uswds/blob/develop/packages/usa-pagination/src/usa-pagination.twig).
 
 {:.usa-content-list}
 - **Set the current page item.** Use the `usa-current` class to highlight the currently active page.


### PR DESCRIPTION
# Summary

Replaced Nunjucks reference with Twig

## Related issue

Closes #2809 

## Preview link

[Pagination page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-nunjucks-ref/components/pagination/)

## Problem statement

Nunjucks is mentioned in pagination guidance and we no longer use it. We should replace with more general guidance or remove it completely.

## Solution

Replaced "Nunjucks" references with "Twig" and added a link to the related source code. 

## Testing and review

- Confirm the copy update is appropriate and accurate
- Confirm the new link points to the correct location