### PR TITLE
USWDS-Site: Site alert accessibility checklist

### DIFF
--- a/_components/site-alert/accessibility-tests.md
+++ b/_components/site-alert/accessibility-tests.md
@@ -1,0 +1,11 @@
+---
+permalink: /components/site-alert/accessibility-tests/
+layout: accessibility-test
+component:
+ name: Site alert
+title: Site alert accessibility tests
+category: Components
+lead: Any USWDS site alert component should pass these manual accessibility tests.
+changelog:
+ key: 'component-site-alert-accessibility'
+---

--- a/_components/site-alert/accessibility-tests.md
+++ b/_components/site-alert/accessibility-tests.md
@@ -2,7 +2,7 @@
 permalink: /components/site-alert/accessibility-tests/
 layout: accessibility-test
 component:
- name: Site alert
+ name: site alert
 title: Site alert accessibility tests
 category: Components
 lead: Any USWDS site alert component should pass these manual accessibility tests.

--- a/_components/site-alert/site-alert.md
+++ b/_components/site-alert/site-alert.md
@@ -12,16 +12,8 @@ type: component
 title: Site alert
 lead: A site alert communicates urgent sitewide information.
 subnav:
-- text: Preview
-  href: '#site-alert-preview'
-- text: Code
-  href: '#site-alert-code'
-- text: Guidance
-  href: '#site-alert-guidance'
-- text: Package
-  href: '#site-alert-package'
-- text: Latest updates
-  href: '#changelog'
+- text: Site alert accessibility tests
+  href: /components/site-alert/accessibility-tests/
 tags:
   - warning
   - bar

--- a/_data/accessibility-tests/site-alert.yml
+++ b/_data/accessibility-tests/site-alert.yml
@@ -30,15 +30,6 @@ test_items:
     version_tested: 3.8.1
     wcag_criterion: 1.4.10
 # Screen reader tests
-  - summary: Icons or graphics provide a text alternative for screen readers when needed.
-    summary_additional: |
-      When you use a screen reader and navigate to a non-decorative icon inside a site alert,
-      you hear an appropriate description of the icon.
-      If the icon is purely decorative, you should not hear a description.
-    test_status: conditional
-    test_type: screen_reader
-    version_tested: 3.9.0
-    wcag_criterion: 1.1.1
   - summary: Screen reader announces the site alert in logical order.
     summary_additional: |
       When you use a screen reader and reach the site alert,

--- a/_data/accessibility-tests/site-alert.yml
+++ b/_data/accessibility-tests/site-alert.yml
@@ -1,0 +1,73 @@
+title: Site alert
+component_status: pass
+test_items:
+# General tests
+  - summary: Color alone is not used to convey meaning.
+    summary_additional: When viewing a site alert, you never have to rely on color alone to determine part of its meaning.
+    test_status: pass
+    test_type: general
+    version_tested: 3.8.1
+    wcag_criterion: 1.4.1
+  - summary: Site alert content meets color contrast requirements.
+    summary_additional: |
+      When you use ANDI color contrast analyzer on the alert, the contrast between the text and background color is at least 4.5:1.
+    test_status: pass
+    test_type: general
+    version_tested: 3.8.1
+    wcag_criterion: 1.4.3
+  - summary: All headings are clear and descriptive.
+    summary_additional: When you view the site alert, the heading is clear and concise.
+    test_status: pass
+    test_type: general
+    version_tested: 3.8.1
+    wcag_criterion: 2.4.6
+# Zoom/screen magnification tests
+  - summary: Site alert remains visible and functional when screen is magnified.
+    summary_additional: |
+      When you zoom to 400%, you can still read content in the alert and surrounding area easily.
+    test_status: pass
+    test_type: zoom
+    version_tested: 3.8.1
+    wcag_criterion: 1.4.10
+# Screen reader tests
+  - summary: Icons or graphics provide a text alternative for screen readers when needed.
+    summary_additional: |
+      When you use a screen reader and navigate to a non-decorative icon inside a site alert,
+      you hear an appropriate description of the icon.
+      If the icon is purely decorative, you should not hear a description.
+    test_status: exception
+    test_type: screen_reader
+    version_tested: 3.9.0
+    wcag_criterion: 1.1.1
+  - summary: Screen reader announces the site alert in logical order.
+    summary_additional: |
+      When you use a screen reader and reach the site alert,
+      the content in the alert follows the visual location on the page and is not announced out of order.
+      Note: By default the site alert should be the first thing heard and coded with `role="alert" or `aria-live="assertive"`.
+    test_status: conditional
+    test_type: screen_reader
+    version_tested: 3.8.1
+    wcag_criterion: 1.3.2
+  - summary: Screen reader announces site alert region.
+    summary_additional: |
+      When using a screen reader to access a site alert, you hear the role of the region or landmark announced.
+    test_status: conditional
+    test_type: screen_reader
+    version_tested: 3.8.1
+    wcag_criterion: 1.3.6
+  - summary: The site alert icon has a consistent meaning across pages.
+    summary_additional: |
+      When you use a screen reader or view the page,
+      the site alert's icon and layout convey similar meaning across all pages where its used.
+    test_status: conditional
+    test_type: screen_reader
+    version_tested: 3.8.1
+    wcag_criterion: 3.2.4
+  - summary: Screen reader announces role values.
+    summary_additional: |
+      When you use a screen reader to access a site alert, you hear the appropriate role announced.
+      For example, time-sensitive alerts with `role="alert"` will announce "alert".
+    test_status: conditional
+    test_type: screen_reader
+    version_tested: 3.8.1
+    wcag_criterion: 4.1.2

--- a/_data/accessibility-tests/site-alert.yml
+++ b/_data/accessibility-tests/site-alert.yml
@@ -43,7 +43,7 @@ test_items:
     summary_additional: |
       When you use a screen reader and reach the site alert,
       the content in the alert follows the visual location on the page and is not announced out of order.
-      Note: By default the site alert should be the first thing heard and coded with `role="alert" or `aria-live="assertive"`.
+      Note: By default the site alert should be the first thing heard and coded with `role="alert"` or `aria-live="assertive"`.
     test_status: conditional
     test_type: screen_reader
     version_tested: 3.8.1

