### PR TITLE
USWDS-Site - HTML-proofer: Fix broken CDC link

### DIFF
--- a/_together/04-get-involved.md
+++ b/_together/04-get-involved.md
@@ -34,7 +34,7 @@ As people working in the federal space we all need to advocate for inclusive exp
 * Own your responsibility to ensure that the research we conduct is as inclusive and representative as possible.
 * Engage with non-profits and community groups to identify, recruit, and fairly compensate diverse users.
 * Consider who benefits and who may be harmed with each design.
-* Ask yourself who is invited and who is absent from the discussion. 
+* Ask yourself who is invited and who is absent from the discussion.
 * Identify who is best positioned to help us understand how to make our solutions better.
 
 The patterns are a start, but we need your help keeping these patterns current as design practices and DEIA norms evolve. We encourage you to continue to share your knowledge and expertise.
@@ -77,14 +77,14 @@ The patterns are a start, but we need your help keeping these patterns current a
 [^1]: A quick guide to inclusive design. (August 15, 2022) Retrieved on August 19, 2022, from <https://medium.com/the-u-s-digital-service/a-quick-guide-to-inclusive-design-be4931ef2c>
 
 
-[^2]: Communicating with and about people with disabilities. (February 1, 2022) Retrieved on August 19, 2022, from <https://www.cdc.gov/ncbddd/disabilityandhealth/materials/factsheets/fs-communicating-with-people.html>
+[^2]: Communicating with and about people with disabilities. (February 1, 2022) Retrieved on August 19, 2022, from <https://www.cdc.gov/disability-and-health/articles-documents/communicating-with-and-about-people-with-disabilities.html>
 
 ## Credits
 Illustrations created using [humaaans](https://www.humaaans.com/), a [CC0 (public domain)](https://creativecommons.org/public-domain/cc0/) design library.
 
 Disclaimer: Links to nongovernment sources are made for educational or source citation purposes only, and do not represent an endorsement of the organizations by the General Services Administration. The General Services Administration does not assume any responsibility for the content, operation, or policies of other entities' websites.
 
-</div> 
+</div>
   </div>
 </section>
 

--- a/pages/patterns/complex-form/establish-trust.md
+++ b/pages/patterns/complex-form/establish-trust.md
@@ -40,7 +40,7 @@ Provide clear information on why it is necessary to complete the form, what info
           <ul>
             <li>Do provide information on why information is being collected and how it is being used. </li>
             <li>Do use <a href="https://www.plainlanguage.gov/">plain language</a>.</li>
-            <li>Do use people-first language. Emphasize <a href="https://www.cdc.gov/ncbddd/disabilityandhealth/materials/factsheets/fs-communicating-with-people.html">people’s abilities, not their limitations</a>, and choose words that emphasize the need for accessibility, not the disability. For example, use accessible parking, not handicapped parking.</li>
+            <li>Do use people-first language. Emphasize <a href="https://www.cdc.gov/disability-and-health/articles-documents/communicating-with-and-about-people-with-disabilities.html">people’s abilities, not their limitations</a>, and choose words that emphasize the need for accessibility, not the disability. For example, use accessible parking, not handicapped parking.</li>
             <li>Do use <a href="https://content-guide.18f.gov/our-style/inclusive-language/">inclusive language</a>. Choose gender neutral words when possible. Avoid using <em>citizen</em>, unless you are specifically addressing that audience. Choose words that include the broadest appropriate group.</li>
             <li>Do <a href="{{ site.baseurl }}/components/icon-list/">provide a list</a> of what information your user will need to successfully complete the form.</li>
             <li>Do provide an approximate amount of time it will take the user to complete the form.</li>
@@ -122,7 +122,7 @@ Provide clear information on why it is necessary to complete the form, what info
 
 - Build trust with these UX guidelines (March 16, 2019) Retrieved on July 19, 2022, from <https://uxdesign.cc/build-trust-with-these-ux-guidelines-f3d547bb2014>.
 - Building trust with users through open communication and feedback, (June 13, 2019) Retrieved on July 19, 2022, from <https://digital.gov/2019/06/13/building-trust-with-users-through-open-communication-feedback/>.
-- Communicating with and about people with disabilities. (February 1, 2022) Retrieved on July 28, 2022, from <https://www.cdc.gov/ncbddd/disabilityandhealth/materials/factsheets/fs-communicating-with-people.html>.
+- Communicating with and about people with disabilities. (February 1, 2022) Retrieved on July 28, 2022, from <https://www.cdc.gov/disability-and-health/articles-documents/communicating-with-and-about-people-with-disabilities.html>.
 - Design principles, (n.d.) Retrieved on July 21, 2022 from [https://designsystem.digital.gov/design-principles/.]({{ site.baseurl }}/design-principles/)
 - Inclusive design. (n.d.) Retrieved on August 24, 2022, from <https://content-guide.18f.gov/our-style/inclusive-language/>.
 - Trauma-informed computing: towards safer technology experiences for all. Journal article Association for Computing Machinery in Proceedings of the 2022 CHI Conference on Human Factors in Computing Systems (CHI '22). 2022. Retrieved on July 22, 2022, from [https://doi.org/10.1145/3491102.3517475.](https://doi.org/10.1145/3491102.3517475)


### PR DESCRIPTION
# Summary

Updated the link to CDC's "Communicating With and About People with Disabilities" page.

Here is the page content for the affected urls:
[Before](https://web.archive.org/web/20241217214129/https://www.cdc.gov/ncbddd/disabilityandhealth/materials/factsheets/fs-communicating-with-people.html) | [After](https://www.cdc.gov/disability-and-health/articles-documents/communicating-with-and-about-people-with-disabilities.html)

## Related issue

N/A

## Preview link

- [Together - Get involved](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-html-proofer-dec-3/together/get-involved/)
- [Establish trust pattern](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-html-proofer-dec-3/patterns/complete-a-complex-form/establish-trust/)

## Problem statement

HTML-proofer is flagging the following broken links:
```
For the Links > External check, the following failures were found:

* At ./_site/patterns/complete-a-complex-form/establish-trust/index.html:2642:

  External link https://www.cdc.gov/ncbddd/disabilityandhealth/materials/factsheets/fs-communicating-with-people.html failed (status code 404)

* At ./_site/patterns/complete-a-complex-form/establish-trust/index.html:2864:

  External link https://www.cdc.gov/ncbddd/disabilityandhealth/materials/factsheets/fs-communicating-with-people.html failed (status code 404)

* At ./_site/together/get-involved/index.html:462:

  External link https://www.cdc.gov/ncbddd/disabilityandhealth/materials/factsheets/fs-communicating-with-people.html failed (status code 404)


HTML-Proofer found 3 failures!
```

## Testing and review
- Confirm the updated url is a suitable replacement
- Confirm updated links work as expected