### PR TITLE
USWDS-Site: Added in page navigation accessibility test page

### DIFF
--- a/_components/in-page-navigation/accessibility-tests.md
+++ b/_components/in-page-navigation/accessibility-tests.md
@@ -2,10 +2,10 @@
 permalink: /components/in-page-navigation/accessibility-tests/
 layout: accessibility-test
 component:
- name: in page navigation
+  name: in page navigation
 title: In page navigation accessibility tests
 category: Components
 lead: Any USWDS in page navigation component should pass these manual accessibility tests.
 changelog:
- key: 'component-in-page-navigation-accessibility'
+  key: 'component-in-page-navigation-accessibility'
 ---

--- a/_components/in-page-navigation/accessibility-tests.md
+++ b/_components/in-page-navigation/accessibility-tests.md
@@ -2,10 +2,10 @@
 permalink: /components/in-page-navigation/accessibility-tests/
 layout: accessibility-test
 component:
-  name: in page navigation
-title: In page navigation accessibility tests
+  name: in-page navigation
+title: In-page navigation accessibility tests
 category: Components
-lead: Any USWDS in page navigation component should pass these manual accessibility tests.
+lead: Any USWDS in-page navigation component should pass these manual accessibility tests.
 changelog:
   key: 'component-in-page-navigation-accessibility'
 ---

--- a/_components/in-page-navigation/accessibility-tests.md
+++ b/_components/in-page-navigation/accessibility-tests.md
@@ -1,0 +1,11 @@
+---
+permalink: /components/in-page-navigation/accessibility-tests/
+layout: accessibility-test
+component:
+ name: in page navigation
+title: In page navigation accessibility tests
+category: Components
+lead: Any USWDS in page navigation component should pass these manual accessibility tests.
+changelog:
+ key: 'component-in-page-navigation-accessibility'
+---

--- a/_components/in-page-navigation/in-page-navigation.md
+++ b/_components/in-page-navigation/in-page-navigation.md
@@ -15,7 +15,7 @@ redirect_from:
 - /in-page-nav/
 - /components/in-page-nav/
 subnav:
-  - text: in page navigation accessibility tests
+  - text: in-page navigation accessibility tests
     href: /components/in-page-navigation/accessibility-tests/
 tags:
   - in-page

--- a/_components/in-page-navigation/in-page-navigation.md
+++ b/_components/in-page-navigation/in-page-navigation.md
@@ -15,26 +15,8 @@ redirect_from:
 - /in-page-nav/
 - /components/in-page-nav/
 subnav:
-- text: Preview
-  href: '#in-page-navigation-preview'
-- text: Code
-  href: '#in-page-navigation-code'
-- text: Guidance
-  href: '#in-page-navigation-guidance'
-- text: When to use
-  href: '#when-to-use-the-in-page-navigation'
-- text: When to consider something else
-  href: '#when-to-consider-something-else-in-page-navigation'
-- text: Usability guidance
-  href: '#usability-guidance-in-page-navigation'
-- text: Accessibility
-  href: '#accessibility-in-page-navigation'
-- text: Package
-  href: '#in-page-navigation-package'
-- text: References
-  href: '#references'
-- text: Latest updates
-  href: '#changelog'
+- text: in page navigation accessibility tests
+  href: /components/in-page-navigation/accessibility-tests/
 tags:
   - in-page
   - nav

--- a/_data/accessibility-tests/in-page-navigation.yml
+++ b/_data/accessibility-tests/in-page-navigation.yml
@@ -1,4 +1,4 @@
-title: In page navigation
+title: In-page navigation
 component_status: pass
 test_items:
   # General tests

