### PR TITLE
USWDS-Site: Added side navigation accessibility test page

### DIFF
--- a/_components/sidenav/accessibility-tests.md
+++ b/_components/sidenav/accessibility-tests.md
@@ -5,7 +5,7 @@ component:
  name: side navigation
 title: Side navigation accessibility tests
 category: Components
-lead: Any USWDS [component name] component should pass these manual accessibility tests.
+lead: Any USWDS side navigation component should pass these manual accessibility tests.
 changelog:
  key: 'component-side-navigation-accessibility'
 ---

--- a/_components/sidenav/accessibility-tests.md
+++ b/_components/sidenav/accessibility-tests.md
@@ -1,0 +1,11 @@
+---
+permalink: /components/side-navigation/accessibility-tests/
+layout: accessibility-test
+component:
+ name: side navigation
+title: Side navigation accessibility tests
+category: Components
+lead: Any USWDS [component name] component should pass these manual accessibility tests.
+changelog:
+ key: 'component-side-navigation-accessibility'
+---

--- a/_components/sidenav/sidenav.md
+++ b/_components/sidenav/sidenav.md
@@ -10,16 +10,8 @@ redirect_from:
 - /sidenav/
 - /components/sidenav/
 subnav:
-- text: Preview
-  href: '#side-navigation-preview'
-- text: Code
-  href: '#side-navigation-code'
-- text: Guidance
-  href: '#side-navigation-guidance'
-- text: Package
-  href: '#side-navigation-package'
-- text: Latest updates
-  href: '#changelog'
+- text: side navigation accessibility tests
+  href: /components/side-navigation/accessibility-tests/
 tags:
   - sidenav
   - nav

--- a/_components/sidenav/sidenav.md
+++ b/_components/sidenav/sidenav.md
@@ -10,7 +10,7 @@ redirect_from:
 - /sidenav/
 - /components/sidenav/
 subnav:
-- text: side navigation accessibility tests
+- text: Side navigation accessibility tests
   href: /components/side-navigation/accessibility-tests/
 tags:
   - sidenav

--- a/_data/accessibility-tests/side-navigation.yml
+++ b/_data/accessibility-tests/side-navigation.yml
@@ -1,0 +1,66 @@
+title: Side navigation
+component_status: pass
+test_items:
+# General tests
+  - summary: Side navigation appears in the same location and order on every page of the website.
+    summary_additional: When you navigate to different pages on the website, the side navigation is always in the same order and in the same place.
+    test_status: conditional
+    test_type: general
+    version_tested: 3.8.2
+    wcag_criterion: 3.2.3
+  - summary: Side navigation clearly indicates location on the website.
+    summary_additional:  When viewing side navigation content, the links have distinct styling that give clear visual indication of where you are in the site. There are also other visual elements to further indicate where you are in relation to the navigation tree.
+    test_status: pass
+    test_type: general
+    version_tested: 3.8.2
+    wcag_criterion: 2.4.8
+  - summary: Side navigation link text and background meet color contrast requirements.
+    summary_additional: When you use a color contrast checker to view the side navigation, contrast between the text and background colors is at least 4.5:1.
+    test_status: pass
+    test_type: general
+    version_tested: 3.8.2
+    wcag_criterion: 1.4.3
+  - summary: Color is not the only method used to convey side navigation link states.
+    summary_additional: When viewing the side navigation links, you can read text to understand what page you are on. There may also be underlining missing to indicate you are on the current page.
+    test_status: pass
+    test_type: general
+    version_tested: 3.8.2
+    wcag_criterion: 1.4.1
+# Keyboard navigation tests
+  - summary: Keyboard can access all links in the side navigation.
+    summary_additional: When you navigate through the side navigation with a keyboard, you can interact with every link inside it.
+    test_status: pass
+    test_type: keyboard
+    version_tested: 3.8.2
+    wcag_criterion: 2.1.1
+  - summary: Side navigation does not trap keyboard focus.
+    summary_additional: When you navigate through side navigation links with a keyboard, you can easily move into and out to get to other content.
+    test_status: conditional
+    test_type: keyboard
+    version_tested: 3.8.2
+    wcag_criterion: 2.1.2
+  - summary: Focus indicator is clearly visible in side navigation.
+    summary_additional: When you use a keyboard to tab into the side navigation, the links have a visible underline, bold style or other clear indication that links are interactive.
+    test_status: pass
+    test_type: keyboard
+    version_tested: 3.8.2
+    wcag_criterion: 2.4.7
+# Screen reader tests
+  - summary: Screen reader announces side navigation region and items.
+    summary_additional: When using a screen reader to access the side navigation, you hear "side navigation" or "section navigation" and the list of items in the navigation. 
+    test_status: pass
+    test_type: screen_reader
+    version_tested: 3.8.2
+    wcag_criterion: 1.3.1
+  - summary: Screen reader provides direct description of links.
+    summary_additional: When you navigate to the side navigation with a screen reader, link titles are read aloud, and match the text seen on screen.
+    test_status: conditional
+    test_type: screen_reader
+    version_tested: 3.8.2
+    wcag_criterion: 2.4.4
+  - summary: Side navigation link titles and states of links are announced. 
+    summary_additional: When using a screen reader and you tab through the side navigation, you hear link titles and if they have been visited or not. You will also be able to tell if a link is a parent or sub-menu link and how many links are present.
+    test_status: conditional
+    test_type: screen_reader
+    version_tested: 3.8.2
+    wcag_criterion: 4.1.2

