### PR TITLE
USWDS-Site: HTML-proofer fixes

### DIFF
--- a/_data/changelogs/docs-showcase.yml
+++ b/_data/changelogs/docs-showcase.yml
@@ -2,7 +2,7 @@ title: Showcase
 type: documentation
 changelogURL:
 items:
-  - date: NNNN-NN-NN
+  - date: 2024-12-18
     summary: Removed broken link to VA Caseflow.
     affectsGuidance: true
     githubPr: 3031

--- a/_data/changelogs/docs-showcase.yml
+++ b/_data/changelogs/docs-showcase.yml
@@ -2,8 +2,13 @@ title: Showcase
 type: documentation
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Removed broken link to VA Caseflow.
+    affectsGuidance: true
+    githubPr: 3031
+    githubRepo: uswds-site
   - date: 2024-04-26
-    summary: Remove broken links that have no alternate for redirects. 
+    summary: Remove broken links that have no alternate for redirects.
     summaryAdditional: Correct misspelling that Siteimprove noted.
     affectsGuidance: true
     githubPr: 2586

--- a/pages/documentation/showcase.md
+++ b/pages/documentation/showcase.md
@@ -169,7 +169,6 @@ If your project is currently using USWDS and you would like to see it included i
 - [USGS Earthquake Hazards Program](http://earthquake.usgs.gov/theme/)
 - [USGS.gov - U.S. Geological Survey](https://www.usgs.gov/)
 - [USGS Publications Warehouse](https://pubs.usgs.gov/)
-- [VA Caseflow](https://github.com/department-of-veterans-affairs/caseflow)
 - [VA Developer Portal](https://developer.va.gov/)
 - [vote.gov](https://vote.gov/)
 - [Water Data for the Nation (USGS)](https://waterdata.usgs.gov/blog/)


### PR DESCRIPTION
# Summary

Removed the 404 link to VA Caseflow from the showcase page. 

## Related issue

N/A

## Preview link

[Showcase page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-html-proofer-dec-2/documentation/showcase/)

## Problem statement
HTML-proofer flagged the following failure:
```
For the Links > External check, the following failures were found:

* At ./_site/documentation/showcase/index.html:2820:

  External link https://github.com/department-of-veterans-affairs/caseflow failed (status code 404)

```

## Solution

Removed the VA Caseflow link from the showcase page because no suitable replacement could be found. 

> [!note]
> The [link in the wayback machine](https://web.archive.org/web/20241214215433/https://github.com/department-of-veterans-affairs/caseflow) shows the repo seemed to be in active development recently, showing a release last week. Not sure if this indicates that the repo might only be temporarily down. 

## Testing and review
- Confirm no suitable replacement exists for the removed link
- Confirm changelog is present, accurate, and free from error