### PR TITLE
USWDS-Site: Alert accessibility checklist

### DIFF
--- a/_components/alert/accessibility-tests.md
+++ b/_components/alert/accessibility-tests.md
@@ -1,0 +1,11 @@
+---
+permalink: /components/alert/accessibility-tests/
+layout: accessibility-test
+component:
+ name: Alert
+title: Alert accessibility tests
+category: Components
+lead: Any USWDS alert component should pass these manual accessibility tests.
+changelog:
+ key: 'component-alert-accessibility'
+---

--- a/_components/alert/alert.md
+++ b/_components/alert/alert.md
@@ -12,16 +12,8 @@ redirect_from:
   - /alerts/
   - /components/alerts/
 subnav:
-  - text: Preview
-    href: '#alert-preview'
-  - text: Code
-    href: '#alert-code'
-  - text: Guidance
-    href: '#alert-guidance'
-  - text: Package
-    href: '#alert-package'
-  - text: Latest updates
-    href: '#changelog'
+  - text: Alert accessibility tests
+    href: /components/alert/accessibility-tests/
 title: Alert
 variants:
   - variant: "`.usa-alert--emergency`"

--- a/_data/accessibility-tests/alert.yml
+++ b/_data/accessibility-tests/alert.yml
@@ -35,7 +35,7 @@ test_items:
       When you use a screen reader and navigate to a non-decorative icon inside an alert,
       you hear an appropriate description of the icon.
       If the icon is purely decorative, you should not hear a description.
-    test_status: exception
+    test_status: conditional
     test_type: screen_reader
     version_tested: 3.9.0
     wcag_criterion: 1.1.1

--- a/_data/accessibility-tests/alert.yml
+++ b/_data/accessibility-tests/alert.yml
@@ -30,15 +30,6 @@ test_items:
     version_tested: 3.8.2
     wcag_criterion: 1.4.10
 # Screen reader tests
-  - summary: Icons or graphics provide a text alternative for screen readers when needed.
-    summary_additional: |
-      When you use a screen reader and navigate to a non-decorative icon inside an alert,
-      you hear an appropriate description of the icon.
-      If the icon is purely decorative, you should not hear a description.
-    test_status: conditional
-    test_type: screen_reader
-    version_tested: 3.9.0
-    wcag_criterion: 1.1.1
   - summary: Screen reader announces the alert in logical order.
     summary_additional: |
       When you use a screen reader and navigate to the alert,

--- a/_data/accessibility-tests/alert.yml
+++ b/_data/accessibility-tests/alert.yml
@@ -75,7 +75,7 @@ test_items:
     wcag_criterion: 4.1.2
   - summary: Status alerts are announced by screen readers.
     summary_additional: |
-      When triggered, assertive alert's (ie. emergency status) content and status message is announced to screen reader users.
+      When triggered, assertive alert (i.e., warning status) content and status message is announced to screen reader users.
     test_status: conditional
     test_type: screen_reader
     version_tested: 3.8.2

--- a/_data/accessibility-tests/alert.yml
+++ b/_data/accessibility-tests/alert.yml
@@ -37,7 +37,7 @@ test_items:
       If the icon is purely decorative, you should not hear a description.
     test_status: exception
     test_type: screen_reader
-    version_tested: 3.8.2
+    version_tested: 3.9.0
     wcag_criterion: 1.1.1
   - summary: Screen reader announces the alert in logical order.
     summary_additional: |

--- a/_data/accessibility-tests/alert.yml
+++ b/_data/accessibility-tests/alert.yml
@@ -17,10 +17,21 @@ test_items:
     wcag_criterion: 1.4.3
   - summary: All headings are clear and descriptive.
     summary_additional: When you view the alert, the heading is clear and concise.
-    test_status: pass
+    test_status: conditional
     test_type: general
     version_tested: 3.8.2
     wcag_criterion: 2.4.6
