### PR TITLE
USWDS-Site: Update snyk ignore

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -3523,8 +3523,8 @@ ignore:
   SNYK-JS-INFLIGHT-6095116:
     - '*':
         reason: No available upgrade or patch
-        expires: 2025-01-08T18:16:33.491Z
-        created: 2024-12-09T18:16:33.532Z
+        expires: 2025-02-07T19:58:46.795Z
+        created: 2025-01-08T19:58:46.829Z
   SNYK-JS-BRACES-6838727:
     - '*':
         reason: No available upgrade or patch


### PR DESCRIPTION
# Summary
Updated snyk ignore file to resolve build error

## Problem statement

`npx snyk` test is throwing the following error:
```
Issues with no direct upgrade or patch:
  ✗ Missing Release of Resource after Effective Lifetime [Medium Severity][https://security.snyk.io/vuln/SNYK-JS-INFLIGHT-6095116] in inflight@1.0.6
    introduced by @uswds/compile@1.2.0 > del@6.1.1 > rimraf@3.0.2 > glob@7.2.3 > inflight@1.0.6
  No upgrade or patch available
```

## Solution

Updated snyk ignore. Ran the following in the command line:
```
npx snyk ignore --id="SNYK-JS-INFLIGHT-6095116" --reason="No available upgrade or patch" 
```

## Testing and review

To test, run `npx snyk` test and check for errors.

## Reference
[Ignoring Snyk Alerts](https://docs.google.com/document/d/1RX6uYky-P37jysuBy6LEBhuMCQlMAvHU0mRJUow345o/edit#heading=h.fa3sv1ray42g)