### PR TITLE
USWDS-Site - HTML-proofer: Fix broken node.js link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Recommended before install:
 You will need to have the following installed on your machine before following the commands below:
 
 1. Ruby v3.2.5 (see `.ruby-version` or `.tool-versions`), [Installation guides](https://www.ruby-lang.org/en/documentation/installation/)
-1. Node v20.9.0 (see `.nvmrc` or `.tool-versions`), [Installation guides](https://nodejs.org/en/download/)
-1. Bundler v2.2.0 (see `.bundler-version`) [Installation guides](https://bundler.io/guides/using_bundler_in_applications.html#getting-started---installing-bundler-and-bundle-init)
+1. Node LTS (see `.nvmrc` or `.tool-versions`), [Installation guides](https://nodejs.org/en/download)
+1. Bundler v2.3.7 (see `.bundler-version`) [Installation guides](https://bundler.io/guides/using_bundler_in_applications.html#getting-started---installing-bundler-and-bundle-init)
 1. Chrome v59 or higher (v60 if on Windows)
 1. Python v2.7* (For node-gyp dependency)
 

--- a/pages/documentation/getting-started-developers/overview.md
+++ b/pages/documentation/getting-started-developers/overview.md
@@ -25,7 +25,7 @@ As always, we're here for you if you have any questions. Please get in touch via
 
 ## What you need
 We recommend using the following tools when working with the Design System:
-- Node (use the version specified in the [.nvmrc file](https://github.com/uswds/uswds/blob/main/.nvmrc); if needed, [download the latest version](https://nodejs.org/en/download/) from Node.js)
+- Node (use the version specified in the [.nvmrc file](https://github.com/uswds/uswds/blob/main/.nvmrc); if needed, [download the latest version](https://nodejs.org/en/download) from Node.js)
 - Npm
 
 These step-by-step instructions describe how to get started with the Design System using npm (recommended method).

--- a/pages/documentation/getting-started-developers/phase-one.md
+++ b/pages/documentation/getting-started-developers/phase-one.md
@@ -25,7 +25,7 @@ Installing the Design System with Node and npm not only allows you to install al
 ## Step 1: Install Node and npm
 Open your Terminal application and a Terminal window. Check to see if you have the [most recent version of Node](https://github.com/uswds/uswds/blob/develop/.nvmrc) installed with `node -v`.
 
-If you don’t have Node, install it from [Node.js](https://nodejs.org/en/download/).
+If you don’t have Node, install it from [Node.js](https://nodejs.org/en/download).
 
 ## Step 2: Initialize your project in Node
 Once you have Node and npm installed, go to the root of your project directory in Terminal. The root is the topmost directory associated with your project, the directory that includes all your project files and directories. In Terminal, the root will read as follows:


### PR DESCRIPTION
# Summary

Fixed 404 links to node.js download page.

## Related issue

N/A

## Preview links

- README
- Getting started for devs: overview
- Getting started for devs: phase 1

## Problem statement

Received the following erorr when running `npm run proof`: 

```
For the Links > External check, the following failures were found:

* At ./_site/documentation/developers/index.html:2936:

  External link https://nodejs.org/en/download/ failed (status code 404)

* At ./_site/documentation/getting-started-for-developers/index.html:2830:

  External link https://nodejs.org/en/download/ failed (status code 404)

* At ./_site/documentation/getting-started/developers/phase-one-install/index.html:2928:

  External link https://nodejs.org/en/download/ failed (status code 404)
```

## Solution
Removing the slash at the end of the url fixes the broken link to the node.js download page.

> [!note]
> The https://nodejs.org/en/download does redirect to https://nodejs.org/en/download/package-manager. However, I chose to leave `package-manager` off the end to be more neutral and allow for node to update where they want their doanlod url to point to. 

Process reference: [Handling HTML proofer errors](https://docs.google.com/document/d/1y5YW5Y9zqzx05bGFfG7MxC42cI04TVOOJVIhC5e7zbA/edit?tab=t.0#heading=h.9q54u2f20p1w) (Google docs :lock:)


## Testing and review
- Confirm the updated links work as expected
- Confirm no errors when running `npm run proof`
