### PR TITLE
Add September and October Monthly Call to MCs page

### DIFF
--- a/_data/changelogs/about-monthly-calls.yml
+++ b/_data/changelogs/about-monthly-calls.yml
@@ -2,7 +2,7 @@ title: Monthly calls
 type: documentation
 changelogURL:
 items:
-  - date: 2024-11-00
+  - date: 2024-11-04
     summary: Added September and October 2024 monthly calls.
     githubPr: 2934
     githubRepo: uswds-site

--- a/_data/changelogs/about-monthly-calls.yml
+++ b/_data/changelogs/about-monthly-calls.yml
@@ -2,6 +2,10 @@ title: Monthly calls
 type: documentation
 changelogURL:
 items:
+  - date: 2024-11-00
+    summary: Added September and October 2024 monthly calls.
+    githubPr: 2934
+    githubRepo: uswds-site
   - date: 2024-10-23
     summary: Added video for August 2024 monthly call.
     githubPr: 2873

--- a/_data/monthly-calls.yml
+++ b/_data/monthly-calls.yml
@@ -5,9 +5,9 @@ videos:
      The October monthly call centered on U.S. Web Design System (USWDS) product and engineering values. To frame the discussion, USWDS Experience Design Lead Anne Petersen examined how the design system’s product and design principles have evolved over the nine year history of USWDS. USWDS Product Lead Dan Williams and USWDS Engineering Lead Matt Henry then presented a set of new product and engineering values and discussed how they will guide decision-making about USWDS Web Components and the broader development of the design system.
     date: October 2024
     id: 
-    event_link:
+    event_link: https://digital.gov/event/2024/10/17/uswds-monthly-call-october-2024/
     slides:
-     link: https://digital.gov/event/2024/10/17/uswds-monthly-call-october-2024/
+     link: https://s3.amazonaws.com/digitalgov/static/uswds-monthly-call-october-2024.pptx
      size: 2.5
      pages: 109
     questions_link:

--- a/_data/monthly-calls.yml
+++ b/_data/monthly-calls.yml
@@ -3,9 +3,10 @@ videos:
     subtitle: What we've learned from other design systems
     description: |
      At the September 2024 monthly call, UX Researcher (USWDS contractor) Jacline Contrino shared results of the team’s recent landscape analysis of Web Components–based design systems. The research focused on four core areas of current design systems and areas for development: documentation, code structure, code size and performance, and distribution.
+     
      USWDS Product Lead Dan Williams and USWDS Engineering Lead Matt Henry expanded on the research to discuss how USWDS currently fits into that landscape and how the design system is positioned for future innovations. The research findings will be foundational to developing engineering principles that will guide the team’s future decision-making about web components and the design system overall. 
     date: September 2024
-    id: 
+    id: E826mR1B6_Y
     event_link: https://digital.gov/event/2024/09/19/uswds-monthly-call-september-2024/
     slides:
      link: https://s3.amazonaws.com/digitalgov/static/uswds-monthly-call-september-2024.pptx

--- a/_data/monthly-calls.yml
+++ b/_data/monthly-calls.yml
@@ -1,4 +1,16 @@
 videos:
+  - title: Engineering values
+    subtitle:
+    description: |
+     The October monthly call centered on U.S. Web Design System (USWDS) product and engineering values. To frame the discussion, USWDS Experience Design Lead Anne Petersen examined how the design system’s product and design principles have evolved over the nine year history of USWDS. USWDS Product Lead Dan Williams and USWDS Engineering Lead Matt Henry then presented a set of new product and engineering values and discussed how they will guide decision-making about USWDS Web Components and the broader development of the design system.
+    date: October 2024
+    id: 
+    event_link:
+    slides:
+     link: https://digital.gov/event/2024/10/17/uswds-monthly-call-october-2024/
+     size: 2.5
+     pages: 109
+    questions_link:
   - title: The landscape of Web Components
     subtitle: What we've learned from other design systems
     description: |