--- a/_data/accessibility-tests/in-page-navigation.yml
+++ b/_data/accessibility-tests/in-page-navigation.yml
@@ -1,0 +1,91 @@
+title: In page navigation
+component_status: pass
+test_items:
+# General tests
+  - summary: In-page navigation adjusts on mobile.
+    summary_additional: When you rotate between portrait mode and landscape mode on a mobile device, in-page navigation is not restricted to a single view.
+    test_status: pass
+    test_type: general
+    version_tested: 3.8.2
+    wcag_criterion: 1.3.4
+  - summary: Color is not the only method used to convey in-page navigation link states. 
+    summary_additional: When you view the in-page navigation links, you can read text to understand what page you are on. There may also be underlining missing to indicate you are on the current page.
+    test_status: pass
+    test_type: general
+    version_tested: 3.8.1
+    wcag_criterion: 1.4.1
+  - summary: In-page navigation text and background meet color contrast requirements. 
+    summary_additional: When you use a color contrast checker to view the in-page navigation, contrast between the text and background colors is at least 4.5:1.
+    test_status: pass
+    test_type: general
+    version_tested: 3.8.2
+    wcag_criterion: 1.4.3
+  - summary: Navigation links clearly indicate location on the website.
+    summary_additional: When you view the in-page navigation, there is distinct styling that gives clear visual indication of where you are on the page. When using a screen reader, you will hear "current" as the indicator for location.
+    test_status: pass
+    test_type: general
+    version_tested: 3.8.2
+    wcag_criterion: 2.4.8
+# Zoom/screen magnification tests
+  - summary: In-page navigation text and links are visible and functional when screen is magnified. 
+    summary_additional: When you zoom in to 200%, in-page links are still readable and legible and properly sized.
+    test_status: pass
+    test_type: zoom
+    version_tested: 3.8.2
+    wcag_criterion: 1.4.4
+# Keyboard navigation tests
+  - summary: Keyboard can access all in-page navigation links.
+    summary_additional: When you navigate through the in-page navigation with a keyboard, you can interact with every link inside it.
+    test_status: pass
+    test_type: keyboard
+    version_tested: 3.8.2
+    wcag_criterion: 2.1.1
+  - summary: In-page navigation content does not trap keyboard focus.
+    summary_additional: When you tab through in-page navigation links with a keyboard, you can easily move into and out to get to other content.
+    test_status: pass
+    test_type: keyboard
+    version_tested: 3.8.2
+    wcag_criterion: 2.1.2
+  - summary: Focus follows logical content order. 
+    summary_additional: When you tab through the in-page navigation with a keyboard, the focus on the links moves in logical order in relation to the other links there.
+    test_status: pass
+    test_type: keyboard
+    version_tested: 3.8.2
+    wcag_criterion: 2.4.3
+  - summary: Focus indicator is clearly visible for in-page navigation. 
+    summary_additional: When you use a keyboard to tab into the in-page navigation, there will be a visible outline or other clear indication of focus on links.
+    test_status: pass
+    test_type: keyboard
+    version_tested: 3.8.2
+    wcag_criterion: 2.4.7
+  - summary: Heading order is the same as displayed on the page. 
+    summary_additional: When you use the keyboard to access in-page navigation,  headings are nested appropriately and match the header order as they appear on the page.
+    test_status: conditional
+    test_type: keyboard
+    version_tested: 3.8.2
+    wcag_criterion: 2.4.7
+# Screen reader tests
+  - summary: Screen reader announces in-page navigation region.
+    summary_additional: When using a screen reader to access the in-page navigation, you hear "complementary navigation region" or "complementary landmark", identifying the navigation pane.
+    test_status: pass
+    test_type: screen_reader
+    version_tested: 3.8.2
+    wcag_criterion: 1.3.1
+  - summary: Screen reader announces links in logical order.
+    summary_additional: When you use a screen reader and reach in-page navigation links, they will be announced in the order that matches the order of content on the page.
+    test_status: conditional
+    test_type: screen_reader
+    version_tested: 3.8.2
+    wcag_criterion: 1.3.2
+  - summary: Screen reader provides clear description of links.
+    summary_additional: When you navigate to the in-page navigation with a screen reader, link titles are read aloud and match the text seen on screen.
+    test_status: pass
+    test_type: screen_reader
+    version_tested: 3.8.2
+    wcag_criterion: 2.4.4
+  - summary: Link text provides direct location description.
+    summary_additional: You can read the text of any link in the in-page navigation to understand where the link will take you.
+    test_status: conditional
+    test_type: screen_reader
+    version_tested: 3.8.2
+    wcag_criterion: 2.4.7

--- a/_data/accessibility-tests/in-page-navigation.yml
+++ b/_data/accessibility-tests/in-page-navigation.yml
@@ -1,20 +1,20 @@
 title: In page navigation
 component_status: pass
 test_items:
-# General tests
+  # General tests
   - summary: In-page navigation adjusts on mobile.
     summary_additional: When you rotate between portrait mode and landscape mode on a mobile device, in-page navigation is not restricted to a single view.
     test_status: pass
     test_type: general
     version_tested: 3.8.2
     wcag_criterion: 1.3.4
