### PR TITLE
Monthly calls page: Add October video and Q&A link

### DIFF
--- a/_data/monthly-calls.yml
+++ b/_data/monthly-calls.yml
@@ -4,13 +4,13 @@ videos:
     description: |
      The October monthly call centered on U.S. Web Design System (USWDS) product and engineering values. To frame the discussion, USWDS Experience Design Lead Anne Petersen examined how the design system’s product and design principles have evolved over the nine year history of USWDS. USWDS Product Lead Dan Williams and USWDS Engineering Lead Matt Henry then presented a set of new product and engineering values and discussed how they will guide decision-making about USWDS Web Components and the broader development of the design system.
     date: October 2024
-    id: 
+    id: H8XUPJxiUEc
     event_link: https://digital.gov/event/2024/10/17/uswds-monthly-call-october-2024/
     slides:
      link: https://s3.amazonaws.com/digitalgov/static/uswds-monthly-call-october-2024.pptx
      size: 2.5
      pages: 109
-    questions_link:
+    questions_link: https://github.com/uswds/uswds/discussions/6207
   - title: The landscape of Web Components
     subtitle: What we've learned from other design systems
     description: |


### PR DESCRIPTION
# Summary

Added link to October monthly call video and Q&A discussion link to[ monthly calls page](https://designsystem.digital.gov/about/monthly-calls/).


## Related issue

Closes [#6214](https://github.com/uswds/uswds/issues/6214)


## Preview link

[Preview link](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/kf-MCspg-Octupdates/about/monthly-calls/)
<!-- If available, provide a link to a demo of the solution in action. -->

## Problem statement

Had to publish summary before video and Q&A were ready. Now they are. Updating the page.


## Testing and review

Check and make sure links work and go to correct location.
Check for any typos or other text issues

