### PR TITLE
USWDS-Site: Add changelog for date picker translations [#5679]

### DIFF
--- a/_data/changelogs/component-date-picker.yml
+++ b/_data/changelogs/component-date-picker.yml
@@ -2,6 +2,13 @@ title: Date picker
 type: component
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Added translations for calendar labels.
+    summaryAdditional: The calendar will now automatically build translated labels based on the document's `lang` attribute.
+    affectsJavascript: true
+    githubPr: 5679
+    githubRepo: uswds
+    versionUswds: N.N.N
   - date: 2025-01-14
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true

--- a/_data/changelogs/component-date-picker.yml
+++ b/_data/changelogs/component-date-picker.yml
@@ -3,7 +3,7 @@ type: component
 changelogURL:
 items:
   - date: NNNN-NN-NN
-    summary: Added translations for calendar labels.
+    summary: Enabled native JavaScript translation for calendar labels.
     summaryAdditional: The calendar now uses the `Date.toLocaleString` API to automatically build translated labels based on the document's `lang` attribute.
     affectsJavascript: true
     githubPr: 5679

--- a/_data/changelogs/component-date-picker.yml
+++ b/_data/changelogs/component-date-picker.yml
@@ -4,7 +4,7 @@ changelogURL:
 items:
   - date: NNNN-NN-NN
     summary: Added translations for calendar labels.
-    summaryAdditional: The calendar will now automatically build translated labels based on the document's `lang` attribute.
+    summaryAdditional: The calendar now uses the `Date.toLocaleString` API to automatically build translated labels based on the document's `lang` attribute.
     affectsJavascript: true
     githubPr: 5679
     githubRepo: uswds


### PR DESCRIPTION
# Summary

Add a changelog for PR uswds/uswds#5679

>[!important]
> We need to update the changelog dates before merge.

## Preview link

[Date picker changelog](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-changelog-5679/components/date-picker/#latest-updates)