--- a/_data/accessibility-tests/side-navigation.yml
+++ b/_data/accessibility-tests/side-navigation.yml
@@ -10,7 +10,7 @@ test_items:
     wcag_criterion: 3.2.3
   - summary: Side navigation clearly indicates location on the website.
     summary_additional: When viewing side navigation content, the links have distinct styling that give clear visual indication of where you are in the site. There are also other visual elements to further indicate where you are in relation to the navigation tree.
-    test_status: pass
+    test_status: conditional
     test_type: general
     version_tested: 3.8.2
     wcag_criterion: 2.4.8

--- a/_data/accessibility-tests/side-navigation.yml
+++ b/_data/accessibility-tests/side-navigation.yml
@@ -40,7 +40,7 @@ test_items:
     version_tested: 3.8.2
     wcag_criterion: 2.1.2
   - summary: Focus indicator is clearly visible in side navigation.
-    summary_additional: When you use a keyboard to tab into the side navigation, the links have a visible underline, bold style or other clear indication that links are interactive.
+    summary_additional: When you use a keyboard to navigate through the side navigation, there will be a visible outline or other clear indication where the focus is.
     test_status: pass
     test_type: keyboard
     version_tested: 3.8.2

--- a/_data/changelogs/component-side-navigation-accessibility.yml
+++ b/_data/changelogs/component-side-navigation-accessibility.yml
@@ -1,0 +1,8 @@
+title: Side navigation accessibility tests
+type: component
+items:
+ - date: NNNN-NN-NN
+   summary: Added accessibility tests page.
+   affectsGuidance: true
+   githubPr: [Related PR number]
+   githubRepo: uswds-site

--- a/_data/changelogs/component-side-navigation-accessibility.yml
+++ b/_data/changelogs/component-side-navigation-accessibility.yml
@@ -4,5 +4,5 @@ items:
  - date: NNNN-NN-NN
    summary: Added accessibility tests page.
    affectsGuidance: true
-   githubPr: [Related PR number]
+   githubPr: 2864
    githubRepo: uswds-site

--- a/_data/changelogs/component-side-navigation-accessibility.yml
+++ b/_data/changelogs/component-side-navigation-accessibility.yml
@@ -1,7 +1,7 @@
 title: Side navigation accessibility tests
 type: component
 items:
-  - date: NNNN-NN-NN
+  - date: 2024-10-16
     summary: Added accessibility tests page.
     affectsGuidance: true
     githubPr: 2864

--- a/_data/changelogs/component-side-navigation.yml
+++ b/_data/changelogs/component-side-navigation.yml
@@ -2,7 +2,7 @@ title: Side navigation
 type: component
 changelogURL:
 items:
-  - date: NNNN-NN-NN
+  - date: 2024-10-16
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 2864

--- a/_data/changelogs/component-side-navigation.yml
+++ b/_data/changelogs/component-side-navigation.yml
@@ -2,6 +2,11 @@ title: Side navigation
 type: component
 changelogURL:
 items:
+ - date: NNNN-NN-NN
+   summary: Added WCAG compliance tag and accessibility test status section.
+   affectsGuidance: true
+   githubPr: [Related PR number]
+   githubRepo: uswds-site
 # 3.8.0 release
 - date: 2024-03-11
   summary: Added a new fallback setting for sidenavs in Documentation template.

--- a/_data/changelogs/component-side-navigation.yml
+++ b/_data/changelogs/component-side-navigation.yml
@@ -5,7 +5,7 @@ items:
  - date: NNNN-NN-NN
    summary: Added WCAG compliance tag and accessibility test status section.
    affectsGuidance: true
-   githubPr: [Related PR number]
+   githubPr: 2864
    githubRepo: uswds-site
 # 3.8.0 release
 - date: 2024-03-11

--- a/_data/changelogs/component-side-navigation.yml
+++ b/_data/changelogs/component-side-navigation.yml
@@ -2,11 +2,11 @@ title: Side navigation
 type: component
 changelogURL:
 items:
- - date: NNNN-NN-NN
-   summary: Added WCAG compliance tag and accessibility test status section.
-   affectsGuidance: true
-   githubPr: 2864
-   githubRepo: uswds-site
+- date: NNNN-NN-NN
+  summary: Added WCAG compliance tag and accessibility test status section.
+  affectsGuidance: true
+  githubPr: 2864
+  githubRepo: uswds-site
 # 3.8.0 release
 - date: 2024-03-11
   summary: Added a new fallback setting for sidenavs in Documentation template.


### PR DESCRIPTION
# Summary

Added accessibility test page for side navigation component

## Related issue

Closes #2857 

## Preview link
Preview link: [Side Navigation Component Page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/rc-side-nav-checklist/components/side-navigation/)

## Testing and review
Follow these steps:

1. Confirm that both the main component page and the accessibility tests page have the correct compliance tag at the top.
2. Confirm that the main component page links to the accessibility tests page in the side navigation.
3. Confirm that the main component page links to the accessibility tests page from the accessibility guidance section.
4. Confirm that the main component page shows the accessibility tests summary.
5. Check that accessibility tests page provides the correct counts for each test status type.
6. Confirm the test checklist summaries and data are accurate.
7. Confirm no visual issues.
8. Confirm there is an appropriate changelog entry on both the main component page and the accessibility tests page.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [X] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [X] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `main`).
- [X] Run `npm run prettier:scss` to format any Sass updates.
- [X] Run `npm test` and confirm that all tests pass.
- [X] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->