+  - summary: Each alert and alert icon has a consistent meaning across pages.
+    summary_additional: |
+      When you use a screen reader or view the page,
+      the alert icon and layout mean the same thing across all pages where an alert is used.
+      No other alert or element uses the same icon or layout.
+      For example, when you see a "warning" alert, the exclamation point icon and yellow design,
+      supporting ARIA labels, headings and alt text are solely used to show a warning on the page.
+    test_status: conditional
+    test_type: general
+    version_tested: 3.8.2
+    wcag_criterion: 3.2.4
 # Zoom/screen magnification tests
   - summary: Alert remains visible and functional when screen is magnified.
     summary_additional: |
@@ -45,17 +56,6 @@ test_items:
     test_type: screen_reader
     version_tested: 3.8.2
     wcag_criterion: 1.3.6
-  - summary: Each alert and alert icon has a consistent meaning across pages.
-    summary_additional: |
-      When you use a screen reader or view the page,
-      the alert icon and layout mean the same thing across all pages where an alert is used.
-      No other alert or element uses the same icon or layout.
-      For example, when you see a "warning" alert, the exclamation point icon and yellow design,
-      supporting ARIA labels, headings and alt text are solely used to show a warning on the page.
-    test_status: conditional
-    test_type: screen_reader
-    version_tested: 3.8.2
-    wcag_criterion: 3.2.4
   - summary: Screen reader announces role values.
     summary_additional: |
       When you use a screen reader to access an alert, you hear the appropriate role announced.

--- a/_data/accessibility-tests/alert.yml
+++ b/_data/accessibility-tests/alert.yml
@@ -1,0 +1,82 @@
+title: Alert
+component_status: pass
+test_items:
+# General tests
+  - summary: Color alone is not used to convey meaning.
+    summary_additional: When viewing an alert, you never have to rely on color alone to determine part of its meaning.
+    test_status: pass
+    test_type: general
+    version_tested: 3.8.2
+    wcag_criterion: 1.4.1
+  - summary: Alert content meets color contrast requirements.
+    summary_additional: |
+      When you use ANDI color contrast analyzer on the alert, the contrast between the text and background color is at least 4.5:1.
+    test_status: pass
+    test_type: general
+    version_tested: 3.8.2
+    wcag_criterion: 1.4.3
+  - summary: All headings are clear and descriptive.
+    summary_additional: When you view the alert, the heading is clear and concise.
+    test_status: passs
+    test_type: general
+    version_tested: 3.8.2
+    wcag_criterion: 2.4.6
+# Zoom/screen magnification tests
+  - summary: Alert remains visible and functional when screen is magnified.
+    summary_additional: |
+      When you zoom to 400%, you can still read content in the alert and surrounding area easily.
+    test_status: pass
+    test_type: zoom
+    version_tested: 3.8.2
+    wcag_criterion: 1.4.10
+# Screen reader tests
+  - summary: Icons or graphics provide a text alternative for screen readers when needed.
+    summary_additional: |
+      When you use a screen reader and navigate to a non-decorative icon inside an alert,
+      you hear an appropriate description of the icon.
+      If the icon is purely decorative, you should not hear a description.
+    test_status: exception
+    test_type: screen_reader
+    version_tested: 3.8.2
+    wcag_criterion: 1.1.1
+  - summary: Screen reader announces the alert in logical order.
+    summary_additional: |
+      When you use a screen reader and navigate to the alert,
+      the content in the alert follows the visual location on the page.
+    test_status: conditional
+    test_type: screen_reader
+    version_tested: 3.8.2
+    wcag_criterion: 1.3.2
+  - summary: Screen reader announces alert region.
+    summary_additional: |
+      When using a screen reader to access an alert, you hear the role of the region or landmark announced.
+    test_status: conditional
+    test_type: screen_reader
+    version_tested: 3.8.2
+    wcag_criterion: 1.3.6
+  - summary: Each alert and alert icon has a consistent meaning across pages.
+    summary_additional: |
+      When you use a screen reader or view the page,
+      the alert icon and layout mean the same thing across all pages where an alert is used.
+      No other alert or element uses the same icon or layout.
+      For example, when you see a "warning" alert, the exclamation point icon and yellow design,
+      supporting ARIA labels, headings and alt text are solely used to show a warning on the page.
+    test_status: conditional
+    test_type: screen_reader
+    version_tested: 3.8.2
+    wcag_criterion: 3.2.4
+  - summary: Screen reader announces role values.
+    summary_additional: |
+      When you use a screen reader to access an alert, you hear the appropriate role announced.
+      For example, time-sensitive alerts with `role="alert"` will announce "alert".
+    test_status: conditional
+    test_type: screen_reader
+    version_tested: 3.8.2
+    wcag_criterion: 4.1.2
+  - summary: Status alerts are announced by screen readers.
+    summary_additional: |
+      When triggered, assertive alert's (ie. emergency status) content and status message is announced to screen reader users.
+    test_status: conditional
+    test_type: screen_reader
+    version_tested: 3.8.2
+    wcag_criterion: 4.1.3