-  - summary: Color is not the only method used to convey in-page navigation link states. 
+  - summary: Color is not the only method used to convey in-page navigation link states.
     summary_additional: When you view the in-page navigation links, you can read text to understand what page you are on. There may also be underlining missing to indicate you are on the current page.
     test_status: pass
     test_type: general
     version_tested: 3.8.1
     wcag_criterion: 1.4.1
-  - summary: In-page navigation text and background meet color contrast requirements. 
+  - summary: In-page navigation text and background meet color contrast requirements.
     summary_additional: When you use a color contrast checker to view the in-page navigation, contrast between the text and background colors is at least 4.5:1.
     test_status: pass
     test_type: general
@@ -26,14 +26,14 @@ test_items:
     test_type: general
     version_tested: 3.8.2
     wcag_criterion: 2.4.8
-# Zoom/screen magnification tests
-  - summary: In-page navigation text and links are visible and functional when screen is magnified. 
+  # Zoom/screen magnification tests
+  - summary: In-page navigation text and links are visible and functional when screen is magnified.
     summary_additional: When you zoom in to 200%, in-page links are still readable and legible and properly sized.
     test_status: pass
     test_type: zoom
     version_tested: 3.8.2
     wcag_criterion: 1.4.4
-# Keyboard navigation tests
+  # Keyboard navigation tests
   - summary: Keyboard can access all in-page navigation links.
     summary_additional: When you navigate through the in-page navigation with a keyboard, you can interact with every link inside it.
     test_status: pass
@@ -46,25 +46,25 @@ test_items:
     test_type: keyboard
     version_tested: 3.8.2
     wcag_criterion: 2.1.2
-  - summary: Focus follows logical content order. 
+  - summary: Focus follows logical content order.
     summary_additional: When you tab through the in-page navigation with a keyboard, the focus on the links moves in logical order in relation to the other links there.
     test_status: pass
     test_type: keyboard
     version_tested: 3.8.2
     wcag_criterion: 2.4.3
-  - summary: Focus indicator is clearly visible for in-page navigation. 
+  - summary: Focus indicator is clearly visible for in-page navigation.
     summary_additional: When you use a keyboard to tab into the in-page navigation, there will be a visible outline or other clear indication of focus on links.
     test_status: pass
     test_type: keyboard
     version_tested: 3.8.2
     wcag_criterion: 2.4.7
-  - summary: Heading order is the same as displayed on the page. 
+  - summary: Heading order is the same as displayed on the page.
     summary_additional: When you use the keyboard to access in-page navigation,  headings are nested appropriately and match the header order as they appear on the page.
     test_status: conditional
     test_type: keyboard
     version_tested: 3.8.2
     wcag_criterion: 2.4.7
-# Screen reader tests
+  # Screen reader tests
   - summary: Screen reader announces in-page navigation region.
     summary_additional: When using a screen reader to access the in-page navigation, you hear "complementary navigation region" or "complementary landmark", identifying the navigation pane.
     test_status: pass

--- a/_data/accessibility-tests/in-page-navigation.yml
+++ b/_data/accessibility-tests/in-page-navigation.yml
@@ -22,7 +22,7 @@ test_items:
     wcag_criterion: 1.4.3
   - summary: Navigation links clearly indicate location on the website.
     summary_additional: When you view the in-page navigation, there is distinct styling that gives clear visual indication of where you are on the page. When using a screen reader, you will hear "current" as the indicator for location.
-    test_status: pass
+    test_status: conditional
     test_type: general
     version_tested: 3.8.1
     wcag_criterion: 2.4.8

--- a/_data/accessibility-tests/in-page-navigation.yml
+++ b/_data/accessibility-tests/in-page-navigation.yml
@@ -6,7 +6,7 @@ test_items:
     summary_additional: When you rotate between portrait mode and landscape mode on a mobile device, in-page navigation is not restricted to a single view.
     test_status: pass
     test_type: general
-    version_tested: 3.8.2
+    version_tested: 3.8.1
     wcag_criterion: 1.3.4
   - summary: Color is not the only method used to convey in-page navigation link states.
     summary_additional: When you view the in-page navigation links, you can read text to understand what page you are on. There may also be underlining missing to indicate you are on the current page.
@@ -18,74 +18,74 @@ test_items:
     summary_additional: When you use a color contrast checker to view the in-page navigation, contrast between the text and background colors is at least 4.5:1.
     test_status: pass
     test_type: general
-    version_tested: 3.8.2
+    version_tested: 3.8.1
     wcag_criterion: 1.4.3
   - summary: Navigation links clearly indicate location on the website.
     summary_additional: When you view the in-page navigation, there is distinct styling that gives clear visual indication of where you are on the page. When using a screen reader, you will hear "current" as the indicator for location.
     test_status: pass
     test_type: general
