### PR TITLE
USWDS-Site: Updates Snyk Alert

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -3522,9 +3522,9 @@ ignore:
         created: 2023-10-11T19:28:02.917Z
   SNYK-JS-INFLIGHT-6095116:
     - '*':
-        reason: Fix requires ESM syntax in uswds-compile
-        expires: 2024-11-30T14:44:47.825Z
-        created: 2024-10-31T14:44:47.866Z
+        reason: No available upgrade or patch
+        expires: 2025-01-01T21:08:46.836Z
+        created: 2024-12-02T21:08:46.867Z
   SNYK-JS-BRACES-6838727:
     - '*':
         reason: No available upgrade or patch


### PR DESCRIPTION
# Summary

**Updated snyk ignore files**

## Problem statement

`npx snyk` test is throwing the following error:
```
Issues with no direct upgrade or patch:
  ✗ Missing Release of Resource after Effective Lifetime [Medium Severity][https://security.snyk.io/vuln/SNYK-JS-INFLIGHT-6095116] in inflight@1.0.6
    introduced by @uswds/compile@1.2.0 > del@6.1.1 > rimraf@3.0.2 > glob@7.2.3 > inflight@1.0.6
  No upgrade or patch available
```

## Solution

Updated snyk ignore. Ran the following in the command line:
```
npx snyk ignore --id="SNYK-JS-INFLIGHT-6095116" --reason="No available upgrade or patch"
```

## Testing and review

To test, run `npx snyk` test and check for errors.

## Reference
[Ignoring Snyk Alerts](https://docs.google.com/document/d/1RX6uYky-P37jysuBy6LEBhuMCQlMAvHU0mRJUow345o/edit#heading=h.fa3sv1ray42g)