--- a/_data/accessibility-tests/alert.yml
+++ b/_data/accessibility-tests/alert.yml
@@ -17,7 +17,7 @@ test_items:
     wcag_criterion: 1.4.3
   - summary: All headings are clear and descriptive.
     summary_additional: When you view the alert, the heading is clear and concise.
-    test_status: passs
+    test_status: pass
     test_type: general
     version_tested: 3.8.2
     wcag_criterion: 2.4.6

--- a/_data/changelogs/component-alert-accessibility.yml
+++ b/_data/changelogs/component-alert-accessibility.yml
@@ -1,0 +1,9 @@
+title: Alert accessibility tests
+type: component
+changelogURL:
+items:
+  - date: NNNN-NN-NN
+    summary: Added accessibility tests page.
+    affectsGuidance: true
+    githubPr: 3048
+    githubRepo: uswds-site

--- a/_data/changelogs/component-alert-accessibility.yml
+++ b/_data/changelogs/component-alert-accessibility.yml
@@ -2,7 +2,7 @@ title: Alert accessibility tests
 type: component
 changelogURL:
 items:
-  - date: NNNN-NN-NN
+  - date: 2025-01-14
     summary: Added accessibility tests page.
     affectsGuidance: true
     githubPr: 3048

--- a/_data/changelogs/component-alert.yml
+++ b/_data/changelogs/component-alert.yml
@@ -2,6 +2,11 @@ title: Alert
 type: component
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Added WCAG compliance tag and accessibility test status section.
+    affectsGuidance: true
+    githubPr: 3048
+    githubRepo: uswds-site
   - date: 2024-10-04
     summary: |
       Fixed a bug that caused `$theme-site-margins-width` to unexpectedly change the alignment inside alert and site alert components.

--- a/_data/changelogs/component-alert.yml
+++ b/_data/changelogs/component-alert.yml
@@ -2,7 +2,7 @@ title: Alert
 type: component
 changelogURL:
 items:
-  - date: NNNN-NN-NN
+  - date: 2025-01-14
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 3048


### PR DESCRIPTION
# Summary

Added accessibility test page for alert component.

> [!Important]
> We need to update changelog dates before merge

## Related issue

Closes #2906

## Preview link
- [Alert component page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-alert-checklist/components/alert/)
- [Alert accessibility page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-alert-checklist/components/alert/accessibility-tests/)

## Testing and review
Follow these steps:

1. Confirm that both the main component page and the accessibility tests page have the correct compliance tag at the top.
2. Confirm that the main component page links to the accessibility tests page in the side navigation.
3. Confirm that the main component page links to the accessibility tests page from the accessibility guidance section.
4. Confirm that the main component page shows the accessibility tests summary.
5. Check that accessibility tests page provides the correct counts for each test status type.
6. Confirm the test checklist summaries and data are accurate.
7. Confirm no visual issues.
8. Confirm there is an appropriate changelog entry on both the main component page and the accessibility tests page.