-    version_tested: 3.8.2
+    version_tested: 3.8.1
     wcag_criterion: 2.4.8
   # Zoom/screen magnification tests
   - summary: In-page navigation text and links are visible and functional when screen is magnified.
     summary_additional: When you zoom in to 200%, in-page links are still readable and legible and properly sized.
     test_status: pass
     test_type: zoom
-    version_tested: 3.8.2
+    version_tested: 3.8.1
     wcag_criterion: 1.4.4
   # Keyboard navigation tests
   - summary: Keyboard can access all in-page navigation links.
     summary_additional: When you navigate through the in-page navigation with a keyboard, you can interact with every link inside it.
     test_status: pass
     test_type: keyboard
-    version_tested: 3.8.2
+    version_tested: 3.8.1
     wcag_criterion: 2.1.1
   - summary: In-page navigation content does not trap keyboard focus.
     summary_additional: When you tab through in-page navigation links with a keyboard, you can easily move into and out to get to other content.
     test_status: pass
     test_type: keyboard
-    version_tested: 3.8.2
+    version_tested: 3.8.1
     wcag_criterion: 2.1.2
   - summary: Focus follows logical content order.
     summary_additional: When you tab through the in-page navigation with a keyboard, the focus on the links moves in logical order in relation to the other links there.
     test_status: pass
     test_type: keyboard
-    version_tested: 3.8.2
+    version_tested: 3.8.1
     wcag_criterion: 2.4.3
   - summary: Focus indicator is clearly visible for in-page navigation.
     summary_additional: When you use a keyboard to tab into the in-page navigation, there will be a visible outline or other clear indication of focus on links.
     test_status: pass
     test_type: keyboard
-    version_tested: 3.8.2
+    version_tested: 3.8.1
     wcag_criterion: 2.4.7
   - summary: Heading order is the same as displayed on the page.
     summary_additional: When you use the keyboard to access in-page navigation,  headings are nested appropriately and match the header order as they appear on the page.
     test_status: conditional
     test_type: keyboard
-    version_tested: 3.8.2
-    wcag_criterion: 2.4.7
+    version_tested: 3.8.1
+    wcag_criterion: 2.4.6
   # Screen reader tests
   - summary: Screen reader announces in-page navigation region.
     summary_additional: When using a screen reader to access the in-page navigation, you hear "complementary navigation region" or "complementary landmark", identifying the navigation pane.
     test_status: pass
     test_type: screen_reader
-    version_tested: 3.8.2
+    version_tested: 3.8.1
     wcag_criterion: 1.3.1
   - summary: Screen reader announces links in logical order.
     summary_additional: When you use a screen reader and reach in-page navigation links, they will be announced in the order that matches the order of content on the page.
     test_status: conditional
     test_type: screen_reader
-    version_tested: 3.8.2
+    version_tested: 3.8.1
     wcag_criterion: 1.3.2
   - summary: Screen reader provides clear description of links.
     summary_additional: When you navigate to the in-page navigation with a screen reader, link titles are read aloud and match the text seen on screen.
     test_status: pass
     test_type: screen_reader
-    version_tested: 3.8.2
+    version_tested: 3.8.1
     wcag_criterion: 2.4.4
   - summary: Link text provides direct location description.
     summary_additional: You can read the text of any link in the in-page navigation to understand where the link will take you.
     test_status: conditional
     test_type: screen_reader
-    version_tested: 3.8.2
-    wcag_criterion: 2.4.7
+    version_tested: 3.8.1
+    wcag_criterion: 2.4.9

--- a/_data/changelogs/component-in-page-navigation-accessibility.yml
+++ b/_data/changelogs/component-in-page-navigation-accessibility.yml
@@ -1,4 +1,4 @@
-title: In page navigation accessibility tests
+title: In-page navigation accessibility tests
 type: component
 items:
   - date: NNNN-NN-NN

--- a/_data/changelogs/component-in-page-navigation-accessibility.yml
+++ b/_data/changelogs/component-in-page-navigation-accessibility.yml
@@ -1,7 +1,7 @@
 title: In-page navigation accessibility tests
 type: component
 items:
-  - date: NNNN-NN-NN
+  - date: 2024-10-16
     summary: Added accessibility tests page.
     affectsGuidance: true
     githubPr: 2863