--- a/_data/monthly-calls.yml
+++ b/_data/monthly-calls.yml
@@ -3,6 +3,7 @@ videos:
     subtitle: What we've learned from other design systems
     description: |
      At the September 2024 monthly call, UX Researcher (USWDS contractor) Jacline Contrino shared results of the team’s recent landscape analysis of Web Components–based design systems. The research focused on four core areas of current design systems and areas for development: documentation, code structure, code size and performance, and distribution.
+     
      USWDS Product Lead Dan Williams and USWDS Engineering Lead Matt Henry expanded on the research to discuss how USWDS currently fits into that landscape and how the design system is positioned for future innovations. The research findings will be foundational to developing engineering principles that will guide the team’s future decision-making about web components and the design system overall. 
     date: September 2024
     id: E826mR1B6_Y

--- a/_data/monthly-calls.yml
+++ b/_data/monthly-calls.yml
@@ -1,5 +1,5 @@
 videos:
-  - title: September 2024: The landscape of Web Components
+  - title: The landscape of Web Components
     subtitle: What we've learned from other design systems
     description: |
      At the September 2024 monthly call, UX Researcher (USWDS contractor) Jacline Contrino shared results of the team’s recent landscape analysis of Web Components–based design systems. The research focused on four core areas of current design systems and areas for development: documentation, code structure, code size and performance, and distribution.

--- a/_data/monthly-calls.yml
+++ b/_data/monthly-calls.yml
@@ -16,7 +16,7 @@ videos:
     description: |
      At the September 2024 monthly call, UX Researcher (USWDS contractor) Jacline Contrino shared results of the team’s recent landscape analysis of Web Components–based design systems. The research focused on four core areas of current design systems and areas for development: documentation, code structure, code size and performance, and distribution.
      
-     USWDS Product Lead Dan Williams and USWDS Engineering Lead Matt Henry expanded on the research to discuss how USWDS currently fits into that landscape and how the design system is positioned for future innovations. The research findings will be foundational to developing engineering principles that will guide the team’s future decision-making about web components and the design system overall. 
+     USWDS Product Lead Dan Williams and USWDS Engineering Lead Matt Henry expanded on the research to discuss how USWDS currently fits into that landscape and how the design system is positioned for future innovations. The research findings will be foundational to developing engineering principles that will guide the team’s future decision-making about USWDS Web Components and the design system overall. 
     date: September 2024
     id: E826mR1B6_Y
     event_link: https://digital.gov/event/2024/09/19/uswds-monthly-call-september-2024/

--- a/_data/monthly-calls.yml
+++ b/_data/monthly-calls.yml
@@ -1,4 +1,17 @@
 videos:
+  - title: September 2024: The landscape of Web Components
+    subtitle: What we've learned from other design systems
+    description: |
+     At the September 2024 monthly call, UX Researcher (USWDS contractor) Jacline Contrino shared results of the team’s recent landscape analysis of Web Components–based design systems. The research focused on four core areas of current design systems and areas for development: documentation, code structure, code size and performance, and distribution. 
+     USWDS Product Lead Dan Williams and USWDS Engineering Lead Matt Henry expanded on the research to discuss how USWDS currently fits into that landscape and how the design system is positioned for future innovations. The research findings will be foundational to developing engineering principles that will guide the team’s future decision-making about web components and the design system overall. 
+    date: September 2024
+    id: 
+    event_link: https://digital.gov/event/2024/09/19/uswds-monthly-call-september-2024/
+    slides:
+     link: https://s3.amazonaws.com/digitalgov/static/uswds-monthly-call-september-2024.pptx
+     size: 6.7
+     pages: 75
+    questions_link: https://github.com/uswds/uswds/discussions/6106
   - title: A look at beta Web Components
     subtitle: Progress toward the next version of USWDS
     description: |

