### PR TITLE
Add November summary to Monthly calls page

### DIFF
--- a/_data/changelogs/about-monthly-calls.yml
+++ b/_data/changelogs/about-monthly-calls.yml
@@ -2,6 +2,10 @@ title: Monthly calls
 type: documentation
 changelogURL:
 items:
+  - date: 2024-12-13
+    summary: Added November 2024 monthly call.
+    githubPr: 3015
+    githubRepo: uswds-site
   - date: 2024-11-04
     summary: Added September and October 2024 monthly calls.
     githubPr: 2934

--- a/_data/monthly-calls.yml
+++ b/_data/monthly-calls.yml
@@ -1,4 +1,15 @@
 videos:
+  - title: The next generation of the design system
+    subtitle: The new, modular USWDS we'll deliver in 2025
+    description: |
+     At the November monthly call, we laid out our vision for the direction of the design system. USWDS Product Lead Dan Williams shared exciting news about the beta for our new <a href="https://www.figma.com/community/file/1440921849343185329/uswds-design-kit-beta>USWDS Figma design kit</a>. USWDS Experience Design Lead Anne Petersen and USWDS Engineering Lead Matt Henry joined Dan to explain the design system’s shift toward modularity, and the relationship between the existing codebase (which we'll rename USWDS Core) and the Web Components–based version (which we're calling USWDS Elements), as well as with design tokens, utilities, and new design kit.    date: October 2024
+    id: 
+    event_link: https://digital.gov/event/2024/11/21/uswds-monthly-call-november-2024/
+    slides:
+     link: https://s3.amazonaws.com/digitalgov/static/uswds-monthly-call-november-2024.pptx
+     size: 5
+     pages: 109
+    questions_link: 
   - title: Engineering values
     subtitle:
     description: |

--- a/_data/monthly-calls.yml
+++ b/_data/monthly-calls.yml
@@ -2,7 +2,7 @@ videos:
   - title: The next generation of the design system
     subtitle: The new, modular USWDS we'll deliver in 2025
     description: |
-     At the November monthly call, we laid out our vision for the direction of the design system. USWDS Product Lead Dan Williams shared exciting news about the beta for our new <a href="https://www.figma.com/community/file/1440921849343185329/uswds-design-kit-beta>USWDS Figma design kit</a>. USWDS Experience Design Lead Anne Petersen and USWDS Engineering Lead Matt Henry joined Dan to explain the design system’s shift toward modularity, and the relationship between the existing codebase (which we'll rename USWDS Core) and the Web Components–based version (which we're calling USWDS Elements), as well as with design tokens, utilities, and new design kit.    date: October 2024
+     At the November monthly call, we laid out our vision for the direction of the design system. USWDS Product Lead Dan Williams shared exciting news about the beta for our new [USWDS Figma design kit](https://www.figma.com/community/file/1440921849343185329/uswds-design-kit-beta). USWDS Experience Design Lead Anne Petersen and USWDS Engineering Lead Matt Henry joined Dan to explain the design system’s shift toward modularity, and the relationship between the existing codebase (which we'll rename USWDS Core) and the Web Components–based version (which we're calling USWDS Elements), as well as with design tokens, utilities, and new design kit.
     date: November 2024
     id: 
     event_link: https://digital.gov/event/2024/11/21/uswds-monthly-call-november-2024/

--- a/_data/monthly-calls.yml
+++ b/_data/monthly-calls.yml
@@ -9,7 +9,7 @@ videos:
      link: https://s3.amazonaws.com/digitalgov/static/uswds-monthly-call-november-2024.pptx
      size: 5
      pages: 109
-    questions_link: 
+    questions_link: https://github.com/uswds/uswds/discussions/6252
   - title: Engineering values
     subtitle:
     description: |

--- a/_data/monthly-calls.yml
+++ b/_data/monthly-calls.yml
@@ -3,6 +3,7 @@ videos:
     subtitle: The new, modular USWDS we'll deliver in 2025
     description: |
      At the November monthly call, we laid out our vision for the direction of the design system. USWDS Product Lead Dan Williams shared exciting news about the beta for our new <a href="https://www.figma.com/community/file/1440921849343185329/uswds-design-kit-beta>USWDS Figma design kit</a>. USWDS Experience Design Lead Anne Petersen and USWDS Engineering Lead Matt Henry joined Dan to explain the design system’s shift toward modularity, and the relationship between the existing codebase (which we'll rename USWDS Core) and the Web Components–based version (which we're calling USWDS Elements), as well as with design tokens, utilities, and new design kit.    date: October 2024
+    date: November 2024
     id: 
     event_link: https://digital.gov/event/2024/11/21/uswds-monthly-call-november-2024/
     slides:

--- a/_data/monthly-calls.yml
+++ b/_data/monthly-calls.yml
@@ -9,7 +9,7 @@ videos:
     slides:
      link: https://s3.amazonaws.com/digitalgov/static/uswds-monthly-call-november-2024.pptx
      size: 5
-     pages: 109
+     pages: 108
     questions_link: https://github.com/uswds/uswds/discussions/6252
   - title: Engineering values
     subtitle:


### PR DESCRIPTION
# Summary

Adding November Monthly Call content to Monthly Calls page 

> [!Important]
> The changelog date will need to be updated before merge.

## Related issue

Closes #6215


## Preview link 
[Monthly calls page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/kf-novMC-MCspage/about/monthly-calls/)

## Problem statement

Needed to get Monthly calls page up to date with November call info. 

## Solution
November Monthly call summary was approved and is ready to be added to the page. Video will not be going up until later in the month. Will need a new ticket or branch off this when it's ready.


## Testing and review

Need someone to look and make sure links work and content is clean and clear. 

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `main`).
- [ ] Run `npm run prettier:scss` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->