### PR TITLE
USWDS-Site: Add changelog for step indicator aria-label removal [#6146]

### DIFF
--- a/_data/changelogs/component-step-indicator.yml
+++ b/_data/changelogs/component-step-indicator.yml
@@ -4,8 +4,8 @@ changelogURL:
 
 items:
   - date: NNNN-NN-NN
-    summary: Removed the aria-label from the wrapper of the step indicator component.
-    summaryAdditional: This resolves an automated testing error related to having an invalid attribute on a div element.
+    summary: Removed the `aria-label`from the wrapper of the step indicator component.
+    summaryAdditional: This resolves an automated testing error related to having an invalid attribute on a `div` element.
     affectsAccessibility: true
     affectsMarkup: true
     githubPr: 6146

--- a/_data/changelogs/component-step-indicator.yml
+++ b/_data/changelogs/component-step-indicator.yml
@@ -1,10 +1,16 @@
 title: Step indicator
 type: component
-# Provide url for the package CHANGELOG.md. Note: Not all pages will have a related CHANGELOG.md file.
 changelogURL:
 
 items:
-  # 3.4.0 release
+  - date: NNNN-NN-NN
+    summary: Removed the aria-label from the wrapper of the step indicator component.
+    summaryAdditional: This resolves an automated testing error related to having an invalid attribute on a div element.
+    affectsAccessibility: true
+    affectsMarkup: true
+    githubPr: 6146
+    githubRepo: uswds
+    versionUswds: N.N.N
   - date: 2023-03-09
     summary: Improved contrast on pending items.
     summaryAdditional: Graphical elements related to pending items now meet accessibility standards for contrast ratio.
@@ -14,7 +20,6 @@ items:
     githubPr: 5048
     githubRepo: uswds
     versionUswds: 3.4.0
-  # 3.0 release
   - date: 2022-04-28
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true

--- a/_data/changelogs/component-step-indicator.yml
+++ b/_data/changelogs/component-step-indicator.yml
@@ -4,8 +4,8 @@ changelogURL:
 
 items:
   - date: NNNN-NN-NN
-    summary: Removed the `aria-label`from the wrapper of the step indicator component.
-    summaryAdditional: This resolves an automated testing error related to having an invalid attribute on a `div` element.
+    summary: Removed the `aria-label` from the wrapper of the step indicator component.
+    summaryAdditional: This resolves an error related to having an invalid attribute on a `div` element.
     affectsAccessibility: true
     affectsMarkup: true
     githubPr: 6146


### PR DESCRIPTION
# Summary

Add a changelog for PR uswds/uswds#6146

>[!important]
> We need to update the changelog dates before merge.

## Related issue

Related to uswds/uswds#6146

## Preview link

[Step indicator changelog](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-changelog-6146/components/step-indicator/#latest-updates)