--- a/_data/changelogs/component-in-page-navigation-accessibility.yml
+++ b/_data/changelogs/component-in-page-navigation-accessibility.yml
@@ -1,0 +1,8 @@
+title: In page navigation accessibility tests
+type: component
+items:
+ - date: NNNN-NN-NN
+   summary: Added accessibility tests page.
+   affectsGuidance: true
+   githubPr: [Related PR number]
+   githubRepo: uswds-site

--- a/_data/changelogs/component-in-page-navigation-accessibility.yml
+++ b/_data/changelogs/component-in-page-navigation-accessibility.yml
@@ -4,5 +4,5 @@ items:
  - date: NNNN-NN-NN
    summary: Added accessibility tests page.
    affectsGuidance: true
-   githubPr: [Related PR number]
+   githubPr: 2863
    githubRepo: uswds-site

--- a/_data/changelogs/component-in-page-navigation.yml
+++ b/_data/changelogs/component-in-page-navigation.yml
@@ -5,7 +5,7 @@ items:
   - date: NNNN-NN-NN
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
-    githubPr: [Related PR number]
+    githubPr: 2863
     githubRepo: uswds-site
   - date: 2024-03-26
     summary: Updated outdated references to `data-heading-selector` with `data-heading-elements`.

--- a/_data/changelogs/component-in-page-navigation.yml
+++ b/_data/changelogs/component-in-page-navigation.yml
@@ -2,7 +2,7 @@ title: In-page navigation
 type: component
 changelogURL:
 items:
-  - date: NNNN-NN-NN
+  - date: 2024-10-16
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 2863

--- a/_data/changelogs/component-in-page-navigation.yml
+++ b/_data/changelogs/component-in-page-navigation.yml
@@ -2,6 +2,11 @@ title: In-page navigation
 type: component
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Added WCAG compliance tag and accessibility test status section.
+    affectsGuidance: true
+    githubPr: [Related PR number]
+    githubRepo: uswds-site
   - date: 2024-03-26
     summary: Updated outdated references to `data-heading-selector` with `data-heading-elements`.
     summaryAdditional:

--- a/_includes/accessibility-tests/wcag-details.html
+++ b/_includes/accessibility-tests/wcag-details.html
@@ -124,7 +124,7 @@
 {% endif %}
 {% if item.wcag_criterion == "2.4.9" %}
   {% assign criterion_level = "AAA" %}
-  {% assign criterion_name = "Location" %}
+  {% assign criterion_name = "Link Purpose (link only)" %}
   {% assign criterion_url = "https://www.w3.org/TR/WCAG21/#link-purpose-link-only" %}
 {% endif %}
 {% if item.wcag_criterion == "2.4.13" %}

--- a/_includes/accessibility-tests/wcag-details.html
+++ b/_includes/accessibility-tests/wcag-details.html
@@ -122,6 +122,11 @@
   {% assign criterion_name = "Location" %}
   {% assign criterion_url = "https://www.w3.org/TR/WCAG21/#location" %}
 {% endif %}
+{% if item.wcag_criterion == "2.4.9" %}
+  {% assign criterion_level = "AAA" %}
+  {% assign criterion_name = "Location" %}
+  {% assign criterion_url = "https://www.w3.org/TR/WCAG21/#link-purpose-link-only" %}
+{% endif %}
 {% if item.wcag_criterion == "2.4.13" %}
   {% assign criterion_level = "AAA" %}
   {% assign criterion_name = "Focus appearance (WCAG 2.2)" %}


### PR DESCRIPTION
# Summary

Added accessibility test page for in page navigation component

## Related issue

Closes #2856

## Preview link
Preview link: [In-page Navigation Component Page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/rc-in-page-nav-checklist/components/in-page-navigation/)

## Testing and review
Follow these steps:

1. Confirm that both the main component page and the accessibility tests page have the correct compliance tag at the top.
2. Confirm that the main component page links to the accessibility tests page in the side navigation.
3. Confirm that the main component page links to the accessibility tests page from the accessibility guidance section.
4. Confirm that the main component page shows the accessibility tests summary.
5. Check that accessibility tests page provides the correct counts for each test status type.
6. Confirm the test checklist summaries and data are accurate.
7. Confirm no visual issues.
8. Confirm there is an appropriate changelog entry on both the main component page and the accessibility tests page.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [X] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [X] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `main`).
- [X] Run `npm run prettier:scss` to format any Sass updates.
- [X] Run `npm test` and confirm that all tests pass.
- [X] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->