### PR TITLE
Add August MC video to Monthly Calls page

### DIFF
--- a/_data/changelogs/about-monthly-calls.yml
+++ b/_data/changelogs/about-monthly-calls.yml
@@ -2,9 +2,9 @@ title: Monthly calls
 type: documentation
 changelogURL:
 items:
- - date: 2024-10-00
-    summary: Added August 2024 monthly call video.
-    githubPr: 2846
+  - date: 2024-10-23
+    summary: Added video for August 2024 monthly call.
+    githubPr: 2873
     githubRepo: uswds-site
   - date: 2024-09-16
     summary: Added August 2024 monthly call.

--- a/_data/changelogs/about-monthly-calls.yml
+++ b/_data/changelogs/about-monthly-calls.yml
@@ -2,6 +2,10 @@ title: Monthly calls
 type: documentation
 changelogURL:
 items:
+ - date: 2024-10-00
+    summary: Added August 2024 monthly call video.
+    githubPr: 2846
+    githubRepo: uswds-site
   - date: 2024-09-16
     summary: Added August 2024 monthly call.
     githubPr: 2827

--- a/_data/monthly-calls.yml
+++ b/_data/monthly-calls.yml
@@ -4,7 +4,7 @@ videos:
     description: |
      At the August 2024 monthly call, USWDS Experience Design Lead Anne Petersen answered community-submitted questions including an update on the submission and review process for component proposals. USWDS Product Lead Dan Williams shared updates on new and upcoming releases and demoed a preview of our new USWDS Figma Design Kit. USWDS Engineering Lead Matt Henry and USWDS contractor developer Amy Leadem also demoed early working prototypes of a few components.
     date: August 2024
-    id:
+    id: duomgOmMwro
     event_link: https://digital.gov/event/2024/08/15/uswds-monthly-call-august-2024/
     slides:
      link: https://s3.amazonaws.com/digitalgov/static/uswds-monthly-call-august-2024.pptx


### PR DESCRIPTION
# Summary

Adding August Monthly Call content to Monthly Calls page 

> [!Important]
> The changelog date will need to be updated before merge.

## Related issue

Closes #2846 
Related to #[6025 ](https://github.com/uswds/uswds/issues/6025)


## Preview link 
[Monthly calls page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/kf-augMCvideo_MCspg/about/monthly-calls/)


## Problem statement

Needed to get Monthly Calls page up to date with August video. 

## Solution

August Monthly Call summary has been done. We just received video and it needs to be added to page. 


## Testing and review

Need someone to look and make sure link to video works. 



<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `main`).
- [ ] Run `npm run prettier:scss` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->