--- a/_data/accessibility-tests/site-alert.yml
+++ b/_data/accessibility-tests/site-alert.yml
@@ -17,10 +17,18 @@ test_items:
     wcag_criterion: 1.4.3
   - summary: All headings are clear and descriptive.
     summary_additional: When you view the site alert, the heading is clear and concise.
-    test_status: pass
+    test_status: conditional
     test_type: general
     version_tested: 3.8.1
     wcag_criterion: 2.4.6
+  - summary: The site alert icon has a consistent meaning across pages.
+    summary_additional: |
+      When you use a screen reader or view the page,
+      the site alert's icon and layout convey similar meaning across all pages where its used.
+    test_status: conditional
+    test_type: general
+    version_tested: 3.8.1
+    wcag_criterion: 3.2.4
 # Zoom/screen magnification tests
   - summary: Site alert remains visible and functional when screen is magnified.
     summary_additional: |
@@ -46,14 +54,6 @@ test_items:
     test_type: screen_reader
     version_tested: 3.8.1
     wcag_criterion: 1.3.6
-  - summary: The site alert icon has a consistent meaning across pages.
-    summary_additional: |
-      When you use a screen reader or view the page,
-      the site alert's icon and layout convey similar meaning across all pages where its used.
-    test_status: conditional
-    test_type: screen_reader
-    version_tested: 3.8.1
-    wcag_criterion: 3.2.4
   - summary: Screen reader announces role values.
     summary_additional: |
       When you use a screen reader to access a site alert, you hear the appropriate role announced.

--- a/_data/accessibility-tests/site-alert.yml
+++ b/_data/accessibility-tests/site-alert.yml
@@ -35,7 +35,7 @@ test_items:
       When you use a screen reader and navigate to a non-decorative icon inside a site alert,
       you hear an appropriate description of the icon.
       If the icon is purely decorative, you should not hear a description.
-    test_status: exception
+    test_status: conditional
     test_type: screen_reader
     version_tested: 3.9.0
     wcag_criterion: 1.1.1

--- a/_data/changelogs/component-site-alert-accessibility.yml
+++ b/_data/changelogs/component-site-alert-accessibility.yml
@@ -2,7 +2,7 @@ title: Site alert accessibility tests
 type: component
 changelogURL:
 items:
-  - date: NNNN-NN-NN
+  - date: 2025-01-14
     summary: Added accessibility tests page.
     affectsGuidance: true
     githubPr: 3049

--- a/_data/changelogs/component-site-alert-accessibility.yml
+++ b/_data/changelogs/component-site-alert-accessibility.yml
@@ -1,0 +1,9 @@
+title: Site alert accessibility tests
+type: component
+changelogURL:
+items:
+  - date: NNNN-NN-NN
+    summary: Added accessibility tests page.
+    affectsGuidance: true
+    githubPr: 3049
+    githubRepo: uswds-site

--- a/_data/changelogs/component-site-alert.yml
+++ b/_data/changelogs/component-site-alert.yml
@@ -2,7 +2,7 @@ title: Site alert
 type: component
 changelogURL:
 items:
-  - date: NNNN-NN-NN
+  - date: 2025-01-14
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 3049

--- a/_data/changelogs/component-site-alert.yml
+++ b/_data/changelogs/component-site-alert.yml
@@ -2,6 +2,11 @@ title: Site alert
 type: component
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Added WCAG compliance tag and accessibility test status section.
+    affectsGuidance: true
+    githubPr: 3049
+    githubRepo: uswds-site
   - date: 2024-10-04
     summary: |
       Fixed a bug that caused `$theme-site-margins-width` to unexpectedly adjust the alignment inside the alert and site alert components.


### PR DESCRIPTION
# Summary

Added accessibility test page for site alert component.

> [!Important]
> We need to update changelog dates before merge

## Related issue

Closes #2909

## Preview link
- [Site alert page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-site-alert-checklist/components/site-alert/)
- [Site alert accessibility page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-site-alert-checklist/components/site-alert/accessibility-tests/)


## Testing and review
Follow these steps:

1. Confirm that both the main component page and the accessibility tests page have the correct compliance tag at the top.
2. Confirm that the main component page links to the accessibility tests page in the side navigation.
3. Confirm that the main component page links to the accessibility tests page from the accessibility guidance section.
4. Confirm that the main component page shows the accessibility tests summary.
5. Check that accessibility tests page provides the correct counts for each test status type.
6. Confirm the test checklist summaries and data are accurate.
7. Confirm no visual issues.
8. Confirm there is an appropriate changelog entry on both the main component page and the accessibility tests page.