--- a/_data/monthly-calls.yml
+++ b/_data/monthly-calls.yml
@@ -3,8 +3,7 @@ videos:
     subtitle: What we've learned from other design systems
     description: |
      At the September 2024 monthly call, UX Researcher (USWDS contractor) Jacline Contrino shared results of the team’s recent landscape analysis of Web Components–based design systems. The research focused on four core areas of current design systems and areas for development: documentation, code structure, code size and performance, and distribution.
-     
-     USWDS Product Lead Dan Williams and USWDS Engineering Lead Matt Henry expanded on the research to discuss how USWDS currently fits into that landscape and how the design system is positioned for future innovations. The research findings will be foundational to developing engineering principles that will guide the team’s future decision-making about web components and the design system overall. 
+USWDS Product Lead Dan Williams and USWDS Engineering Lead Matt Henry expanded on the research to discuss how USWDS currently fits into that landscape and how the design system is positioned for future innovations. The research findings will be foundational to developing engineering principles that will guide the team’s future decision-making about web components and the design system overall. 
     date: September 2024
     id: E826mR1B6_Y
     event_link: https://digital.gov/event/2024/09/19/uswds-monthly-call-september-2024/

--- a/_data/monthly-calls.yml
+++ b/_data/monthly-calls.yml
@@ -3,7 +3,7 @@ videos:
     subtitle: What we've learned from other design systems
     description: |
      At the September 2024 monthly call, UX Researcher (USWDS contractor) Jacline Contrino shared results of the team’s recent landscape analysis of Web Components–based design systems. The research focused on four core areas of current design systems and areas for development: documentation, code structure, code size and performance, and distribution.
-USWDS Product Lead Dan Williams and USWDS Engineering Lead Matt Henry expanded on the research to discuss how USWDS currently fits into that landscape and how the design system is positioned for future innovations. The research findings will be foundational to developing engineering principles that will guide the team’s future decision-making about web components and the design system overall. 
+     USWDS Product Lead Dan Williams and USWDS Engineering Lead Matt Henry expanded on the research to discuss how USWDS currently fits into that landscape and how the design system is positioned for future innovations. The research findings will be foundational to developing engineering principles that will guide the team’s future decision-making about web components and the design system overall. 
     date: September 2024
     id: E826mR1B6_Y
     event_link: https://digital.gov/event/2024/09/19/uswds-monthly-call-september-2024/

--- a/_data/monthly-calls.yml
+++ b/_data/monthly-calls.yml
@@ -2,7 +2,7 @@ videos:
   - title: September 2024: The landscape of Web Components
     subtitle: What we've learned from other design systems
     description: |
-     At the September 2024 monthly call, UX Researcher (USWDS contractor) Jacline Contrino shared results of the team’s recent landscape analysis of Web Components–based design systems. The research focused on four core areas of current design systems and areas for development: documentation, code structure, code size and performance, and distribution. 
+     At the September 2024 monthly call, UX Researcher (USWDS contractor) Jacline Contrino shared results of the team’s recent landscape analysis of Web Components–based design systems. The research focused on four core areas of current design systems and areas for development: documentation, code structure, code size and performance, and distribution.
      USWDS Product Lead Dan Williams and USWDS Engineering Lead Matt Henry expanded on the research to discuss how USWDS currently fits into that landscape and how the design system is positioned for future innovations. The research findings will be foundational to developing engineering principles that will guide the team’s future decision-making about web components and the design system overall. 
     date: September 2024
     id: 


### PR DESCRIPTION
# Summary

Adding September and October Monthly Call content to Monthly Calls page 

> [!Important]
> The changelog date will need to be updated before merge.

## Related issue

Closes #2849 and #2916


## Preview link 
[[Monthly calls page]](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/kf-septMC-MCspage/about/monthly-calls/)

## Problem statement

Needed to get Monthly Calls page up to date with September and October call info. 

## Solution

September Monthly Call summary was approved and is ready to be added to the page. Video will not be going up until later in the month. Will need a new ticket or branch off this when it's ready.


## Testing and review

Need someone to look and make sure links work and content is clean and clear. 



<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `main`).
- [ ] Run `npm run prettier:scss` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->