### PR TITLE
USWDS-Site - Implementations: Salesforce Lightning is Archived  

### DIFF
--- a/_data/implementations.yml
+++ b/_data/implementations.yml
@@ -160,6 +160,7 @@
 - name: uswds-sf-lightning-community
   distribution: Salesforce Lightning
   url: https://github.com/GSA/uswds-sf-lightning-community
+  status: archived
   author:
     name: GSA IT (Mark Vogelgesang)
     url: https://github.com/GSA/


### PR DESCRIPTION
# Summary

Thanks @caseywatts for originally submitting this. Created this PR to verify commits via cherry picking and build site preview on cloud.gov pages.

From #3013:
>The Salesforce Lightning implementation of USWDS was archived in January 2024 this year:
https://github.com/GSA/uswds-sf-lightning-community
>
>This pull request marks that implementation as "archived" on the Implementations page.


## Preview link

<img width="400" alt="Salesforce implementation marked archived" src="https://github.com/user-attachments/assets/aca60413-4089-401a-8310-6e02b783a51e"/>


[Implementations page →](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/jm-test-commit-signature/documentation/implementations/) 

