### PR TITLE
Add a consolidated What's New changelog view

### DIFF
--- a/_data/changelogs/about-community.yml
+++ b/_data/changelogs/about-community.yml
@@ -3,6 +3,7 @@ type: documentation
 changelogURL:
 items:
   - date: 2022-10-20
+    page: Community
     summary: Updated community conduct section.
     summaryAdditional:
     isBreaking:
@@ -16,6 +17,7 @@ items:
     githubRepo: uswds-site
     versionUswds:
   - date: 2022-08-29
+    page: Community
     summary: Removed Ammie Farraj Feijoo from the community managers section.
     summaryAdditional:
     isBreaking:

--- a/_data/changelogs/about-contribute.yml
+++ b/_data/changelogs/about-contribute.yml
@@ -3,11 +3,13 @@ type: documentation
 changelogURL:
 items:
   - date: 2024-02-15
+    page: Contribute
     summary: Added USWDS component proposal information.
     affectsGuidance: true
     githubPr: 2491
     githubRepo: uswds-site
   - date: 2022-06-16
+    page: Contribute
     summary: Added contribute page.
     summaryAdditional:
     isBreaking:

--- a/_data/changelogs/about-download.yml
+++ b/_data/changelogs/about-download.yml
@@ -3,6 +3,7 @@ type: documentation
 changelogURL:
 items:
   - date: 2024-05-15
+    page: Download
     summary: Added note about incorrect package dates in downloadable USWDS package.
     githubPr: 2621
     githubRepo: uswds-site

--- a/_data/changelogs/about-key-benefits.yml
+++ b/_data/changelogs/about-key-benefits.yml
@@ -3,6 +3,7 @@ type: documentation
 changelogURL:
 items:
   - date: 2021-04-14
+    page: Key benefits
     summary: Added key benefits page.
     summaryAdditional:
     isBreaking:

--- a/_data/changelogs/about-monthly-calls.yml
+++ b/_data/changelogs/about-monthly-calls.yml
@@ -3,54 +3,67 @@ type: documentation
 changelogURL:
 items:
   - date: 2025-01-13
+    page: Monthly Calls
     summary: Added December 2024 monthly call. Added November monthly call video.
     githubPr: 3044
     githubRepo: uswds-site
   - date: 2024-12-13
+    page: Monthly Calls
     summary: Added November 2024 monthly call.
     githubPr: 3015
     githubRepo: uswds-site
   - date: 2024-11-04
+    page: Monthly Calls
     summary: Added September and October 2024 monthly calls.
     githubPr: 2934
     githubRepo: uswds-site
   - date: 2024-10-23
+    page: Monthly Calls
     summary: Added video for August 2024 monthly call.
     githubPr: 2873
     githubRepo: uswds-site
   - date: 2024-09-16
+    page: Monthly Calls
     summary: Added August 2024 monthly call.
     githubPr: 2827
     githubRepo: uswds-site
   - date: 2024-07-26
+    page: Monthly Calls
     summary: Added June 2024 monthly call.
     githubPr: 2747
     githubRepo: uswds-site
   - date: 2024-06-14
+    page: Monthly Calls
     summary: Added May 2024 monthly call.
     githubPr: 2708
     githubRepo: uswds-site
   - date: 2024-05-15
+    page: Monthly Calls
     summary: Added April 2024 monthly call.
     githubPr: 2671
     githubRepo: uswds-site
   - date: 2024-04-26
+    page: Monthly Calls
     summary: Added March 2024 monthly call.
     githubPr: 2631
     githubRepo: uswds-site
   - date: 2024-04-26
+    page: Monthly Calls
     summary: Added February 2024 monthly call.
     githubPr: 2576
     githubRepo: uswds-site
   - date: 2024-02-09
+    page: Monthly Calls
     summary: Added January 2024 monthly call.
     githubPr: 2465
     githubRepo: uswds-site
   - date: 2023-12-11
+    page: Monthly Calls
     summary: Added November 2023 monthly call.
     githubPr: 2393
     githubRepo: uswds-site
   - date: 2023-11-06
+    page: Monthly Calls
     summary: Added monthly calls page.
     githubPr: 2345
     githubRepo: uswds-site

--- a/_data/changelogs/about-policies.yml
+++ b/_data/changelogs/about-policies.yml
@@ -3,11 +3,13 @@ type: documentation
 changelogURL:
 items:
   - date: 2023-12-01
+    page: Website policies
     summary: Removed open government link.
     affectsGuidance: true
     githubPr: 2384
     githubRepo: uswds-site
   - date: 2021-10-19
+    page: Website policies
     summary: Added policies page.
     summaryAdditional:
     isBreaking:

--- a/_data/changelogs/about-research-recruitment-federal.yml
+++ b/_data/changelogs/about-research-recruitment-federal.yml
@@ -3,6 +3,7 @@ type: documentation
 changelogURL:
 items:
   - date: 2024-02-24
+    page: Recruitment for Federal
     summary: Page created.
     affectsGuidance: true
     githubPr: 2504

--- a/_data/changelogs/about-research-recruitment-public.yml
+++ b/_data/changelogs/about-research-recruitment-public.yml
@@ -3,6 +3,7 @@ type: documentation
 changelogURL:
 items:
   - date: 2024-01-10
+    page: Recruitment for general public
     summary: Page created.
     affectsGuidance: true
     githubPr: 2424

--- a/_data/changelogs/about-research.yml
+++ b/_data/changelogs/about-research.yml
@@ -3,21 +3,25 @@ type: documentation
 changelogURL:
 items:
   - date: 2025-01-23
+    page: Research
     summary: Removed Together report link.
     summaryAdditional: Removed content related to the January 20, 2025 Executive Order, \"Ending Radical And Wasteful Government DEI Programs And Preferencing\".
     githubRepo: uswds-site
     githubPr: 3078
   - date: 2024-03-18
+    page: Research
     summary: Added link to the Recruitment for Feds page
     affectsGuidance: true
     githubPr: 2527
     githubRepo: uswds-site
   - date: 2023-11-15
+    page: Research
     summary: Replaced page content.
     affectsGuidance: true
     githubPr: 2355
     githubRepo: uswds-site
   - date: 2023-07-14
+    page: Research
     summary: Removed broken link.
     affectsGuidance: true
     githubPr: 2185

--- a/_data/changelogs/about-roadmap.yml
+++ b/_data/changelogs/about-roadmap.yml
@@ -3,6 +3,7 @@ type: documentation
 changelogURL:
 items:
   - date: 2022-06-16
+    page: Product roadmap
     summary: Simplified content and added link to the public roadmap on GitHub.
     summaryAdditional:
     isBreaking:

--- a/_data/changelogs/about-security.yml
+++ b/_data/changelogs/about-security.yml
@@ -3,6 +3,7 @@ type: documentation
 changelogURL:
 items:
   - date: 2021-11-05
+    page: Security
     summary: Added security updates section.
     summaryAdditional:
     isBreaking:

--- a/_data/changelogs/about-whats-new.yml
+++ b/_data/changelogs/about-whats-new.yml
@@ -3,11 +3,13 @@ type: documentation
 changelogURL:
 items:
   - date: 2024-11-20
+    page: "What's new"
     summary: Combined "What's new" and "News and updates" pages.
     affectsGuidance: true
     githubPr: 2958
     githubRepo: uswds-site
   - date: 2024-02-26
+    page: "What's new"
     summary: Added release notes section.
     affectsGuidance: true
     githubPr: 2318

--- a/_data/changelogs/component-accordion-accessibility.yml
+++ b/_data/changelogs/component-accordion-accessibility.yml
@@ -3,12 +3,14 @@ type: component
 changelogURL:
 items:
   - date: 2024-03-29
+    page: Accordion accessibility tests
     summary: Updated the test status for announcing the "collapsed" and "expanded" states from "Passed with exceptions" to "Passed".
     summaryAdditional: We determined that the flagged issue was isolated to our documentation site and fixed the issue.
     affectsGuidance: true
     githubPr: 2557
     githubRepo: uswds-site
   - date: 2024-01-17
+    page: Accordion accessibility tests
     summary: Added accessibility tests page.
     affectsGuidance: true
     githubPr: 2138

--- a/_data/changelogs/component-accordion.yml
+++ b/_data/changelogs/component-accordion.yml
@@ -3,16 +3,19 @@ type: component
 changelogURL:
 items:
   - date: 2024-01-17
+    page: Accordion
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 2138
     githubRepo: uswds-site
   - date: 2023-11-20
+    page: Accordion
     summary: Added `usa-icon` to the dependency list and removed `usa-list`.
     affectsGuidance: true
     githubPr: 2149
     githubRepo: uswds-site
   - date: 2023-06-09
+    page: Accordion
     summary: Added two new settings to customize accordion background colors.
     summaryAdditional: You can now customize accordion button and content background colors with `$theme-accordion-button-background-color` and `$theme-accordion-background-color`.
     isBreaking: false
@@ -24,6 +27,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-06-09
+    page: Accordion
     summary: Adjusted forced colors mode styles to ensure visibility and increase consistency.
     summaryAdditional: Forced colors mode styles will now override the background color and display the button outline. The open/close icons now dynamically adjust to `ButtonText` colors.
     affectsStyles: true
@@ -32,6 +36,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2022-08-05
+    page: Accordion
     summary: Added `type="button"` to all non-form buttons to prevent default submit behaviors.
     summaryAdditional: This allowed us to remove `preventDefault()` from the relevant component JavaScript.
     isBreaking: true
@@ -41,12 +46,14 @@ items:
     githubRepo: uswds
     versionUswds: 3.1.0
   - date: 2022-08-01
+    page: Accordion
     summary: Updated documentation to reference the correct multi-select attribute.
     summaryAdditional: The attribute was updated from `aria-multiselectable="true"` to `data-allow-multiple`.
     affectsGuidance: true
     githubPr: 1718
     githubRepo: uswds-site
   - date: 2022-04-28
+    page: Accordion
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true
@@ -56,6 +63,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.0
   - date: 2021-03-17
+    page: Accordion
     summary: Restored missing white icons.
     summaryAdditional: Restored `add--white` and `remove--white` icons.
     affectsAssets: true
@@ -63,6 +71,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.11.1
   - date: 2021-03-02
+    page: Accordion
     summary: Introduced white `add`, `remove`, and `expand_more` icons.
     summaryAdditional:
     isBreaking: false

--- a/_data/changelogs/component-alert-accessibility.yml
+++ b/_data/changelogs/component-alert-accessibility.yml
@@ -3,6 +3,7 @@ type: component
 changelogURL:
 items:
   - date: 2025-01-14
+    page: Alert accessibility tests
     summary: Added accessibility tests page.
     affectsGuidance: true
     githubPr: 3048

--- a/_data/changelogs/component-alert.yml
+++ b/_data/changelogs/component-alert.yml
@@ -3,11 +3,13 @@ type: component
 changelogURL:
 items:
   - date: 2025-01-14
+    page: Alert
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 3048
     githubRepo: uswds-site
   - date: 2024-10-04
+    page: Alert
     summary: |
       Fixed a bug that caused `$theme-site-margins-width` to unexpectedly change the alignment inside alert and site alert components.
     summaryAdditional: |
@@ -19,22 +21,26 @@ items:
     githubRepo: uswds
     versionUswds: 3.9.0
   - date: 2024-03-27
+    page: Alert
     summary: Added a note about USWDS developing dismissible alerts.
     affectsGuidance: true
     githubPr: 2563
     githubRepo: uswds-site
   - date: 2023-11-20
+    page: Alert
     summary: Added documentation for the `usa-alert--emergency` variant.
     affectsGuidance: true
     githubPr: 2149
     githubRepo: uswds-site
   - date: 2023-06-09
+    page: Alert
     summary: Removed redundant and invalid height declaration.
     affectsStyles: true
     githubPr: 5187
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-03-09
+    page: Alert
     summary: Updated padding settings to accept any valid spacing token.
     summaryAdditional:
     affectsStyles: true
@@ -42,6 +48,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.4.0
   - date: 2022-10-19
+    page: Alert
     summary: Updated the alignment of alert content to visually match banner content.
     summaryAdditional: The site alert component was also updated.
     affectsStyles: true
@@ -49,12 +56,14 @@ items:
     githubRepo: uswds
     versionUswds: 3.2.0
   - date: 2022-09-26
+    page: Alert
     summary: Updated instructions for using the ARIA `role` attribute.
     affectsAccessibility: true
     affectsGuidance: true
     githubPr: 1770
     githubRepo: uswds-site
   - date: 2022-04-28
+    page: Alert
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true
@@ -64,6 +73,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.0
   - date: 2021-03-17
+    page: Alert
     summary: Restored missing white icons.
     summaryAdditional: Restored `error--white`, `info--white`, and `warning--white` icons.
     affectsAssets: true
@@ -71,6 +81,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.11.1
   - date: 2021-03-17
+    page: Alert
     summary: Provided better support for color icons that adapt to theme settings.
     summaryAdditional: Now the color of the alert icon will update automatically to adapt to the alert background, or to the color of the alert text.
     affectsAccessibility:
@@ -80,6 +91,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.11.0
   - date: 2021-03-17
+    page: Alert
     summary: Added the `$theme-alert-padding-y` setting.
     summaryAdditional:
     affectsAccessibility:

--- a/_data/changelogs/component-banner-accessibility.yml
+++ b/_data/changelogs/component-banner-accessibility.yml
@@ -3,6 +3,7 @@ type: component
 changelogURL:
 items:
   - date: 2024-06-07
+    page: Banner accessibility tests
     summary: Added accessibility tests page.
     summaryAdditional:
     affectsGuidance: true

--- a/_data/changelogs/component-banner.yml
+++ b/_data/changelogs/component-banner.yml
@@ -3,11 +3,13 @@ type: component
 changelogURL:
 items:
   - date: 2024-06-07
+    page: Banner
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 2687
     githubRepo: uswds-site
   - date: 2023-11-30
+    page: Banner
     summary: Fixed a bug causing component code example ID's and relevant aria attributes to display incorrectly.
     summaryAdditional: Now, example ID's match what's found in the USWDS repo and are more succinct.
     isBreaking: true
@@ -15,17 +17,20 @@ items:
     githubPr: 2312
     githubRepo: uswds-site
   - date: 2023-11-20
+    page: Banner
     summary: Updated the text in the `aria-label` documentation to match the component markup.
     affectsGuidance: true
     githubPr: 2149
     githubRepo: uswds-site
   - date: 2023-11-20
+    page: Banner
     summary: Removed `usa-layout-grid` from the list of dependencies.
     affectsGuidance: true
     githubPr: 2149
     githubRepo: uswds-site
     versionUswds:
   - date: 2023-11-09
+    page: Banner
     summary: Updated the banner component so that it initializes without requiring import of the `usa-accordion` package.
     isBreaking: false
     affectsJavascript: true
@@ -33,6 +38,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.7.0
   - date: 2023-11-09
+    page: Banner
     summary: Optimized the `us_flag_small.png` icon and added a vector `us_flag.svg`icon.
     summaryAdditional:
     affectsAssets: true
@@ -40,6 +46,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.7.0
   - date: 2023-09-29
+    page: Banner
     summary: Improved horizontal alignment in `icon-dot-gov.svg`.
     summaryAdditional:
     affectsAssets: true
@@ -47,6 +54,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.6.1
   - date: 2023-03-09
+    page: Banner
     summary: Improved display of focus outline on mobile.
     summaryAdditional: Now the focus outline is visible all around the banner on mobile devices.
     affectsStyles: true
@@ -54,6 +62,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.4.0
   - date: 2023-03-09
+    page: Banner
     summary: Updated padding settings to accept any valid spacing token.
     summaryAdditional:
     affectsStyles: true
@@ -61,6 +70,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.4.0
   - date: 2023-03-09
+    page: Banner
     summary: Removed grid dependency from Banner.
     summaryAdditional: Banner no longer needs the `usa-layout-grid` package resulting in a much smaller package size.
     affectsStyles: true
@@ -68,6 +78,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.4.0
   - date: 2022-10-09
+    page: Banner
     summary: Updated the aria-label in English versions of banner.
     summaryAdditional: When read out on a screen reader, the statement "An official website of the United States government" can sound like "Unofficial website of the United States government". To minimize confusion, we updated the component's `aria-label` to instead read "Official website of the United States government".
     affectsAccessibility: true
@@ -76,6 +87,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.2.0
   - date: 2022-10-09
+    page: Banner
     summary: Added aria-hidden attribute to the flag icon.
     summaryAdditional: The flag icon in the banner component is purely decorative and we can safely remove it from the screen reader readout.
     affectsAccessibility: true
@@ -84,6 +96,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.2.0
   - date: 2022-10-09
+    page: Banner
     summary: Simplified ARIA label in the lock SVG.
     summaryAdditional: We simplified the way we're using `aria-labelledby` in the lock SVG to streamline screen reader vocalization.
     affectsAccessibility: true
@@ -92,6 +105,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.2.0
   - date: 2022-08-05
+    page: Banner
     summary: Added `type="button"` to all non-form buttons to prevent default submit behaviors.
     summaryAdditional: This allowed us to remove `preventDefault()` from the relevant component JavaScript.
     isBreaking: true
@@ -101,6 +115,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.1.0
   - date: 2022-06-17
+    page: Banner
     summary: Updated uswds-init.js to better suppress flashing content.
     summaryAdditional: We updated the `uswds-init` script's event listener to target `window` from `document`. This assures that the page's JavaScript is fully loaded before we remove the `loadingClass` that suppresses the open banner. The banner should no longer flash open.
     affectsAssets: true
@@ -109,12 +124,14 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.2
   - date: 2022-06-17
+    page: Banner
     summary: Updated flag icon to be high resolution.
     affectsAssets: true
     githubPr: 4792
     githubRepo: uswds
     versionUswds: 3.0.2
   - date: 2022-04-28
+    page: Banner
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true
@@ -124,6 +141,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.0
   - date: 2022-04-11
+    page: Banner
     summary: Added support for forced colors mode.
     summaryAdditional: All our components now support proper display when users have a forced colors mode set in their operating system.
     affectsAccessibility: true
@@ -132,11 +150,13 @@ items:
     githubRepo: uswds
     versionUswds: 2.13.3
   - date: 2021-03-02
+    page: Banner
     summary: Updated guidance to identify banner as a core component.
     affectsGuidance: true
     githubPr: 1136
     githubRepo: uswds-site
   - date: 2020-12-17
+    page: Banner
     summary: Introduced uswds-init.js to prevent banner flash.
     summaryAdditional: When added to the `head` of your document, this script prevents the banner from flashing its content on page load and shifting content.
     affectsAssets: true
@@ -145,6 +165,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.10.0
   - date: 2020-12-17
+    page: Banner
     summary: Improved the accessibility of decorative images in the banner.
     summaryAdditional: We modified the banner to properly mark up SVG files used as decorative images. Now all decorative images are hidden from screen readers, and all SVGs are more resilient to browser bugs. See the banner page for the complete, correct markup, and see the pull request for more context on the changes.
     affectsAccessibility: true
@@ -153,6 +174,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.10.0
   - date: 2020-07-09
+    page: Banner
     summary: Updated banner copy.
     summaryAdditional: Updated the expanded text in the banner to emphasize that trustworthiness is a combination of an official TLD and a secure HTTPS connection.
     affectsContent: true
@@ -160,6 +182,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.8.0
   - date: 2020-07-09
+    page: Banner
     summary: Added Spanish versions.
     summaryAdditional: Included approved Spanish versions of the banner text.
     affectsContent: true
@@ -167,6 +190,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.8.0
   - date: 2020-07-09
+    page: Banner
     summary: Updated banner settings.
     summaryAdditional: Allowed users to change background color, link color, and link reverse colors. This update requires the use of Autoprefixer.
     isBreaking: true
@@ -175,6 +199,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.8.0
   - date: 2020-06-17
+    page: Banner
     summary: Added `role="img"` to SVGs.
     affectsAccessibility: true
     affectsAssets: true
@@ -182,6 +207,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.7.1
   - date: 2020-05-11
+    page: Banner
     summary: Improved display of the "Here's how you know" link in the gov banner.
     summaryAdditional: Now there's no distracting change to the length of the underline on hover.
     affectsStyles: true

--- a/_data/changelogs/component-breadcrumb-accessibility.yml
+++ b/_data/changelogs/component-breadcrumb-accessibility.yml
@@ -3,6 +3,7 @@ type: component
 changelogURL:
 items:
   - date: 2024-10-16
+    page: Breadcrumb accessibility tests
     summary: Added accessibility tests page.
     affectsGuidance: true
     githubPr: 2853

--- a/_data/changelogs/component-breadcrumb.yml
+++ b/_data/changelogs/component-breadcrumb.yml
@@ -3,17 +3,20 @@ type: component
 changelogURL:
 items:
   - date: 2024-10-16
+    page: Breadcrumb
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 2853
     githubRepo: uswds-site
   - date: 2023-09-29
+    page: Breadcrumb
     summary: Fixed a bug that prevented text from wrapping to a new line in the `.usa-breadcrumb--wrap` variant.
     affectsStyles: true
     githubPr: 5497
     githubRepo: uswds
     versionUswds: 3.6.1
   - date: 2022-04-28
+    page: Breadcrumb
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true
@@ -23,6 +26,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.0
   - date: 2021-08-18
+    page: Breadcrumb
     summary: Updated breadcrumb to work with a broader range of focus widths.
     summaryAdditional: Now the breadcrumb component isn't affected by custom focus widths.
     affectsAccessibility: true

--- a/_data/changelogs/component-button-accessibility.yml
+++ b/_data/changelogs/component-button-accessibility.yml
@@ -3,6 +3,7 @@ type: component
 changelogURL:
 items:
   - date: 2024-01-17
+    page: Button accessibility tests
     summary: Added accessibility tests page.
     affectsGuidance: true
     githubPr: 2138

--- a/_data/changelogs/component-button-group-accessibility.yml
+++ b/_data/changelogs/component-button-group-accessibility.yml
@@ -2,6 +2,7 @@ title: Button group accessibility tests
 type: component
 items:
   - date: 2024-12-19
+    page: Button group accessibility tests
     summary: Added accessibility tests page.
     affectsGuidance: true
     githubPr: 3009

--- a/_data/changelogs/component-button-group.yml
+++ b/_data/changelogs/component-button-group.yml
@@ -3,11 +3,13 @@ type: component
 changelogURL:
 items:
   - date: 2024-12-19
+    page: Button group
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 3009
     githubRepo: uswds-site
   - date: 2024-05-31
+    page: Button group
     summary: Improved styles for nested button groups.
     summaryAdditional: Now, nested button groups should match the height of their parents.
     affectsStyles: true
@@ -15,6 +17,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.8.1
   - date: 2024-03-11
+    page: Button group
     summary: Improved the appearance of button groups when text wraps to multiple lines.
     summaryAdditional: Now, every button in the group will be the same height.
     isBreaking: false
@@ -30,6 +33,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.8.0
   - date: 2022-08-05
+    page: Button group
     summary: Styled aria-disabled to match disabled.
     summaryAdditional: Now disabled styling is applied whether you use `disabled` (disabled and hidden from screen readers) or `aria-disabled` (disabled and visible to screen readers).
     affectsAccessibility: true
@@ -38,6 +42,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.1.0
   - date: 2022-08-05
+    page: Button group
     summary: Added `type="button"` to all non-form buttons to prevent default submit behaviors.
     summaryAdditional: This allowed us to remove `preventDefault()` from the relevant component JavaScript.
     isBreaking: true
@@ -47,6 +52,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.1.0
   - date: 2022-08-05
+    page: Button group
     summary: Updated the alignment of unstyled buttons in a button group.
     summaryAdditional:
     affectsStyles: true
@@ -54,11 +60,13 @@ items:
     githubRepo: uswds
     versionUswds: 3.1.0
   - date: 2022-04-28
+    page: Button group
     summary: Updated package name to `usa-button-group`.
     affectsGuidance: true
     githubPr: 1538
     githubRepo: uswds-site
   - date: 2022-04-28
+    page: Button group
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true

--- a/_data/changelogs/component-button.yml
+++ b/_data/changelogs/component-button.yml
@@ -3,6 +3,7 @@ type: component
 changelogURL:
 items:
   - date: 2024-10-04
+    page: Button
     summary: Updated the width of unstyled buttons at narrow screen widths.
     summaryAdditional: |
       Now, unstyled buttons receive a width of `auto` to better match USWDS link styles.
@@ -13,6 +14,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.9.0
   - date: 2024-03-11
+    page: Button
     summary: Added a new setting to adjust the gap between the button's text and icon.
     summaryAdditional: Gap between elements can be adjusted using the `$theme-button-icon-gap` setting.
     affectsStyles: true
@@ -21,6 +23,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.8.0
   - date: 2024-03-11
+    page: Button
     summary: Improved the vertical alignment of `usa-icon` when placed inside of `usa-button`.
     affectsStyles: true
     affectsSettings: true
@@ -28,16 +31,19 @@ items:
     githubRepo: uswds
     versionUswds: 3.8.0
   - date: 2024-01-17
+    page: Button
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 2138
     githubRepo: uswds-site
   - date: 2023-11-20
+    page: Button
     summary: Updated summaries in the "Using the button component" section.
     affectsGuidance: true
     githubPr: 2149
     githubRepo: uswds-site
   - date: 2023-06-09
+    page: Button
     summary: Fixed a bug that caused the button `type` attribute to render empty.
     affectsAccessibility: true
     affectsMarkup: true
@@ -45,6 +51,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-06-09
+    page: Button
     summary: Improved consistency and visibility of disabled styles.
     summaryAdditional: Form elements with the `disabled` or `aria-disabled` attribute now get consistent styling and have proper color contrast.
     affectsAccessibility: true
@@ -53,6 +60,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-06-09
+    page: Button
     summary: Improved consistency of disabled styles in forced colors mode.
     summaryAdditional:
     affectsAccessibility: true
@@ -61,6 +69,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-06-09
+    page: Button
     summary: Improved legibility in forced colors mode.
     summaryAdditional: Adds a consistent border in forced colors mode.
     affectsAccessibility: true
@@ -69,6 +78,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-06-09
+    page: Button
     summary: Added spacebar trigger to links styled as buttons.
     affectsAccessibility: true
     affectsJavascript: true
@@ -76,6 +86,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2022-08-05
+    page: Button
     summary: Styled aria-disabled to match disabled.
     summaryAdditional: Now disabled styling is applied whether you use `disabled` (disabled and hidden from screen readers) or `aria-disabled` (disabled and visible to screen readers).
     affectsAccessibility: true
@@ -84,6 +95,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.1.0
   - date: 2022-08-05
+    page: Button
     summary: Added `type="button"` to all non-form buttons to prevent default submit behaviors.
     summaryAdditional: This allowed us to remove `preventDefault()` from the relevant component JavaScript.
     isBreaking: true
@@ -93,11 +105,13 @@ items:
     githubRepo: uswds
     versionUswds: 3.1.0
   - date: 2022-06-03
+    page: Button
     summary: Added guidance for using the button `type` attribute.
     affectsGuidance: true
     githubPr: 1608
     githubRepo: uswds-site
   - date: 2022-04-28
+    page: Button
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true
@@ -107,11 +121,13 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.0
   - date: 2021-06-08
+    page: Button
     summary: Added guidance to use the `disabled` attribute instead of `.usa-button--disabled`.
     affectsGuidance: true
     githubPr: 1232
     githubRepo: uswds-site
   - date: 2021-04-28
+    page: Button
     summary: Fixed unstyled button styling.
     summaryAdditional: We updated and strengthened the styling of unstyled buttons to prevent any unwanted style leakage from conventional buttons, especially is used in conjunction with <code>usa-button--hover</code> and <code>usa-button--active</code> classes.
     affectsStyles: true
@@ -119,6 +135,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.11.2
   - date: 2020-12-17
+    page: Button
     summary: Improved support for buttons with multiple variants.
     summaryAdditional: We fixed a display bug with visited inverse unstyled buttons. Button styling is more reliable with different combinations of variants.
     affectsStyles: true

--- a/_data/changelogs/component-card.yml
+++ b/_data/changelogs/component-card.yml
@@ -3,6 +3,7 @@ type: component
 changelogURL:
 items:
   - date: 2024-10-04
+    page: Card
     summary: Fixed a bug that caused the component to ignore the `$theme-card-font-family` setting.
     summaryAdditional: Confirm that your implementation of the card component displays with the expected font family.
     affectsStyles: true
@@ -12,17 +13,20 @@ items:
     githubPr: 5974
     versionUswds: 3.9.0
   - date: 2023-11-30
+    page: Card
     summary: Updated the grid breakpoints in the card template.
     summaryAdditional: This change affects only the template grid, not the component itself.
     affectsMarkup: true
     githubPr: 2299
     githubRepo: uswds-site
   - date: 2023-11-20
+    page: Card
     summary: Clarified guidance for using layout grid utilities.
     affectsGuidance: true
     githubPr: 2149
     githubRepo: uswds-site
   - date: 2023-11-09
+    page: Card
     summary: Fixed a bug that prevented `$theme-card-padding-y` from accepting expected token values.
     affectsSettings: true
     affectsStyles: true
@@ -30,23 +34,27 @@ items:
     githubRepo: uswds
     versionUswds: 3.7.0
   - date: 2023-09-29
+    page: Card
     summary: Fixed a margin bug on header-first variants that caused exdent card media to overlap headers.
     affectsStyles: true
     githubPr: 5423
     githubRepo: uswds
     versionUswds: 3.6.1
   - date: 2023-09-20
+    page: Card
     summary: Added `usa-card__header--exdent` variant to variants table.
     affectsGuidance: true
     githubPr: 2228
     githubRepo: uswds-site
   - date: 2023-08-23
+    page: Card
     summary: Fixed a bug that prevented `$theme-card-border-width` from accepting `0` or string tokens.
     affectsStyles: true
     githubPr: 5325
     githubRepo: uswds
     versionUswds: 3.6.0
   - date: 2023-06-09
+    page: Card
     summary: Replaced `button` elements with links styled as buttons.
     affectsMarkup: true
     affectsAccessibility: true
@@ -54,11 +62,13 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2022-08-29
+    page: Card
     summary: Added guidance for using aspect ratio utility classes.
     affectsGuidance: true
     githubPr: 1729
     githubRepo: uswds-site
   - date: 2022-08-05
+    page: Card
     summary: Added `type="button"` to all non-form buttons to prevent default submit behaviors.
     summaryAdditional: This allowed us to remove `preventDefault()` from the relevant component JavaScript.
     affectsJavascript: true
@@ -67,6 +77,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.1.0
   - date: 2022-04-28
+    page: Card
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true
@@ -76,6 +87,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.0
   - date: 2021-06-16
+    page: Card
     summary: Updated the exdent modifier to work as documented.
     summaryAdditional: Now adding the `.usa-card__body--exdent` modifier will work as expected.
     affectsStyles: true
@@ -83,6 +95,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.12.0
   - date: 2021-03-17
+    page: Card
     summary: Updated and improved guidance around cards.
     affectsGuidance: true
     githubPr: 1180

--- a/_data/changelogs/component-character-count-accessibility.yml
+++ b/_data/changelogs/component-character-count-accessibility.yml
@@ -1,8 +1,9 @@
 title: Character count accessibility tests
 type: component
 items:
- - date: 2024-05-15
-   summary: Added accessibility tests page.
-   affectsGuidance: true
-   githubPr: 2607
-   githubRepo: uswds-site
+  - date: 2024-05-15
+    page: Character count accessibility tests
+    summary: Added accessibility tests page.
+    affectsGuidance: true
+    githubPr: 2607
+    githubRepo: uswds-site

--- a/_data/changelogs/component-character-count.yml
+++ b/_data/changelogs/component-character-count.yml
@@ -3,36 +3,42 @@ type: component
 changelogURL:
 items:
   - date: 2024-10-04
+    page: Character count
     summary: Enhanced visual cue when `maxlength` is exceeded.
-    summaryAdditional:  Now, the component uses standard USWDS error styles to visually enhance the error state.
+    summaryAdditional: Now, the component uses standard USWDS error styles to visually enhance the error state.
     affectsJavascript: true
     affectsStyles: true
     githubPr: 5908
     githubRepo: uswds
     versionUswds: 3.9.0
   - date: 2024-05-15
+    page: Character count
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 2607
     githubRepo: uswds-site
   - date: 2024-03-13
+    page: Character count
     summary: Added known issues section.
     summaryAdditional:
     affectsGuidance: true
     githubPr: 2402
     githubRepo: uswds-site
   - date: 2023-11-20
+    page: Character count
     summary: Removed note about adding `aria-live` to the markup.
     summaryAdditional: The `aria-live` attribute is now added dynamically.
     affectsGuidance: true
     githubPr: 2149
     githubRepo: uswds-site
   - date: 2023-11-20
+    page: Character count
     summary: Added detail to the instructions for adding defaults for non-JavaScript environments.
     affectsGuidance: true
     githubPr: 2149
     githubRepo: uswds-site
   - date: 2022-10-19
+    page: Character count
     summary: Improved screen reader experience.
     summaryAdditional: The character counter now includes a brief pause after input before announcing how many characters remain. Announcing the input no longer prevents the character counter from reading.
     affectsAccessibility: true
@@ -43,6 +49,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.2.0
   - date: 2022-04-28
+    page: Character count
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true

--- a/_data/changelogs/component-checkbox-accessibility.yml
+++ b/_data/changelogs/component-checkbox-accessibility.yml
@@ -1,8 +1,9 @@
-title: Checkbox
+title: Checkbox accessibility tests
 type: component
 items:
- - date: 2024-09-18
-   summary: Added accessibility tests page.
-   affectsGuidance: true
-   githubPr: 2803
-   githubRepo: uswds-site
+  - date: 2024-09-18
+    page: Checkbox accessibility tests
+    summary: Added accessibility tests page.
+    affectsGuidance: true
+    githubPr: 2803
+    githubRepo: uswds-site

--- a/_data/changelogs/component-checkbox.yml
+++ b/_data/changelogs/component-checkbox.yml
@@ -3,6 +3,7 @@ type: component
 changelogURL:
 items:
   - date: 2024-11-13
+    page: Checkbox
     summary: Removed style tags from indeterminate checkbox SVGs.
     summaryAdditional: |
       These style tags were unnecessary and caused a conflict with some automated testing tools.
@@ -11,11 +12,13 @@ items:
     githubRepo: uswds
     versionUswds: 3.10.0
   - date: 2024-09-18
+    page: Checkbox
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 2803
     githubRepo: uswds-site
   - date: 2024-04-26
+    page: Checkbox
     summary: Added indeterminate styles for checkboxes.
     summaryAdditional: Checkboxes will now display as indeterminate when you set `input.indeterminate = true` via JavaScript or add the `data-indeterminate` attribute. This is currently only a style addition and does not affect checkbox functionality.
     affectsAssets: true
@@ -24,12 +27,14 @@ items:
     githubRepo: uswds
     versionUswds: 3.8.0
   - date: 2023-11-20
+    page: Checkbox
     summary: Added `usa-input-list` to the list of dependencies.
     affectsGuidance: true
     githubPr: 2149
     githubRepo: uswds-site
     versionUswds:
   - date: 2023-09-29
+    page: Checkbox
     summary: Updated radio and checkbox tiles to have lighter borders, reducing visual noise.
     summaryAdditional:
     affectsAccessibility: true
@@ -38,6 +43,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.6.1
   - date: 2023-06-09
+    page: Checkbox
     summary: Improved legibility in forced colors mode.
     summaryAdditional: Adds a consistent border in forced colors mode.
     affectsAccessibility: true
@@ -46,6 +52,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-06-09
+    page: Checkbox
     summary: Improved consistency and visibility of disabled styles.
     summaryAdditional: Form elements with the `disabled` or `aria-disabled` attribute now get consistent styling and have proper color contrast.
     affectsAccessibility: true
@@ -54,6 +61,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-06-09
+    page: Checkbox
     summary: Improved consistency of disabled styles in forced colors mode.
     summaryAdditional:
     affectsAccessibility: true
@@ -62,6 +70,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2022-08-05
+    page: Checkbox
     summary: Styled aria-disabled to match disabled.
     summaryAdditional: Now disabled styling is applied whether you use `disabled` (disabled and hidden from screen readers) or `aria-disabled` (disabled and visible to screen readers).
     affectsAccessibility: true
@@ -70,6 +79,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.1.0
   - date: 2022-04-28
+    page: Checkbox
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true
@@ -79,6 +89,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.0
   - date: 2022-04-11
+    page: Checkbox
     summary: Added support for forced colors mode.
     summaryAdditional: All our components now support proper display when users have a forced colors mode set in their operating system.
     affectsAccessibility: true
@@ -87,6 +98,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.13.3
   - date: 2021-08-18
+    page: Checkbox
     summary: Improved whitespace sensitivity of radio and checkbox tiles.
     summaryAdditional: Now radio and checkbox tiles will display consistently whether or not there's extra whitespace in the markup.
     affectsStyles: true
@@ -94,6 +106,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.12.1
   - date: 2021-08-18
+    page: Checkbox
     summary: Improved class order sensitivity for checkbox and radio.
     summaryAdditional: Now checkbox and radio components display properly regardless of the order of the class and modifier names.
     affectsStyles: true
@@ -101,6 +114,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.12.1
   - date: 2021-06-16
+    page: Checkbox
     summary: Updated checkbox and radio buttons to include automatic accessible color.
     summaryAdditional: Now checkbox and radio buttons will display in the proper accessible color, and adapt to the text, link, and background colors you set in your projects's settings.
     affectsAccessibility: true
@@ -109,6 +123,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.12.0
   - date: 2021-03-17
+    page: Checkbox
     summary: Fixed character display in checkboxes and radio buttons.
     summaryAdditional: Allowed checkboxes and radio buttons to display properly regardless of character encoding.
     affectsJavascript: true

--- a/_data/changelogs/component-collection-accessibility.yml
+++ b/_data/changelogs/component-collection-accessibility.yml
@@ -3,6 +3,7 @@ type: component
 changelogURL:
 items:
   - date: 2024-12-18
+    page: Collection accessibility tests
     summary: Added accessibility tests page.
     affectsGuidance: true
     githubPr: 3010

--- a/_data/changelogs/component-collection.yml
+++ b/_data/changelogs/component-collection.yml
@@ -3,17 +3,20 @@ type: component
 changelogURL:
 items:
   - date: 2024-12-18
+    page: Collection
     summary: Replaced deprecated `xlink:href` references with `href` in icons.
     affectsMarkup: true
     githubPr: 6165
     githubRepo: uswds
     versionUswds: 3.11.0
   - date: 2024-12-18
+    page: Collection
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 3010
     githubRepo: uswds-site
   - date: 2022-04-28
+    page: Collection
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true
@@ -23,6 +26,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.0
   - date: 2021-11-01
+    page: Collection
     summary: Removed extraneous href from collection calendar.
     summaryAdditional: The `usa-collection__calendar-date` should not include an `href`, so we removed it.
     affectsMarkup: true

--- a/_data/changelogs/component-combo-box-accessibility.yml
+++ b/_data/changelogs/component-combo-box-accessibility.yml
@@ -1,8 +1,9 @@
 title: Combo box accessibility tests
 type: component
 items:
- - date: 2024-09-18
-   summary: Added accessibility tests page.
-   affectsGuidance: true
-   githubPr: 2811
-   githubRepo: uswds-site
+  - date: 2024-09-18
+    page: Combo box accessibility tests
+    summary: Added accessibility tests page.
+    affectsGuidance: true
+    githubPr: 2811
+    githubRepo: uswds-site

--- a/_data/changelogs/component-combo-box.yml
+++ b/_data/changelogs/component-combo-box.yml
@@ -3,14 +3,16 @@ type: component
 changelogURL:
 items:
   - date: 2024-11-13
+    page: Combo box
     summary: Updated the order of combo box search results.
-    summaryAdditional:  The component now displays options that start with the query at the top of the list, followed by options that contain the query. This behavior more closely aligns with user expectations.
+    summaryAdditional: The component now displays options that start with the query at the top of the list, followed by options that contain the query. This behavior more closely aligns with user expectations.
     isBreaking: false
     affectsJavascript: true
     githubPr: 6122
     githubRepo: uswds
     versionUswds: 3.10.0
   - date: 2024-10-04
+    page: Combo box
     summary: Removed custom screen reader instructions.
     summaryAdditional: Combo box now relies on the default instructions provided by screen readers.
     affectsAccessibility: true
@@ -19,17 +21,20 @@ items:
     githubRepo: uswds
     versionUswds: 3.9.0
   - date: 2024-09-18
+    page: Combo box
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 2811
     githubRepo: uswds-site
   - date: 2024-03-13
+    page: Combo box
     summary: Added known issues section.
     summaryAdditional:
     affectsGuidance: true
     githubPr: 2402
     githubRepo: uswds-site
   - date: 2023-06-09
+    page: Combo box
     summary: Improved consistency and visibility of disabled styles.
     summaryAdditional: Form elements with the `disabled` or `aria-disabled` attribute now get consistent styling and have proper color contrast.
     affectsAccessibility: true
@@ -38,6 +43,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-06-09
+    page: Combo box
     summary: Improved consistency of disabled styles in forced colors mode.
     summaryAdditional:
     affectsAccessibility: true
@@ -46,6 +52,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-06-09
+    page: Combo box
     summary: Improved consistency of keyboard actions.
     summaryAdditional: Users can now to use `Tab` to escape the combo box selection without making a choice, and `Space` to select the current highlighted option when within the dropdown menu.
     affectsAccessibility: true
@@ -54,17 +61,20 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2022-11-14
+    page: Combo box
     summary: Added note on usability issues with assistive technology.
     summaryAdditional: Testing with people using assistive technology revealed usability concerns that require additional investigation. Until addressed, consider using a Select component instead of a Combo box.
     affectsGuidance: true
     githubPr: 1898
     githubRepo: uswds-site
   - date: 2022-04-28
+    page: Combo box
     summary: Updated package name to `usa-combo-box`.
     affectsGuidance: true
     githubPr: 1538
     githubRepo: uswds-site
   - date: 2022-04-28
+    page: Combo box
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true
@@ -74,11 +84,13 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.0
   - date: 2022-04-13
+    page: Combo box
     summary: Updated package name to `form-controls`.
     affectsGuidance: true
     githubPr: 1497
     githubRepo: uswds-site
   - date: 2022-04-11
+    page: Combo box
     summary: Added support for forced colors mode.
     summaryAdditional: All our components now support proper display when users have a forced colors mode set in their operating system.
     affectsAccessibility: true
@@ -87,6 +99,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.13.3
   - date: 2022-03-07
+    page: Combo box
     summary: Added proper `aria-controls` to combo box.
     summaryAdditional: Now the combo box input gets the expected `aria-controls` property when it's initialized.
     affectsAccessibility: true
@@ -95,6 +108,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.13.2
   - date: 2021-11-01
+    page: Combo box
     summary: Added automatic sanitizing.
     summaryAdditional: The design system now automatically sanitizes content in elements we compose with JavaScript. This means that components like combo box, tooltip, file input, and date picker will sanitize any content passed to them. This helps protect any design system implementation against malicious XSS attacks through these components.
     affectsJavascript: true
@@ -102,6 +116,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.12.2
   - date: 2021-08-18
+    page: Combo box
     summary: Improved performance of date picker and combo box JavaScript.
     summaryAdditional:
     affectsJavascript: true
@@ -109,6 +124,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.12.1
   - date: 2021-08-18
+    page: Combo box
     summary: Improved how combo box parses and displays `option` text.
     summaryAdditional:
     affectsJavascript: true

--- a/_data/changelogs/component-data-visualizations.yml
+++ b/_data/changelogs/component-data-visualizations.yml
@@ -3,11 +3,13 @@ type: component
 changelogURL:
 items:
   - date: 2022-10-31
+    page: Data visualizations
     summary: Fixed invalid value for `aria-describedby` in the bar chart example.
     affectsGuidance: true
     githubPr: 1861
     githubRepo: uswds-site
   - date: 2022-04-28
+    page: Data visualizations
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true

--- a/_data/changelogs/component-date-picker-accessibility.yml
+++ b/_data/changelogs/component-date-picker-accessibility.yml
@@ -3,6 +3,7 @@ type: component
 changelogURL:
 items:
   - date: 2025-01-14
+    page: Date picker accessibility tests
     summary: Added accessibility tests page.
     affectsGuidance: true
     githubPr: 3051

--- a/_data/changelogs/component-date-picker.yml
+++ b/_data/changelogs/component-date-picker.yml
@@ -3,24 +3,28 @@ type: component
 changelogURL:
 items:
   - date: 2025-01-14
+    page: Date picker
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 3051
     githubRepo: uswds-site
   - date: 2024-11-19
+    page: Date picker
     summary: Added guidance about always allowing users to type in the date manually.
     affectsGuidance: true
     githubPr: 2822
     githubRepo: uswds-site
   - date: 2024-10-04
+    page: Date picker
     summary: Fixed a bug that caused `mouseover` events to prevent keyboard navigation.
-    summaryAdditional:  Now when you hover your mouse over the date picker buttons, only the hover state will be triggered.
+    summaryAdditional: Now when you hover your mouse over the date picker buttons, only the hover state will be triggered.
     affectsAccessibility: true
     affectsJavascript: true
     githubPr: 5774
     githubRepo: uswds
     versionUswds: 3.9.0
   - date: 2024-10-04
+    page: Date picker
     summary: Added `aria-disabled` to the list of expected attributes.
     summaryAdditional: Now, the component will disable toggle when the `aria-disabled` attribute is present.
     affectsAccessibility: true
@@ -29,12 +33,14 @@ items:
     githubRepo: uswds
     versionUswds: 3.9.0
   - date: 2024-03-13
+    page: Date picker
     summary: Added known issues section.
     summaryAdditional:
     affectsGuidance: true
     githubPr: 2402
     githubRepo: uswds-site
   - date: 2024-03-11
+    page: Date picker
     summary: Added focus styles to calendar button in high contrast mode.
     summaryAdditional: Now, the calendar icon changes to the `highlight` high contrast token on focus.
     affectsAccessibility: true
@@ -43,12 +49,14 @@ items:
     githubRepo: uswds
     versionUswds: 3.8.0
   - date: 2023-11-20
+    page: Date picker
     summary: Added known issues section.
     summaryAdditional:
     affectsGuidance: true
     githubPr: 2360
     githubRepo: uswds-site
   - date: 2023-11-09
+    page: Date picker
     summary: Improved keyboard navigation for screen readers.
     summaryAdditional: This change enables table navigation controls in the calendar, which creates more consistent and intuitive navigation across browsers and screen readers.
     affectsAccessibility: true
@@ -57,6 +65,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.7.0
   - date: 2023-06-09
+    page: Date picker
     summary: Improved legibility in forced colors mode.
     summaryAdditional: Adds a consistent border in forced colors mode.
     affectsAccessibility: true
@@ -65,6 +74,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-06-09
+    page: Date picker
     summary: Improved consistency and visibility of disabled styles.
     summaryAdditional: Form elements with the `disabled` or `aria-disabled` attribute now get consistent styling and have proper color contrast.
     affectsAccessibility: true
@@ -73,6 +83,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-06-09
+    page: Date picker
     summary: Improved consistency of disabled styles in forced colors mode.
     summaryAdditional:
     affectsAccessibility: true
@@ -81,6 +92,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-03-09
+    page: Date picker
     summary: Updated documentation for accessibility guidance.
     summaryAdditional: Added instructions for keyboard navigation.
     affectsAccessibility:
@@ -88,6 +100,7 @@ items:
     githubPr: 1695
     githubRepo: uswds-site
   - date: 2022-08-05
+    page: Date picker
     summary: Styled aria-disabled to match disabled.
     summaryAdditional: Now disabled styling is applied whether you use `disabled` (disabled and hidden from screen readers) or `aria-disabled` (disabled and visible to screen readers).
     affectsAccessibility: true
@@ -96,6 +109,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.1.0
   - date: 2022-06-17
+    page: Date picker
     summary: Improved date picker display at very narrow widths.
     summaryAdditional: We improved the display of the date picker at very narrow widths so there are no UX inconsistencies when the date picker is in a form at less than 320px width. This assures that date picker conforms to WCAG 2.1.
     affectsAccessibility: true
@@ -104,17 +118,20 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.2
   - date: 2022-06-17
+    page: Date picker
     summary: Updated the documentation for initialization properties.
     summaryAdditional: Changed the initialization element from `select` to `input`.
     affectsGuidance: true
     githubPr: 1605
     githubRepo: uswds-site
   - date: 2022-04-28
+    page: Date picker
     summary: Updated package name to `usa-date-picker`.
     affectsGuidance: true
     githubPr: 1538
     githubRepo: uswds-site
   - date: 2022-04-28
+    page: Date picker
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true
@@ -124,11 +141,13 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.0
   - date: 2022-04-13
+    page: Date picker
     summary: Updated package name to `form-controls`.
     affectsGuidance: true
     githubPr: 1497
     githubRepo: uswds-site
   - date: 2022-04-11
+    page: Date picker
     summary: Added support for forced colors mode.
     summaryAdditional: All our components now support proper display when users have a forced colors mode set in their operating system.
     affectsAccessibility: true
@@ -137,6 +156,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.13.3
   - date: 2022-01-20
+    page: Date picker
     summary: Fixed date picker input bug in Safari.
     summaryAdditional: We fixed a bug where date picker selections would not propagate into the input field in Safari.
     affectsJavascript: true
@@ -144,6 +164,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.13.1
   - date: 2021-12-14
+    page: Date picker
     summary: Improved screen reader experience.
     summaryAdditional: Now screen readers can better describe the label and description of a date picker `input`.
     affectsAccessibility: true
@@ -152,6 +173,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.13.0
   - date: 2021-11-01
+    page: Date picker
     summary: Added automatic sanitizing.
     summaryAdditional: The design system now automatically sanitizes content in elements we compose with JavaScript. This means that components like combo box, tooltip, file input, and date picker will sanitize any content passed to them. This helps protect any design system implementation against malicious XSS attacks through these components.
     affectsJavascript: true
@@ -159,6 +181,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.12.2
   - date: 2021-08-18
+    page: Date picker
     summary: Improved performance of date picker and combo box JavaScript.
     summaryAdditional:
     affectsJavascript: true

--- a/_data/changelogs/component-date-range-picker-accessibility.yml
+++ b/_data/changelogs/component-date-range-picker-accessibility.yml
@@ -3,6 +3,7 @@ type: component
 changelogURL:
 items:
   - date: 2025-01-14
+    page: Date range picker accessibility tests
     summary: Added accessibility tests page.
     affectsGuidance: true
     githubPr: 3052

--- a/_data/changelogs/component-date-range-picker.yml
+++ b/_data/changelogs/component-date-range-picker.yml
@@ -3,24 +3,28 @@ type: component
 changelogURL:
 items:
   - date: 2025-01-14
+    page: Date range picker
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 3052
     githubRepo: uswds-site
   - date: 2024-11-19
+    page: Date range picker
     summary: Added guidance about always allowing users to type in the date manually.
     affectsGuidance: true
     githubPr: 2822
     githubRepo: uswds-site
   - date: 2024-10-04
+    page: Date range picker
     summary: Fixed a bug that caused `mouseover` events to prevent keyboard navigation.
-    summaryAdditional:  Now when you hover your mouse over the date picker buttons, only the hover state will be triggered.
+    summaryAdditional: Now when you hover your mouse over the date picker buttons, only the hover state will be triggered.
     affectsAccessibility: true
     affectsJavascript: true
     githubPr: 5774
     githubRepo: uswds
     versionUswds: 3.9.0
   - date: 2024-10-04
+    page: Date range picker
     summary: Added `aria-disabled` to the list of expected attributes.
     summaryAdditional: Now, the component will disable toggle when the `aria-disabled` attribute is present.
     affectsAccessibility: true
@@ -29,12 +33,14 @@ items:
     githubRepo: uswds
     versionUswds: 3.9.0
   - date: 2024-06-07
+    page: Date range picker
     summary: Added known issues section.
     summaryAdditional:
     affectsGuidance: true
     githubPr: 2620
     githubRepo: uswds-site
   - date: 2023-06-09
+    page: Date range picker
     summary: Improved consistency and visibility of disabled styles.
     summaryAdditional: Form elements with the `disabled` or `aria-disabled` attribute now get consistent styling and have proper color contrast.
     affectsAccessibility: true
@@ -43,6 +49,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-06-09
+    page: Date range picker
     summary: Improved consistency of disabled styles in forced colors mode.
     summaryAdditional:
     affectsAccessibility: true
@@ -51,6 +58,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2022-08-05
+    page: Date range picker
     summary: Styled aria-disabled to match disabled.
     summaryAdditional: Now disabled styling is applied whether you use `disabled` (disabled and hidden from screen readers) or `aria-disabled` (disabled and visible to screen readers).
     affectsAccessibility: true
@@ -59,6 +67,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.1.0
   - date: 2022-06-17
+    page: Date range picker
     summary: Improved date picker display at very narrow widths.
     summaryAdditional: We improved the display of the date picker at very narrow widths so there are no UX inconsistencies when the date picker is in a form at less than 320px width. This assures that date picker conforms to WCAG 2.1.
     affectsAccessibility: true
@@ -67,23 +76,27 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.2
   - date: 2022-06-17
+    page: Date range picker
     summary: Updated the documentation for initialization properties.
     summaryAdditional: Changed the initialization element from `select` to `input`.
     affectsGuidance: true
     githubPr: 1605
     githubRepo: uswds-site
   - date: 2022-06-17
+    page: Date range picker
     summary: Updated the documentation for properties.
     summaryAdditional: Changed the element from `.usa-date-picker` to `.usa-date-range-picker`.
     affectsGuidance: true
     githubPr: 1605
     githubRepo: uswds-site
   - date: 2022-04-28
+    page: Date range picker
     summary: Updated package name to `usa-date-range-picker`.
     affectsGuidance: true
     githubPr: 1538
     githubRepo: uswds-site
   - date: 2022-04-28
+    page: Date range picker
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true
@@ -93,11 +106,13 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.0
   - date: 2022-04-13
+    page: Date range picker
     summary: Updated package name to `form-controls`.
     affectsGuidance: true
     githubPr: 1497
     githubRepo: uswds-site
   - date: 2022-04-11
+    page: Date range picker
     summary: Added support for forced colors mode.
     summaryAdditional: All our components now support proper display when users have a forced colors mode set in their operating system.
     affectsAccessibility: true
@@ -106,6 +121,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.13.3
   - date: 2022-01-20
+    page: Date range picker
     summary: Fixed date picker input bug in Safari.
     summaryAdditional: We fixed a bug where date picker selections would not propagate into the input field in Safari.
     affectsJavascript: true
@@ -113,6 +129,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.13.1
   - date: 2021-12-14
+    page: Date range picker
     summary: Improved screen reader experience.
     summaryAdditional: Now screen readers can better describe the label and description of a date picker `input`.
     affectsAccessibility: true
@@ -121,6 +138,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.13.0
   - date: 2021-11-01
+    page: Date range picker
     summary: Added automatic sanitizing.
     summaryAdditional: The design system now automatically sanitizes content in elements we compose with JavaScript. This means that components like combo box, tooltip, file input, and date picker will sanitize any content passed to them. This helps protect any design system implementation against malicious XSS attacks through these components.
     affectsJavascript: true
@@ -128,6 +146,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.12.2
   - date: 2021-08-18
+    page: Date range picker
     summary: Improved performance of date picker and combo box JavaScript.
     summaryAdditional:
     affectsJavascript: true

--- a/_data/changelogs/component-file-input-accessibility.yml
+++ b/_data/changelogs/component-file-input-accessibility.yml
@@ -2,6 +2,7 @@ title: File input accessibility tests
 type: component
 items:
   - date: 2024-11-19
+    page: File input accessibility tests
     summary: Added accessibility tests page.
     affectsGuidance: true
     githubPr: 2963

--- a/_data/changelogs/component-file-input.yml
+++ b/_data/changelogs/component-file-input.yml
@@ -3,6 +3,7 @@ type: component
 changelogURL:
 items:
   - date: 2024-12-18
+    page: File input
     summary: Fixed a bug that prevented screen readers from announcing the invalid file type error message.
     affectsAccessibility: true
     affectsJavascript: true
@@ -10,17 +11,20 @@ items:
     githubRepo: uswds
     versionUswds: 3.11.0
   - date: 2024-12-18
+    page: File input
     summary: Replaced deprecated `xlink:href` references with `href`.
     affectsAssets: true
     githubPr: 6165
     githubRepo: uswds
     versionUswds: 3.11.0
   - date: 2024-11-19
+    page: File input
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 2963
     githubRepo: uswds-site
   - date: 2024-11-13
+    page: File input
     summary: Fixed a bug that caused image previews to break when a Content Security Policy is enabled.
     summaryAdditional: The component now uses event listeners in place of inline JavaScript to handle error states.
     affectsJavascript: true
@@ -28,12 +32,14 @@ items:
     githubRepo: uswds
     versionUswds: 3.10.0
   - date: 2024-03-13
+    page: File input
     summary: Added known issues section.
     summaryAdditional:
     affectsGuidance: true
     githubPr: 2402
     githubRepo: uswds-site
   - date: 2023-06-09
+    page: File input
     summary: Removed disabled file input variant preview.
     summaryAdditional:
     affectsGuidance: true
@@ -41,6 +47,7 @@ items:
     githubRepo: uswds-site
     versionUswds: 3.5.0
   - date: 2023-06-09
+    page: File input
     summary: Improved the file input experience for voice command and screen reader users.
     summaryAdditional:
       Voice command users can now interact with the component by speaking the visible instructions text.
@@ -53,6 +60,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-06-09
+    page: File input
     summary: Improved consistency and visibility of disabled styles.
     summaryAdditional: Form elements with the `disabled` or `aria-disabled` attribute now get consistent styling and have proper color contrast.
     affectsAccessibility: true
@@ -61,6 +69,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-06-09
+    page: File input
     summary: Improved consistency of disabled styles in forced colors mode.
     summaryAdditional:
     affectsAccessibility: true
@@ -69,6 +78,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-06-09
+    page: File input
     summary: Fixed a bug that caused large files to trigger an infinite spinner.
     summaryAdditional: Adding large files should now result in an accurate preview.
     affectsJavascript: true
@@ -76,11 +86,13 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2022-04-28
+    page: File input
     summary: Updated package name to `usa-file-input`.
     affectsGuidance: true
     githubPr: 1538
     githubRepo: uswds-site
   - date: 2022-04-28
+    page: File input
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true
@@ -90,11 +102,13 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.0
   - date: 2022-04-13
+    page: File input
     summary: Updated package name to `form-controls`.
     affectsGuidance: true
     githubPr: 1497
     githubRepo: uswds-site
   - date: 2021-12-14
+    page: File input
     summary: Updated file upload to confirm files to screen readers.
     summaryAdditional: Now file input will tell screen readers the total number of files and the names of files added to the component.
     affectsAccessibility: true
@@ -103,6 +117,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.13.0
   - date: 2021-11-01
+    page: File input
     summary: Fixed a duplicate file bug in file input.
     summaryAdditional: If a file with the same name was uploaded in two separate file input fields, the preview spinner would spin indefinitely. We now assign each upload an individual ID, and the image preview loads properly.
     affectsJavascript: true
@@ -110,6 +125,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.12.2
   - date: 2021-11-01
+    page: File input
     summary: Added automatic sanitizing.
     summaryAdditional: The design system now automatically sanitizes content in elements we compose with JavaScript. This means that components like combo box, tooltip, file input, and date picker will sanitize any content passed to them. This helps protect any design system implementation against malicious XSS attacks through these components.
     affectsJavascript: true
@@ -117,11 +133,13 @@ items:
     githubRepo: uswds
     versionUswds: 2.12.2
   - date: 2021-09-20
+    page: File input
     summary: Added documentation for using `data-errorMessage`.
     affectsGuidance: true
     githubPr: 1269
     githubRepo: uswds-site
   - date: 2021-06-07
+    page: File input
     summary: Updated package name to `usa-form-controls`.
     affectsGuidance: true
     githubPr: 1219

--- a/_data/changelogs/component-footer-accessibility.yml
+++ b/_data/changelogs/component-footer-accessibility.yml
@@ -2,6 +2,7 @@ title: Footer accessibility tests
 type: component
 items:
   - date: 2024-10-04
+    page: Footer accessibility tests
     summary: Updated the status of the WCAG 1.3.5 test to "pass".
     summaryAdditional: The reported issue was fixed in the USWDS 3.9.0 release.
     affectsGuidance: true
@@ -9,6 +10,7 @@ items:
     githubRepo: uswds-site
     versionUswds: 3.9.0
   - date: 2024-08-13
+    page: Footer accessibility tests
     summary: Added accessibility tests page.
     affectsGuidance: true
     githubPr: 2760

--- a/_data/changelogs/component-footer.yml
+++ b/_data/changelogs/component-footer.yml
@@ -3,7 +3,8 @@ type: component
 changelogURL:
 items:
   - date: 2024-12-18
-    summary: 'Removed `overflow: hidden` from `usa-footer` to allow the full focus outline to show.'
+    page: Footer
+    summary: "Removed `overflow: hidden` from `usa-footer` to allow the full focus outline to show."
     summaryAdditional: This fix also improves horizontal alignment in the slim footer variant.
     affectsStyles: true
     affectsAccessibility: true
@@ -11,6 +12,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.11.0
   - date: 2024-10-04
+    page: Footer
     summary: Added the `autocomplete="email"` attribute to the email input element.
     summaryAdditional: This allows the component to meet all the standards outlined in [WCAG 1.3.5](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html).
     affectsAccessibility: true
@@ -19,18 +21,21 @@ items:
     githubRepo: uswds
     versionUswds: 3.9.0
   - date: 2024-08-13
+    page: Footer
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 2760
     githubRepo: uswds-site
   - date: 2024-05-31
+    page: Footer
     summary: Restored the `usa-layout-grid` dependency in the footer package and removed layout grid styles from the footer stylesheet.
-    summaryAdditional:  This update prevents visual regressions in footer and other components with layout grid utility classes in their markup.
+    summaryAdditional: This update prevents visual regressions in footer and other components with layout grid utility classes in their markup.
     affectsStyles: true
     githubPr: 5930
     githubRepo: uswds
     versionUswds: 3.8.1
   - date: 2024-03-11
+    page: Footer
     summary: Fixed a bug that caused some grid utility classes to be ignored when used inside `usa-footer`.
     summaryAdditional:
     affectsStyles: true
@@ -38,6 +43,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.8.0
   - date: 2023-12-08
+    page: Footer
     summary: Removed the `usa-layout-grid` dependency.
     summaryAdditional: This update reduces the footer package size. If you notice changes in your layout after making this update, add the `usa-layout-grid` package to your [Sass entry point](https://designsystem.digital.gov/documentation/migration/#using-component-packages).
     affectsStyles: true
@@ -45,6 +51,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.7.1
   - date: 2023-12-08
+    page: Footer
     summary: Adjusted the right alignment of footer elements.
     summaryAdditional: Footer content should now align with other page elements.
     affectsStyles: true
@@ -52,6 +59,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.7.1
   - date: 2023-11-09
+    page: Footer
     summary: Restored underlines to footer links in the default state.
     summaryAdditional: Now, footer links meet WCAG 2.0 AA requirements.
     affectsAccessibility: true
@@ -60,6 +68,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.7.0
   - date: 2023-03-09
+    page: Footer
     summary: Footer now accepts any heading level for primary link headers.
     summaryAdditional: Use any heading level for `.usa-footer__primary-link` without it reverting to an `h4` when the JavaScript rebuilds the element for mobile.
     affectsAccessibility: true
@@ -69,11 +78,13 @@ items:
     githubRepo: uswds
     versionUswds: 3.4.0
   - date: 2022-08-29
+    page: Footer
     summary: Added documentation for `$theme-footer-max-width`.
     affectsGuidance: true
     githubPr: 1719
     githubRepo: uswds-site
   - date: 2022-08-05
+    page: Footer
     summary: Added unmodified social media icons.
     summaryAdditional: We now provide simpler social media icons, and removed any decoration not in the original icon. This means that the new icons are not in an enclosing circle unless the original icon is enclosed in a circle.
     isBreaking: true
@@ -82,6 +93,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.1.0
   - date: 2022-04-28
+    page: Footer
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true
@@ -91,6 +103,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.0
   - date: 2022-04-11
+    page: Footer
     summary: Added more accessible disclosure buttons to the big footer variant.
     summaryAdditional: Now the big footer variant uses more accessible disclosure buttons for showing and hiding submenus at mobile widths.
     affectsAccessibility: true
@@ -100,6 +113,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.13.3
   - date: 2022-04-11
+    page: Footer
     summary: Added support for forced colors mode.
     summaryAdditional: All our components now support proper display when users have a forced colors mode set in their operating system.
     affectsAccessibility: true
@@ -108,6 +122,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.13.3
   - date: 2022-03-07
+    page: Footer
     summary: Fixed expanded display in the big footer variant.
     summaryAdditional: Fixes an issue where the big footer variant does not show the proper expanded display at exactly 480px.
     affectsJavascript: true
@@ -116,6 +131,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.13.2
   - date: 2021-12-14
+    page: Footer
     summary: Improved resilience of icon-only functionality.
     summaryAdditional: We updated a couple components that use icon-only buttons so that they provide a text equivalent if the image path is broken and does not load.
     isBreaking: true
@@ -126,6 +142,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.13.0
   - date: 2021-03-17
+    page: Footer
     summary: Updated and improved guidance for footer.
     affectsGuidance: true
     githubPr: 1180

--- a/_data/changelogs/component-form.yml
+++ b/_data/changelogs/component-form.yml
@@ -6,6 +6,7 @@ type: component
 changelogURL:
 items:
   - date: 2024-12-18
+    page: Form
     summary: Moved `.usa-input--[width]` and `.usa-input-group--[width]` classes out of the `usa-form` package.
     summaryAdditional: These classes are now generated in the `usa-input` and `usa-input-prefix-suffix` packages and can be used without the `.usa-form` parent element.
     affectsStyles: true
@@ -13,20 +14,23 @@ items:
     githubRepo: uswds
     versionUswds: 3.11.0
   - date: 2024-10-04
+    page: Form
     summary: Added guidance discouraging most uses of disabled form inputs.
     summaryAdditional: We also added guidance on the rare instances when disabled inputs improve usability.
     affectsGuidance: true
     githubPr: 2776
     githubRepo: uswds-site
   - date: 2024-03-11
+    page: Form
     summary: Added color contrast checks for disabled tokens.
-    summaryAdditional:  On compilation, USWDS will test disabled element color contrast and provide a fallback color if minimum contrast is not met. If the fallback does not meet minimum requirements, USWDS will provide a warning in the terminal.
+    summaryAdditional: On compilation, USWDS will test disabled element color contrast and provide a fallback color if minimum contrast is not met. If the fallback does not meet minimum requirements, USWDS will provide a warning in the terminal.
     affectsAccessibility: true
     affectsStyles: true
     githubPr: 5455
     githubRepo: uswds
     versionUswds: 3.8.0
   - date: 2023-08-23
+    page: Form
     summary: Fixed a bug that caused some form inputs to show disabled styles when in forced colors mode.
     summaryAdditional:
     affectsStyles: true
@@ -35,6 +39,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.6.0
   - date: 2023-06-09
+    page: Form
     summary: Updated guidance to suggest identifying required and optional fields.
     summaryAdditional: We added a new section on identifying required fields and now suggest labeling required fields with a red asterisk and optional fields with the word "optional".
     affectsGuidance: true
@@ -43,6 +48,7 @@ items:
     githubRepo: uswds-site
     versionUswds: 3.5.0
   - date: 2023-03-13
+    page: Form
     summary: Fixed invisible link text for links styled as buttons within forms.
     summaryAdditional: Now link text does not match the primary button color when nested inside of a form and the `usa-button` class is present.
     isBreaking: false
@@ -51,6 +57,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.4.1
   - date: 2022-04-28
+    page: Form
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true

--- a/_data/changelogs/component-header-accessibility.yml
+++ b/_data/changelogs/component-header-accessibility.yml
@@ -1,8 +1,9 @@
 title: Header accessibility tests
 type: component
 items:
- - date: 2024-08-13
-   summary: Added accessibility tests page.
-   affectsGuidance: true
-   githubPr: 2761
-   githubRepo: uswds-site
+  - date: 2024-08-13
+    page: Header accessibility tests
+    summary: Added accessibility tests page.
+    affectsGuidance: true
+    githubPr: 2761
+    githubRepo: uswds-site

--- a/_data/changelogs/component-header.yml
+++ b/_data/changelogs/component-header.yml
@@ -3,6 +3,7 @@ type: component
 changelogURL:
 items:
   - date: 2024-10-04
+    page: Header
     summary: Removed the CSS order property from mobile header navigation.
     summaryAdditional: |
       Now, the visual order of the component matches the tab order.
@@ -14,11 +15,13 @@ items:
     githubPr: 6037
     versionUswds: 3.9.0
   - date: 2024-08-13
+    page: Header
     summary: Added accessibility tests page.
     affectsGuidance: true
     githubPr: 2761
     githubRepo: uswds-site
   - date: 2023-12-08
+    page: Header
     summary: Fixed a bug that caused long button text to overflow into its padding.
     summaryAdditional: Now, button text breaks to multiple lines as expected and maintains vertical center alignment.
     affectsStyles: True
@@ -26,6 +29,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.7.1
   - date: 2023-12-08
+    page: Header
     summary: Improved the vertical alignment of the expand icon.
     summaryAdditional: The icon will now maintain vertical alignment when menu button text breaks to multiple lines.
     affectsStyles: true
@@ -33,12 +37,14 @@ items:
     githubRepo: uswds
     versionUswds: 3.7.1
   - date: 2023-12-08
+    page: Header
     summary: Fixed a bug that prevented `$theme-max-header-width` from accepting a value of "none".
     affectsStyles: true
     githubPr: 5624
     githubRepo: uswds
     versionUswds: 3.7.1
   - date: 2023-12-08
+    page: Header
     summary: Fixed the horizontal alignment of header submenu elements.
     summaryAdditional: Now, `usa-nav__submenu` elements should align with other header elements.
     isBreaking: false
@@ -47,12 +53,14 @@ items:
     githubRepo: uswds
     versionUswds: 3.7.1
   - date: 2023-11-20
+    page: Header
     summary: Removed the role, banner component, and HTTPS sections.
     summaryAdditional:
     affectsGuidance: true
     githubPr: 2162
     githubRepo: uswds-site
   - date: 2023-09-29
+    page: Header
     summary: Fixed a Safari-only bug that caused the mobile menu to unexpectedly close at a narrow range of window widths.
     summaryAdditional:
     affectsJavascript: true
@@ -61,11 +69,13 @@ items:
     githubRepo: uswds
     versionUswds: 3.6.1
   - date: 2023-07-14
+    page: Header
     summary: Added header variants table to guidance page.
     affectsGuidance: true
     githubPr: 2139
     githubRepo: uswds-site
   - date: 2023-06-09
+    page: Header
     summary: Fixed a bug that caused inaccurate megamenu template markup in the documentation.
     summaryAdditional: The markup in megamenu code examples now accurately includes the `usa-megamenu` class.
     isBreaking: false
@@ -75,6 +85,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-06-09
+    page: Header
     summary: Removed the `id` attribute from the `usa-logo` element.
     summaryAdditional:
     isBreaking: false
@@ -83,6 +94,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-03-13
+    page: Header
     summary: Extended headers now respect the value passed to `$theme-header-logo-text-width`.
     summaryAdditional:
       For extended headers, the default setting value is narrower than
@@ -93,6 +105,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.4.1
   - date: 2023-03-09
+    page: Header
     summary: Secondary nav is now read properly on screen readers.
     summaryAdditional: The separator between nav elements is no longer read on screen readers.
     isBreaking: false
@@ -102,6 +115,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.4.0
   - date: 2023-03-09
+    page: Header
     summary: Allow full-page width for header.
     summaryAdditional: You can now set a value of `"none"` for any `max-width` setting, including `$theme-header-max-width`.
     isBreaking: false
@@ -110,6 +124,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.4.0
   - date: 2022-08-05
+    page: Header
     summary: Added `type="button"` to all non-form buttons to prevent default submit behaviors.
     summaryAdditional: This allowed us to remove `preventDefault()` from the relevant component JavaScript.
     isBreaking: true
@@ -119,6 +134,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.1.0
   - date: 2022-08-05
+    page: Header
     summary: Fixed mobile menu appearance for different CSS layouts.
     summaryAdditional: The menu now appears properly on layouts using flex or CSS grid.
     affectsStyles: true
@@ -126,6 +142,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.1.0
   - date: 2022-06-17
+    page: Header
     summary: Improved target area for header dropdown links.
     summaryAdditional: Links in dropdown menus are now formatted as block elements to provide a larger selectable surface.
     affectsStyles: true
@@ -133,6 +150,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.2
   - date: 2022-06-17
+    page: Header
     summary: Updated megamenu to always stay within the viewport.
     summaryAdditional: We improved the styling of the header megamenu so it resizes properly when trying to capture screenshots.
     affectsStyles: true
@@ -140,11 +158,13 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.2
   - date: 2022-04-28
+    page: Header
     summary: Updated package name to `usa-header`.
     affectsGuidance: true
     githubPr: 1538
     githubRepo: uswds-site
   - date: 2022-04-28
+    page: Header
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true
@@ -154,6 +174,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.0
   - date: 2022-04-11
+    page: Header
     summary: Added support for forced colors mode.
     summaryAdditional: All our components now support proper display when users have a forced colors mode set in their operating system.
     affectsAccessibility: true
@@ -162,6 +183,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.13.3
   - date: 2021-12-14
+    page: Header
     summary: Updated mobile navigation to make background content inert.
     summaryAdditional: When the mobile navigation is active, all other non-nav content is hidden. This prevents accidentally leaving the focus of the active mobile menu.
     affectsAccessibility: true
@@ -170,6 +192,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.13.0
   - date: 2021-12-14
+    page: Header
     summary: Improved resilience of icon-only functionality in search.
     summaryAdditional: Updated search to add a text equivalent if the image path is broken and does not load.
     isBreaking: true
@@ -183,6 +206,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.13.0
   - date: 2021-08-18
+    page: Header
     summary: Updated header dropdown menus to close with escape or focus out.
     summaryAdditional: Now `esc` or focusing out will close dropdown menus in the header.
     affectsAccessibility: true
@@ -191,6 +215,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.12.1
   - date: 2021-03-17
+    page: Header
     summary: Restored missing white icons.
     summaryAdditional: Restored `add--white`, `check_circle--white`, `error--white`, `expand_more--white`, `info--white`, `remove--white`, and `warning--white` icons.
     affectsAssets: true
@@ -198,6 +223,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.11.1
   - date: 2021-03-02
+    page: Header
     summary: Introduced white `add`, `remove`, and `expand_more` icons.
     summaryAdditional:
     isBreaking: false

--- a/_data/changelogs/component-icon-accessibility.yml
+++ b/_data/changelogs/component-icon-accessibility.yml
@@ -3,6 +3,7 @@ type: component
 changelogURL:
 items:
   - date: 2024-03-20
+    page: Icon accessibility tests
     summary: Added accessibility tests page.
     affectsGuidance: true
     githubPr: 2518

--- a/_data/changelogs/component-icon-list-accessibility.yml
+++ b/_data/changelogs/component-icon-list-accessibility.yml
@@ -1,8 +1,9 @@
 title: Icon list accessibility tests
 type: component
 items:
- - date: 2024-12-13
-   summary: Added accessibility tests page.
-   affectsGuidance: true
-   githubPr: 3008
-   githubRepo: uswds-site
+  - date: 2024-12-13
+    page: Icon list accessibility tests
+    summary: Added accessibility tests page.
+    affectsGuidance: true
+    githubPr: 3008
+    githubRepo: uswds-site

--- a/_data/changelogs/component-icon-list.yml
+++ b/_data/changelogs/component-icon-list.yml
@@ -3,27 +3,32 @@ type: component
 changelogURL:
 items:
   - date: 2024-12-18
+    page: Icon list
     summary: Removed deprecated `xlink` references from code samples.
     affectsGuidance: true
     githubPr: 2926
     githubRepo: uswds-site
   - date: 2024-12-18
+    page: Icon list
     summary: Replaced deprecated `xlink:href` references with `href`.
     affectsMarkup: true
     githubPr: 6165
     githubRepo: uswds
     versionUswds: 3.11.0
   - date: 2024-12-13
+    page: Icon list
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 3008
     githubRepo: uswds-site
   - date: 2023-11-20
+    page: Icon list
     summary: Updated the value list for icon list variants.
     affectsGuidance: true
     githubPr: 2162
     githubRepo: uswds-site
   - date: 2022-04-28
+    page: Icon list
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true
@@ -33,11 +38,13 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.0
   - date: 2021-03-17
+    page: Icon list
     summary: Added icon list documentation.
     affectsGuidance: true
     githubPr: 1180
     githubRepo: uswds-site
   - date: 2021-03-17
+    page: Icon list
     summary: Added the icon list component.
     summaryAdditional: An icon list reinforces the meaning and visibility of individual list items with a leading icon.
     affectsGuidance: true

--- a/_data/changelogs/component-icon.yml
+++ b/_data/changelogs/component-icon.yml
@@ -3,27 +3,32 @@ type: component
 changelogURL:
 items:
   - date: 2024-12-18
+    page: Icon
     summary: Removed deprecated `xlink` references from code samples.
     affectsGuidance: true
     githubPr: 2926
     githubRepo: uswds-site
   - date: 2024-12-18
+    page: Icon
     summary: Replaced deprecated `xlink:href` references with `href`.
     affectsMarkup: true
     githubPr: 6165
     githubRepo: uswds
     versionUswds: 3.11.0
   - date: 2024-06-07
+    page: Icon
     summary: Added clarity to icon guidance.
     affectsGuidance: true
     githubPr: 2643
     githubRepo: uswds-site
   - date: 2024-03-20
+    page: Icon
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 2518
     githubRepo: uswds-site
   - date: 2023-11-09
+    page: Icon
     summary: Added the X social media icon.
     summaryAdditional: We also preserved the legacy Twitter icon to allow teams to make the decision on when to update their social media information.
     affectsAssets: true
@@ -31,17 +36,20 @@ items:
     githubRepo: uswds
     versionUswds: 3.7.0
   - date: 2023-10-20
+    page: Icon
     summary: Added note about icon color contrast.
     affectsGuidance: true
     githubPr: 2258
     githubRepo: uswds-site
   - date: 2023-09-29
+    page: Icon
     summary: Added social media icon disclaimer.
     summaryAdditional: This disclaimer explains that social media icons are subject to separate terms and conditions, and that our inclusion of these icons does not constitute an endorsement of these services.
     affectsGuidance: true
     githubPr: 2292
     githubRepo: uswds-site
   - date: 2022-10-19
+    page: Icon
     summary: Updated our SVG sprite compiler to fix potential incompatibility with ARM-based Macs.
     summaryAdditional: This should resolve potential dependency incompatibilities on computers with ARM processors.
     affectsJavascript: true
@@ -49,6 +57,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.2.0
   - date: 2022-08-05
+    page: Icon
     summary: Added LinkedIn icon.
     summaryAdditional: We now have a LinkedIn icon included in our default icon sprite as `linkedin`.
     affectsAssets: true
@@ -56,6 +65,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.1.0
   - date: 2022-08-05
+    page: Icon
     summary: Added unmodified social media icons.
     summaryAdditional: We now provide simpler social media icons, and removed any decoration not in the original icon. This means that the new icons are not in an enclosing circle unless the original icon is enclosed in a circle.
     isBreaking: true
@@ -64,12 +74,14 @@ items:
     githubRepo: uswds
     versionUswds: 3.1.0
   - date: 2022-06-17
+    page: Icon
     summary: Updated `us_flag_small` to be high resolution.
     affectsAssets: true
     githubPr: 4792
     githubRepo: uswds
     versionUswds: 3.0.2
   - date: 2022-06-17
+    page: Icon
     summary: Added `fax` to the default set.
     summaryAdditional:
     affectsAssets: true
@@ -77,12 +89,14 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.2
   - date: 2022-06-17
+    page: Icon
     summary: Added `remove_circle` to the default set.
     affectsAssets: true
     githubPr: 4791
     githubRepo: uswds
     versionUswds: 3.0.2
   - date: 2022-06-17
+    page: Icon
     summary: Navigate_far icons now accept custom color.
     summaryAdditional: We fixed the `navigate_far_before` and `navigate_far_next` icons to allow a `customColor` fill.
     affectsAssets: true
@@ -91,6 +105,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.2
   - date: 2022-04-28
+    page: Icon
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true
@@ -100,11 +115,13 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.0
   - date: 2022-03-10
+    page: Icon
     summary: Replaced `uswds-gulp` with `uswds-compile`.
     affectsGuidance: true
     githubPr: 1424
     githubRepo: uswds-site
   - date: 2022-03-07
+    page: Icon
     summary: Fixed GitHub icon to prevent CSP flag.
     summaryAdditional: Resolves an error which can occur when using the USWDS icon component SVG sprite in combination with a <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP">Content Security Policy (CSP)</a>, where the presence of an inline style tag within the GitHub icon can violate most common CSPs which do not include the unsafe-inline style-src directive.
     affectsAssets: true
@@ -112,6 +129,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.13.2
   - date: 2021-12-14
+    page: Icon
     summary: Improved resilience of icon-only functionality.
     summaryAdditional: We updated a couple components that use icon-only buttons so that they provide a text equivalent if the image path is broken and does not load.
     isBreaking: true
@@ -122,6 +140,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.13.0
   - date: 2021-04-28
+    page: Icon
     summary: Fixed the size of some of our icons.
     summaryAdditional: The view box on some or our icons was 20px instead of 24px. We updated these icons to use the proper view box. This may result in small changes to the display of icons, but will result in a more consistent placement and appearance across all icons in our icon set.
     isBreaking: true
@@ -130,6 +149,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.11.2
   - date: 2021-04-28
+    page: Icon
     summary: Swapped thumb icons in our sprite for consistency.
     summaryAdditional: We replaced `thumb_down_off_alt` with `thumb_down_off` in our icon sprite for consistency with its `thumb_up` pair.
     affectsAssets: true
@@ -137,6 +157,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.11.2
   - date: 2021-04-28
+    page: Icon
     summary: Removed duplicate eye icon.
     summaryAdditional: Removes `remove_red_eye` icon from `usa-icons` and sprite. Use `visibility` instead.
     isBreaking: true
@@ -145,11 +166,13 @@ items:
     githubRepo: uswds
     versionUswds: 2.11.2
   - date: 2021-03-17
+    page: Icon
     summary: Updated and improved guidance for icons.
     affectsGuidance: true
     githubPr: 1180
     githubRepo: uswds-site
   - date: 2021-03-17
+    page: Icon
     summary: Restored missing white icons.
     summaryAdditional: Restored `add--white`, `check_circle--white`, `error--white`, `expand_more--white`, `info--white`, `remove--white`, and `warning--white` icons.
     affectsAssets: true
@@ -157,6 +180,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.11.1
   - date: 2021-03-17
+    page: Icon
     summary: Provided better support for color icons that adapt to theme settings.
     summaryAdditional: Now the color of the alert icon will update automatically to adapt to the alert background, or to the color of the alert text.
     affectsAssets: true
@@ -165,6 +189,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.11.0
   - date: 2021-03-02
+    page: Icon
     summary: Introduced white `add`, `remove`, and `expand_more` icons.
     summaryAdditional:
     isBreaking: false

--- a/_data/changelogs/component-identifier-accessibility.yml
+++ b/_data/changelogs/component-identifier-accessibility.yml
@@ -3,6 +3,7 @@ type: component
 changelogURL:
 items:
   - date: 2024-08-13
+    page: Identifier accessibility tests
     summary: Added accessibility tests page.
     affectsGuidance: true
     githubPr: 2754

--- a/_data/changelogs/component-identifier.yml
+++ b/_data/changelogs/component-identifier.yml
@@ -3,12 +3,14 @@ type: component
 changelogURL:
 items:
   - date: 2024-11-07
+    page: Identifier
     summary: Added clarification on parent agency.
     summaryAdditional: We added guidance to cover cases where a site has no higher-level agency.
     affectsGuidance: true
     githubPr: 2591
     githubRepo: uswds-site
   - date: 2024-10-04
+    page: Identifier
     summary: Updated the USA.gov link in Spanish versions of the identifier.
     summaryAdditional: The link text now reads "Visite USAGov en Español" and the link url is now "https://www.usa.gov/es/".
     affectsContent: true
@@ -16,11 +18,13 @@ items:
     githubRepo: uswds
     versionUswds: 3.9.0
   - date: 2024-08-13
+    page: Identifier
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 2754
     githubRepo: uswds-site
   - date: 2024-05-31
+    page: Identifier
     summary: Fixed a bug that mistakenly added the English word "An" to Spanish variants in the component preview.
     summaryAdditional:
     affectsGuidance: true
@@ -29,6 +33,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.8.1
   - date: 2023-11-09
+    page: Identifier
     summary: Updated the screen reader readout in English versions of the component.
     summaryAdditional: When read out on a screen reader, the statement "An official website of [Agency name]" can sound like "UNofficial website of [Agency name]". Users should update their markup to improve the screen reader experience.
     affectsAccessibility: true
@@ -37,6 +42,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.7.0
   - date: 2023-06-09
+    page: Identifier
     summary: Updated Accessibility statement link text.
     summaryAdditional: Updated the identifier to use the text "Accessibility statement" (EN) / "Declaración de accesibilidad" (ES) for the required link to an accessibility statement.
     isBreaking: true
@@ -45,6 +51,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-06-09
+    page: Identifier
     summary: Updated Accessibility statement link guidance.
     summaryAdditional: Updated and clarified the identifier guidance for accessibility statements. We also improved the  accessibility statement example links.
     affectsGuidance: true
@@ -52,6 +59,7 @@ items:
     githubRepo: uswds-site
     versionUswds: 3.5.0
   - date: 2022-10-19
+    page: Identifier
     summary: Used valid element for identity's aria-label.
     summaryAdditional: We updated the identity section of the identifier to use a `section` instead of a `div` so its `aria-label` will apply to a valid element.
     isBreaking: true
@@ -61,6 +69,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.2.0
   - date: 2022-04-28
+    page: Identifier
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true
@@ -70,6 +79,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.0
   - date: 2021-03-17
+    page: Identifier
     summary: Added identifier guidance and documentation.
     affectsGuidance: true
     githubPr: 1180

--- a/_data/changelogs/component-in-page-navigation-accessibility.yml
+++ b/_data/changelogs/component-in-page-navigation-accessibility.yml
@@ -2,6 +2,7 @@ title: In-page navigation accessibility tests
 type: component
 items:
   - date: 2024-10-16
+    page: In-page navigation accessibility tests
     summary: Added accessibility tests page.
     affectsGuidance: true
     githubPr: 2863

--- a/_data/changelogs/component-in-page-navigation.yml
+++ b/_data/changelogs/component-in-page-navigation.yml
@@ -3,17 +3,20 @@ type: component
 changelogURL:
 items:
   - date: 2024-10-16
+    page: In-page navigation
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 2863
     githubRepo: uswds-site
   - date: 2024-03-26
+    page: In-page navigation
     summary: Updated outdated references to `data-heading-selector` with `data-heading-elements`.
     summaryAdditional:
     affectsGuidance: true
     githubRepo: uswds-site
     githubPr: 2560
   - date: 2024-03-11
+    page: In-page navigation
     summary: Added the optional `data-heading-selector` attribute.
     summaryAdditional: This attribute allows users to list the heading levels that should be included in the component link list.
     affectsJavascript: true
@@ -22,6 +25,7 @@ items:
     githubPr: 5444
     versionUswds: 3.8.0
   - date: 2023-08-23
+    page: In-page navigation
     summary: Updated JavaScript to exclude headers that have a style of `display:none` or `visibility:hidden` from the component link list.
     summaryAdditional:
     affectsJavascript: true
@@ -29,12 +33,14 @@ items:
     githubPr: 5393
     versionUswds: 3.6.0
   - date: 2023-08-23
+    page: In-page navigation
     summary: Added the option to designate a custom main content region with the `data-main-content-selector` attribute.
     affectsJavascript: true
     githubRepo: uswds
     githubPr: 5387
     versionUswds: 3.6.0
   - date: 2023-06-09
+    page: In-page navigation
     summary: Fixed a bug that prevented links that start with a number from scrolling when clicked.
     summaryAdditional:
     affectsJavascript: true
@@ -42,6 +48,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-03-27
+    page: In-page navigation
     summary: Updated the documentation to clarify the component's recommended display location.
     summaryAdditional:
     affectsGuidance: true
@@ -52,6 +59,7 @@ items:
     githubPr: 2033
     versionUswds:
   - date: 2023-03-13
+    page: In-page navigation
     summary: URL in address bar is updated when navigating component.
     summaryAdditional: Users can now see the proper anchor link in the address bar when navigating from the in-page navigation.
     affectsGuidance:
@@ -62,6 +70,7 @@ items:
     githubPr: 5170
     versionUswds: 3.4.1
   - date: 2022-11-14
+    page: In-page navigation
     summary: Component released.
     affectsGuidance: true
     affectsJavascript: true

--- a/_data/changelogs/component-input-mask.yml
+++ b/_data/changelogs/component-input-mask.yml
@@ -3,6 +3,7 @@ type: component
 changelogURL:
 items:
   - date: 2024-05-31
+    page: Input mask
     summary: Fixed a bug that caused input mask to break when it is not a direct child of a form.
     summaryAdditional: Nested input masks will now initialize and work properly.
     affectsJavascript: true
@@ -10,18 +11,21 @@ items:
     githubRepo: uswds
     versionUswds: 3.8.1
   - date: 2024-03-13
+    page: Input mask
     summary: Added known issues section.
     summaryAdditional:
     affectsGuidance: true
     githubPr: 2402
     githubRepo: uswds-site
   - date: 2023-08-23
+    page: Input mask
     summary: Fixed a bug that caused the hover state to adopt disabled styling.
     affectsStyles: true
     githubPr: 5378
     githubRepo: uswds
     versionUswds: 3.6.0
   - date: 2023-08-23
+    page: Input mask
     summary: Improved legibility in forced colors mode.
     affectsStyles: true
     affectsAccessibility: true
@@ -29,6 +33,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.6.0
   - date: 2023-06-09
+    page: Input mask
     summary: Improved consistency and visibility of disabled styles.
     summaryAdditional: Form elements with the `disabled` or `aria-disabled` attribute now get consistent styling and have proper color contrast.
     affectsAccessibility: true
@@ -37,6 +42,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-06-09
+    page: Input mask
     summary: Improved consistency of disabled styles in forced colors mode.
     summaryAdditional:
     affectsAccessibility: true
@@ -45,6 +51,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2022-11-14
+    page: Input mask
     summary: Component released.
     affectsGuidance: true
     affectsJavascript: true

--- a/_data/changelogs/component-input-prefix-suffix.yml
+++ b/_data/changelogs/component-input-prefix-suffix.yml
@@ -3,6 +3,7 @@ type: component
 changelogURL:
 items:
   - date: 2024-12-18
+    page: Input prefix or suffix
     summary: Moved `.usa-input-group--[width]` classes into the `usa-input-prefix-suffix` package from `usa-form`.
     summaryAdditional: These classes can now be used without the `usa-form` package and `.usa-form` parent element.
     affectsStyles: true
@@ -10,17 +11,20 @@ items:
     githubRepo: uswds
     versionUswds: 3.11.0
   - date: 2024-12-18
+    page: Input prefix or suffix
     summary: Replaced deprecated `xlink:href` references with `href`.
     affectsMarkup: true
     githubPr: 6165
     githubRepo: uswds
     versionUswds: 3.11.0
   - date: 2023-11-20
+    page: Input prefix or suffix
     summary: Added documentation for `usa-input-group--success` variant.
     affectsGuidance: true
     githubPr: 2162
     githubRepo: uswds-site
   - date: 2023-06-09
+    page: Input prefix or suffix
     summary: Improved consistency and visibility of disabled styles.
     summaryAdditional: Form elements with the `disabled` or `aria-disabled` attribute now get consistent styling and have proper color contrast.
     affectsAccessibility: true
@@ -29,6 +33,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-06-09
+    page: Input prefix or suffix
     summary: Improved consistency of disabled styles in forced colors mode.
     summaryAdditional:
     affectsAccessibility: true
@@ -37,11 +42,13 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2022-04-28
+    page: Input prefix or suffix
     summary: Updated package name to `usa-input-prefix-suffix`.
     affectsGuidance: true
     githubPr: 1538
     githubRepo: uswds-site
   - date: 2022-04-28
+    page: Input prefix or suffix
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true
@@ -51,21 +58,25 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.0
   - date: 2022-04-13
+    page: Input prefix or suffix
     summary: Updated package name to `form-controls`.
     affectsGuidance: true
     githubPr: 1497
     githubRepo: uswds-site
   - date: 2021-03-18
+    page: Input prefix or suffix
     summary: Clarified that the input cannot include units.
     affectsGuidance: true
     githubPr: 1186
     githubRepo: uswds-site
   - date: 2021-03-17
+    page: Input prefix or suffix
     summary: Added input prefix or suffix documentation.
     affectsGuidance: true
     githubPr: 1180
     githubRepo: uswds-site
   - date: 2021-03-17
+    page: Input prefix or suffix
     summary: Added input prefix or suffix component.
     summaryAdditional: Use input prefixes and suffixes to show symbols or abbreviations that help users enter the right type of information in a form’s text input.
     affectsGuidance: true

--- a/_data/changelogs/component-language-selector.yml
+++ b/_data/changelogs/component-language-selector.yml
@@ -3,12 +3,14 @@ type: component
 changelogURL:
 items:
   - date: 2023-11-20
+    page: Language selector
     summary: Removed the note about using links styled as buttons in the two languages variant.
     summaryAdditional:
     affectsGuidance: true
     githubPr: 2162
     githubRepo: uswds-site
   - date: 2022-11-14
+    page: Language selector
     summary: Component released.
     affectsGuidance: true
     githubRepo: uswds

--- a/_data/changelogs/component-link-accessibility.yml
+++ b/_data/changelogs/component-link-accessibility.yml
@@ -3,8 +3,8 @@ type: component
 changelogURL:
 items:
   - date: 2024-01-17
+    page: Link accessibility tests
     summary: Added accessibility tests page.
     affectsGuidance: true
     githubPr: 2138
     githubRepo: uswds-site
-    

--- a/_data/changelogs/component-link.yml
+++ b/_data/changelogs/component-link.yml
@@ -3,26 +3,31 @@ type: component
 changelogURL:
 items:
   - date: 2025-01-22
+    page: Link
     summary: Updated the url for the "OMB M-23-22" link.
     affectsGuidance: true
     githubPr: 3068
     githubRepo: uswds-site
   - date: 2024-01-17
+    page: Link
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 2138
     githubRepo: uswds-site
   - date: 2023-11-20
+    page: Link
     summary: Added `uswds-fonts` and `usa-icon` to list of dependencies.
     affectsGuidance: true
     githubPr: 2162
     githubRepo: uswds-site
   - date: 2023-11-20
+    page: Link
     summary: Updated code examples for encoding email and phone links.
     affectsGuidance: true
     githubPr: 2162
     githubRepo: uswds-site
   - date: 2023-06-09
+    page: Link
     summary: Labeled external links for screen readers.
     summaryAdditional: Adds a label for screen readers that identifies external links and if they open in a new tab.
     affectsAccessibility: true
@@ -31,12 +36,14 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-03-09
+    page: Link
     summary: External link icons and link text now wrap as expected.
     affectsStyles: true
     githubPr: 5046
     githubRepo: uswds
     versionUswds: 3.4.0
   - date: 2022-04-28
+    page: Link
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true
@@ -46,6 +53,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.0
   - date: 2022-01-20
+    page: Link
     summary: Fixed external link icon display bug in Safari.
     summaryAdditional: Fixed a bug that resulted in colored bars on the top and bottom of external link icons in Safari.
     isBreaking: false
@@ -59,11 +67,13 @@ items:
     githubRepo: uswds
     versionUswds: 2.13.1
   - date: 2021-10-01
+    page: Link
     summary: Updated component definition and use case.
     affectsGuidance: true
     githubPr: 1275
     githubRepo: uswds-site
   - date: 2021-11-01
+    page: Link
     summary: Fixed external link icon color.
     summaryAdditional: Resolved an issue with visited links where the icon color may not match the color of the link.
     isBreaking: false
@@ -77,11 +87,13 @@ items:
     githubRepo: uswds
     versionUswds: 2.12.2
   - date: 2021-09-16
+    page: Link
     summary: Added a link to the external link indicator research findings.
     affectsGuidance: true
     githubPr: 1261
     githubRepo: uswds-site
   - date: 2021-08-18
+    page: Link
     summary: Improved external link icon display.
     summaryAdditional: Made external link icon bigger and better aligned with the link text.
     isBreaking: false
@@ -95,21 +107,25 @@ items:
     githubRepo: uswds
     versionUswds: 2.12.1
   - date: 2021-07-30
+    page: Link
     summary: Updated external link guidance and added a summary of external link indicator research findings.
     affectsGuidance: true
     githubPr: 1249
     githubRepo: uswds-site
   - date: 2021-06-16
+    page: Link
     summary: Updated accessibility and usability guidance for external links.
     affectsGuidance: true
     githubPr: 1225
     githubRepo: uswds-site
   - date: 2021-03-18
+    page: Link
     summary: Added documentation for the `usa-link--external` variant.
     affectsGuidance: true
     githubPr: 1186
     githubRepo: uswds-site
   - date: 2021-03-17
+    page: Link
     summary: Updated and improved guidance around links.
     affectsGuidance: true
     githubPr: 1180

--- a/_data/changelogs/component-list-accessibility.yml
+++ b/_data/changelogs/component-list-accessibility.yml
@@ -1,9 +1,9 @@
 title: List accessibility tests
 type: component
 items:
- - date: 2024-08-13
-   summary: Added accessibility tests page.
-   affectsGuidance: true
-   githubPr: 2746
-   githubRepo: uswds-site
-   
+  - date: 2024-08-13
+    page: List accessibility tests
+    summary: Added accessibility tests page.
+    affectsGuidance: true
+    githubPr: 2746
+    githubRepo: uswds-site

--- a/_data/changelogs/component-list.yml
+++ b/_data/changelogs/component-list.yml
@@ -2,22 +2,25 @@ title: List
 type: component
 changelogURL:
 items:
-- date: 2024-08-13
-  summary: Added WCAG compliance tag and accessibility test status section.
-  affectsGuidance: true
-  githubPr: 2746
-  githubRepo: uswds-site
-- date: 2023-11-20
-  summary: Added documentation for `usa-list--unstyled` variant.
-  affectsGuidance: true
-  githubPr: 2162
-  githubRepo: uswds-site
-- date: 2022-04-28
-  summary: Updated to Sass module syntax and new package structure.
-  isBreaking: true
-  affectsAssets: true
-  affectsJavascript: true
-  affectsStyles: true
-  githubPr: 4656
-  githubRepo: uswds
-  versionUswds: 3.0.0
+  - date: 2024-08-13
+    page: List
+    summary: Added WCAG compliance tag and accessibility test status section.
+    affectsGuidance: true
+    githubPr: 2746
+    githubRepo: uswds-site
+  - date: 2023-11-20
+    page: List
+    summary: Added documentation for `usa-list--unstyled` variant.
+    affectsGuidance: true
+    githubPr: 2162
+    githubRepo: uswds-site
+  - date: 2022-04-28
+    page: List
+    summary: Updated to Sass module syntax and new package structure.
+    isBreaking: true
+    affectsAssets: true
+    affectsJavascript: true
+    affectsStyles: true
+    githubPr: 4656
+    githubRepo: uswds
+    versionUswds: 3.0.0

--- a/_data/changelogs/component-memorable-date-accessibility.yml
+++ b/_data/changelogs/component-memorable-date-accessibility.yml
@@ -1,9 +1,9 @@
 title: Memorable date accessibility tests
 type: component
 items:
- - date: 2024-11-19
-   summary: Added accessibility tests page.
-   affectsGuidance: true
-   githubPr: 2919
-   githubRepo: uswds-site
-   
+  - date: 2024-11-19
+    page: Memorable date accessibility tests
+    summary: Added accessibility tests page.
+    affectsGuidance: true
+    githubPr: 2919
+    githubRepo: uswds-site

--- a/_data/changelogs/component-memorable-date.yml
+++ b/_data/changelogs/component-memorable-date.yml
@@ -2,69 +2,79 @@ title: Memorable date
 type: component
 changelogURL:
 items:
-- date: 2024-11-19
-  summary: Added WCAG compliance tag and accessibility test status section.
-  affectsGuidance: true
-  githubPr: 2919
-  githubRepo: uswds-site
-- date: 2024-11-06
-  summary: Added known issues section.
-  summaryAdditional:
-  affectsGuidance: true
-  githubPr: 2716
-  githubRepo: uswds-site
-- date: 2024-10-04
-  summary: Removed numeric representation of months from the `select` element.
-  summaryAdditional: Recent usability testing indicated that having both numbers and names to represent months was confusing for screen reader users.
-  affectsAccessibility: true
-  affectsContent: true
-  affectsMarkup: true
-  githubRepo: uswds
-  githubPr: 6028
-  versionUswds: 3.9.0
-- date: 2023-08-23
-  summary: Updated styles to allow the component to wrap to multiple lines at narrow widths.
-  summaryAdditional:
-  affectsAccessibility: true
-  affectsStyles: true
-  githubRepo: uswds
-  githubPr: 5372
-  versionUswds: 3.6.0
-- date: 2022-11-14
-  summary: Updated the month entry to a `select` from an `input`.
-  summaryAdditional: Recent usability testing indicated that using a `select` for month entry was more clear and reduced mistakes.
-  affectsMarkup: true
-  affectsStyles: true
-  affectsGuidance: true
-  githubRepo: uswds
-  githubPr: 4937
-  versionUswds: 3.3.0
-- date: 2022-04-28
-  summary: Added guidance for adding labels and using text boxes in place of select elements.
-  affectsGuidance: true
-  githubPr: 1538
-  githubRepo: uswds-site
-- date: 2022-04-28
-  summary: Updated package name to `usa-memorable-date`.
-  affectsGuidance: true
-  githubPr: 1538
-  githubRepo: uswds-site
-- date: 2022-04-28
-  summary: Renamed component from "date input" to "memorable date".
-  affectsGuidance: true
-  githubPr: 1538
-  githubRepo: uswds-site
-- date: 2022-04-28
-  summary: Updated to Sass module syntax and new package structure.
-  isBreaking: true
-  affectsAssets: true
-  affectsJavascript: true
-  affectsStyles: true
-  githubPr: 4656
-  githubRepo: uswds
-  versionUswds: 3.0.0
-- date: 2022-04-13
-  summary: Updated package name to `form-controls`.
-  affectsGuidance: true
-  githubPr: 1497
-  githubRepo: uswds-site
+  - date: 2024-11-19
+    page: Memorable date
+    summary: Added WCAG compliance tag and accessibility test status section.
+    affectsGuidance: true
+    githubPr: 2919
+    githubRepo: uswds-site
+  - date: 2024-11-06
+    page: Memorable date
+    summary: Added known issues section.
+    summaryAdditional:
+    affectsGuidance: true
+    githubPr: 2716
+    githubRepo: uswds-site
+  - date: 2024-10-04
+    page: Memorable date
+    summary: Removed numeric representation of months from the `select` element.
+    summaryAdditional: Recent usability testing indicated that having both numbers and names to represent months was confusing for screen reader users.
+    affectsAccessibility: true
+    affectsContent: true
+    affectsMarkup: true
+    githubRepo: uswds
+    githubPr: 6028
+    versionUswds: 3.9.0
+  - date: 2023-08-23
+    page: Memorable date
+    summary: Updated styles to allow the component to wrap to multiple lines at narrow widths.
+    summaryAdditional:
+    affectsAccessibility: true
+    affectsStyles: true
+    githubRepo: uswds
+    githubPr: 5372
+    versionUswds: 3.6.0
+  - date: 2022-11-14
+    page: Memorable date
+    summary: Updated the month entry to a `select` from an `input`.
+    summaryAdditional: Recent usability testing indicated that using a `select` for month entry was more clear and reduced mistakes.
+    affectsMarkup: true
+    affectsStyles: true
+    affectsGuidance: true
+    githubRepo: uswds
+    githubPr: 4937
+    versionUswds: 3.3.0
+  - date: 2022-04-28
+    page: Memorable date
+    summary: Added guidance for adding labels and using text boxes in place of select elements.
+    affectsGuidance: true
+    githubPr: 1538
+    githubRepo: uswds-site
+  - date: 2022-04-28
+    page: Memorable date
+    summary: Updated package name to `usa-memorable-date`.
+    affectsGuidance: true
+    githubPr: 1538
+    githubRepo: uswds-site
+  - date: 2022-04-28
+    page: Memorable date
+    summary: Renamed component from "date input" to "memorable date".
+    affectsGuidance: true
+    githubPr: 1538
+    githubRepo: uswds-site
+  - date: 2022-04-28
+    page: Memorable date
+    summary: Updated to Sass module syntax and new package structure.
+    isBreaking: true
+    affectsAssets: true
+    affectsJavascript: true
+    affectsStyles: true
+    githubPr: 4656
+    githubRepo: uswds
+    versionUswds: 3.0.0
+  - date: 2022-04-13
+    page: Memorable date
+    summary: Updated package name to `form-controls`.
+    affectsGuidance: true
+    githubPr: 1497
+    githubRepo: uswds-site

--- a/_data/changelogs/component-modal.yml
+++ b/_data/changelogs/component-modal.yml
@@ -3,12 +3,14 @@ type: component
 changelogURL:
 items:
   - date: 2024-12-18
+    page: Modal
     summary: Replaced deprecated `xlink:href` references with `href`.
     affectsMarkup: true
     githubPr: 6165
     githubRepo: uswds
     versionUswds: 3.11.0
   - date: 2024-11-13
+    page: Modal
     summary: Fixed a bug that prevented bundling the modal package with a custom prefix.
     summaryAdditional: This update removed hard-coded class names from the modal JavaScript.
     isBreaking: false
@@ -17,6 +19,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.10.0
   - date: 2024-11-6
+    page: Modal
     summary: Added focus trap guidance.
     summaryAdditional: Updated guidance to ensure users trap focus inside the modal so that it doesn't move to the content behind it.
     isBreaking: false
@@ -25,6 +28,7 @@ items:
     githubRepo: uswds-site
     versionUswds: 3.9.0
   - date: 2023-11-09
+    page: Modal
     summary: Updated JavaScript to include fallbacks and error messages when initialization cannot be completed.
     summaryAdditional: Additionally, this improved code consistency and prevented errors when trying to initialize modal twice.
     isBreaking: false
@@ -33,6 +37,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.7.0
   - date: 2023-09-29
+    page: Modal
     summary: Updated how the modal JavaScript resets body padding and improved body padding detection.
     summaryAdditional: Now the component will rely on the CSS to reset body padding rather than injecting an inline style with JavaScript.
     affectsJavascript: true
@@ -41,6 +46,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.6.1
   - date: 2023-03-09
+    page: Modal
     summary: Fixed the display of interactive form elements (like Date Picker) in modal windows.
     summaryAdditional: Now any element in a modal should work as expected.
     isBreaking: false
@@ -49,6 +55,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.4.0
   - date: 2022-08-05
+    page: Modal
     summary: Styled aria-disabled to match disabled.
     summaryAdditional: Now disabled styling is applied whether you use `disabled` (disabled and hidden from screen readers) or `aria-disabled` (disabled and visible to screen readers).
     isBreaking: false
@@ -62,6 +69,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.1.0
   - date: 2022-08-05
+    page: Modal
     summary: Added `type="button"` to all non-form buttons to prevent default submit behaviors.
     summaryAdditional: This allowed us to remove `preventDefault()` from the relevant component JavaScript.
     affectsJavascript: true
@@ -70,6 +78,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.1.0
   - date: 2022-04-28
+    page: Modal
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAccessibility: true
@@ -82,16 +91,19 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.0
   - date: 2022-06-16
+    page: Modal
     summary: Added guidance for handling external links.
     affectsGuidance: true
     githubPr: 1225
     githubRepo: uswds-site
   - date: 2021-03-17
+    page: Modal
     summary: Added modal documentation.
     affectsGuidance: true
     githubPr: 1180
     githubRepo: uswds-site
   - date: 2021-03-17
+    page: Modal
     summary: Added modal component.
     summaryAdditional: A modal disables page content and focuses the user’s attention on a single task or message.
     isBreaking: false

--- a/_data/changelogs/component-pagination-accessibility.yml
+++ b/_data/changelogs/component-pagination-accessibility.yml
@@ -2,6 +2,7 @@ title: Pagination accessibility tests
 type: component
 items:
   - date: 2024-10-16
+    page: Pagination accessibility tests
     summary: Added accessibility tests page.
     affectsGuidance: true
     githubPr: 2865

--- a/_data/changelogs/component-pagination.yml
+++ b/_data/changelogs/component-pagination.yml
@@ -3,17 +3,20 @@ type: component
 changelogURL:
 items:
   - date: 2024-12-18
+    page: Pagination
     summary: Replaced deprecated `xlink:href` references with `href`.
     affectsMarkup: true
     githubPr: 6165
     githubRepo: uswds
     versionUswds: 3.11.0
   - date: 2024-10-16
+    page: Pagination
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 2865
     githubRepo: uswds-site
   - date: 2024-10-04
+    page: Pagination
     summary: Added text underline styles to pagination links.
     summaryAdditional: Pagination links are now visually consistent with other USWDS text links.
     affectsAccessibility: true
@@ -22,6 +25,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.9.0
   - date: 2023-08-23
+    page: Pagination
     summary: Updated styles to respect the value of `$theme-pagination-background-color`.
     summaryAdditional: Users should confirm that pagination colors display as expected.
     isBreaking: true
@@ -30,6 +34,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.6.0
   - date: 2023-08-23
+    page: Pagination
     summary: Updated the ellipsis color to meet color contrast requirements.
     summaryAdditional:
     affectsAccessibility: true
@@ -38,6 +43,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.6.0
   - date: 2023-06-09
+    page: Pagination
     summary: Improved legibility in forced colors mode.
     summaryAdditional: Adds a consistent border in forced colors mode.
     affectsAccessibility: true
@@ -46,6 +52,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-06-09
+    page: Pagination
     summary: Improved accessible markup of overflow ellipses.
     summaryAdditional: We replaced the `role="presentation"` with `aria-label="ellipsis indicating non-visible pages"` for `usa-pagination__overflow` items to better conform to WCAG 2.0 and 2.1.
     affectsMarkup: true
@@ -54,6 +61,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2022-04-28
+    page: Pagination
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true
@@ -63,6 +71,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.0
   - date: 2022-04-11
+    page: Pagination
     summary: Added support for forced colors mode.
     summaryAdditional: All our components now support proper display when users have a forced colors mode set in their operating system.
     isBreaking: false
@@ -76,11 +85,13 @@ items:
     githubRepo: uswds
     versionUswds: 2.13.3
   - date: 2021-06-16
+    page: Pagination
     summary: Added pagination documentation.
     affectsGuidance: true
     githubPr: 1218
     githubRepo: uswds-site
   - date: 2021-06-16
+    page: Pagination
     summary: Added pagination component.
     summaryAdditional: Pagination is navigation for paginated content.
     isBreaking: false

--- a/_data/changelogs/component-process-list-accessibility.yml
+++ b/_data/changelogs/component-process-list-accessibility.yml
@@ -2,6 +2,7 @@ title: Process list accessibility tests
 type: component
 items:
   - date: 2024-12-18
+    page: Process list accessibility tests
     summary: Added accessibility tests page.
     affectsGuidance: true
     githubPr: 3007

--- a/_data/changelogs/component-process-list.yml
+++ b/_data/changelogs/component-process-list.yml
@@ -3,11 +3,13 @@ type: component
 changelogURL:
 items:
   - date: 2024-12-18
+    page: Process list
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 3007
     githubRepo: uswds-site
   - date: 2022-04-28
+    page: Process list
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true

--- a/_data/changelogs/component-prose-accessibility.yml
+++ b/_data/changelogs/component-prose-accessibility.yml
@@ -1,8 +1,9 @@
 title: Prose accessibility tests
 type: component
 items:
-- date: 2024-04-18
-  summary: Added accessibility tests page.
-  affectsGuidance: true
-  githubPr: 2613
-  githubRepo: uswds-site
+  - date: 2024-04-18
+    page: Prose accessibility tests
+    summary: Added accessibility tests page.
+    affectsGuidance: true
+    githubPr: 2613
+    githubRepo: uswds-site

--- a/_data/changelogs/component-prose.yml
+++ b/_data/changelogs/component-prose.yml
@@ -2,33 +2,37 @@ title: Prose
 type: component
 changelogURL:
 items:
-- date: 2024-05-15
-  summary: Added WCAG compliance tag and accessibility test status section.
-  affectsGuidance: true
-  githubPr: 2613
-  githubRepo: uswds-site
-- date: 2023-06-09
-  summary: Added `$theme-heading-margin-top` and `$theme-paragraph-margin-top` system variables.
-  affectsStyles: true
-  affectsSettings: true
-  githubPr: 5158
-  githubRepo: uswds
-  versionUswds: 3.5.0
-- date: 2023-06-09
-  summary: Removed `usa-prose-` mixins and placeholders from Sass.
-  summaryAdditional: Users should instead use `typeset-` mixins in their place. This is a breaking change only if your project Sass uses `usa-prose-` mixins and placeholders. It does not affect the look of any `usa-prose`–styled element.
-  isBreaking: true
-  affectsStyles: true
-  affectsSettings: true
-  githubPr: 5158
-  githubRepo: uswds
-  versionUswds: 3.5.0
-- date: 2022-04-28
-  summary: Updated to Sass module syntax and new package structure.
-  isBreaking: true
-  affectsAssets: true
-  affectsJavascript: true
-  affectsStyles: true
-  githubPr: 4656
-  githubRepo: uswds
-  versionUswds: 3.0.0
+  - date: 2024-05-15
+    page: Prose
+    summary: Added WCAG compliance tag and accessibility test status section.
+    affectsGuidance: true
+    githubPr: 2613
+    githubRepo: uswds-site
+  - date: 2023-06-09
+    page: Prose
+    summary: Added `$theme-heading-margin-top` and `$theme-paragraph-margin-top` system variables.
+    affectsStyles: true
+    affectsSettings: true
+    githubPr: 5158
+    githubRepo: uswds
+    versionUswds: 3.5.0
+  - date: 2023-06-09
+    page: Prose
+    summary: Removed `usa-prose-` mixins and placeholders from Sass.
+    summaryAdditional: Users should instead use `typeset-` mixins in their place. This is a breaking change only if your project Sass uses `usa-prose-` mixins and placeholders. It does not affect the look of any `usa-prose`–styled element.
+    isBreaking: true
+    affectsStyles: true
+    affectsSettings: true
+    githubPr: 5158
+    githubRepo: uswds
+    versionUswds: 3.5.0
+  - date: 2022-04-28
+    page: Prose
+    summary: Updated to Sass module syntax and new package structure.
+    isBreaking: true
+    affectsAssets: true
+    affectsJavascript: true
+    affectsStyles: true
+    githubPr: 4656
+    githubRepo: uswds
+    versionUswds: 3.0.0

--- a/_data/changelogs/component-radio-buttons-accessibility.yml
+++ b/_data/changelogs/component-radio-buttons-accessibility.yml
@@ -1,8 +1,9 @@
 title: Radio button accessibility tests
 type: component
 items:
- - date: 2024-09-18
-   summary: Added accessibility tests page.
-   affectsGuidance: true
-   githubPr: 2821
-   githubRepo: uswds-site
+  - date: 2024-09-18
+    page: Radio button accessibility tests
+    summary: Added accessibility tests page.
+    affectsGuidance: true
+    githubPr: 2821
+    githubRepo: uswds-site

--- a/_data/changelogs/component-radio-buttons.yml
+++ b/_data/changelogs/component-radio-buttons.yml
@@ -2,157 +2,173 @@ title: Radio buttons
 type: component
 changelogURL:
 items:
-- date: 2024-09-18
-  summary: Added WCAG compliance tag and accessibility test status section.
-  affectsGuidance: true
-  githubPr: 2821
-  githubRepo: uswds-site
-- date: 2023-09-29
-  summary: Updated radio and checkbox tile styling to have lighter borders.
-  summaryAdditional:
-  affectsAccessibility: true
-  affectsStyles: true
-  githubPr: 5494
-  githubRepo: uswds
-  versionUswds: 3.6.1
-- date: 2023-06-09
-  summary: Improved legibility in forced colors mode.
-  summaryAdditional: Adds a consistent border in forced colors mode.
-  affectsAccessibility: true
-  affectsStyles: true
-  githubPr: 5147
-  githubRepo: uswds
-  versionUswds: 3.5.0
-- date: 2023-06-09
-  summary: Improved consistency and visibility of disabled styles.
-  summaryAdditional: Form elements with the `disabled` or `aria-disabled` attribute now get consistent styling and have proper color contrast.
-  affectsAccessibility: true
-  affectsStyles: true
-  githubPr: 5063
-  githubRepo: uswds
-  versionUswds: 3.5.0
-- date: 2023-06-09
-  summary: Improved consistency of disabled styles in forced colors mode.
-  summaryAdditional:
-  affectsAccessibility: true
-  affectsStyles: true
-  githubPr: 5295
-  githubRepo: uswds
-  versionUswds: 3.5.0
-- date: 2022-08-05
-  summary: Styled aria-disabled to match disabled.
-  summaryAdditional: Now disabled styling is applied whether you use `disabled` (disabled and hidden from screen readers) or `aria-disabled` (disabled and visible to screen readers).
-  isBreaking:
-  affectsAccessibility:
-  affectsAssets:
-  affectsGuidance:
-  affectsJavascript:
-  affectsMarkup:
-  affectsStyles:
-  githubPr: 4783
-  githubRepo: uswds
-  versionUswds: 3.1.0
-- date: 2022-04-28
-  summary: Updated package name to `usa-radio`.
-  affectsGuidance: true
-  githubPr: 1538
-  githubRepo: uswds-site
-- date: 2022-04-28
-  summary: Updated to Sass module syntax and new package structure.
-  isBreaking: true
-  affectsAssets: true
-  affectsJavascript: true
-  affectsStyles: true
-  githubPr: 4656
-  githubRepo: uswds
-  versionUswds: 3.0.0
-- date: 2022-04-13
-  summary: Updated package name to `form-controls`.
-  affectsGuidance: true
-  githubPr: 1497
-  githubRepo: uswds-site
-- date: 2022-04-11
-  summary: Added support for forced colors mode.
-  summaryAdditional: All our components now support proper display when users have a forced colors mode set in their operating system.
-  isBreaking: false
-  affectsAccessibility: true
-  affectsAssets: false
-  affectsGuidance: false
-  affectsJavascript: false
-  affectsMarkup: false
-  affectsStyles: true
-  githubPr: 4610
-  githubRepo: uswds
-  versionUswds: 2.13.3
-- date: 2021-08-18
-  summary: Improved whitespace sensitivity of radio and checkbox tiles.
-  summaryAdditional: Now radio and checkbox tiles will display consistently whether or not there's extra whitespace in the markup.
-  isBreaking: false
-  affectsAccessibility: false
-  affectsAssets: false
-  affectsGuidance: false
-  affectsJavascript: false
-  affectsMarkup: false
-  affectsStyles: true
-  githubPr: 4286
-  githubRepo: uswds
-  versionUswds: 2.12.1
-- date: 2021-08-18
-  summary: Improved class order sensitivity for checkbox and radio.
-  summaryAdditional: Now checkbox and radio components display properly regardless of the order of the class and modifier names.
-  isBreaking: false
-  affectsAccessibility: false
-  affectsAssets: false
-  affectsGuidance: false
-  affectsJavascript: false
-  affectsMarkup: false
-  affectsStyles: true
-  githubPr: 4262
-  githubRepo: uswds
-  versionUswds: 2.12.1
-- date: 2021-06-16
-  summary: Updated checkbox and radio buttons to include automatic accessible color.
-  summaryAdditional: Now checkbox and radio buttons will display in the proper accessible color, and adapt to the text, link, and background colors you set in your projects's settings.
-  isBreaking: false
-  affectsAccessibility: true
-  affectsAssets: false
-  affectsGuidance: false
-  affectsJavascript: false
-  affectsMarkup: false
-  affectsStyles: true
-  githubPr: 4199
-  githubRepo: uswds
-  versionUswds: 2.12.0
-- date: 2021-06-16
-  summary:  Updated margins in radio tiles.
-  summaryAdditional: Now radio tiles have cleaner, more reliable styling for their margin.
-  affectsStyles: true
-  githubPr: 4181
-  githubRepo: uswds
-  versionUswds: 2.12.0
-- date: 2021-04-28
-  summary: Updated checked radio buttons to remain checked in disabled state.
-  summaryAdditional: Now the visual checked state of a checked checkbox does not change if that element is later disabled.
-  isBreaking: false
-  affectsAccessibility: false
-  affectsAssets: false
-  affectsGuidance: false
-  affectsJavascript: false
-  affectsMarkup: false
-  affectsStyles: true
-  githubPr: 4160
-  githubRepo: uswds
-  versionUswds: 2.11.2
-- date: 2021-03-17
-  summary: Fixed character display in checkboxes and radio buttons.
-  summaryAdditional: Allowed checkboxes and radio buttons to display properly regardless of character encoding.
-  isBreaking: false
-  affectsAccessibility: false
-  affectsAssets: false
-  affectsGuidance: false
-  affectsJavascript: true
-  affectsMarkup: false
-  affectsStyles: true
-  githubPr: 4080
-  githubRepo: uswds
-  versionUswds: 2.11.0
+  - date: 2024-09-18
+    page: Radio buttons
+    summary: Added WCAG compliance tag and accessibility test status section.
+    affectsGuidance: true
+    githubPr: 2821
+    githubRepo: uswds-site
+  - date: 2023-09-29
+    page: Radio buttons
+    summary: Updated radio and checkbox tile styling to have lighter borders.
+    summaryAdditional:
+    affectsAccessibility: true
+    affectsStyles: true
+    githubPr: 5494
+    githubRepo: uswds
+    versionUswds: 3.6.1
+  - date: 2023-06-09
+    page: Radio buttons
+    summary: Improved legibility in forced colors mode.
+    summaryAdditional: Adds a consistent border in forced colors mode.
+    affectsAccessibility: true
+    affectsStyles: true
+    githubPr: 5147
+    githubRepo: uswds
+    versionUswds: 3.5.0
+  - date: 2023-06-09
+    page: Radio buttons
+    summary: Improved consistency and visibility of disabled styles.
+    summaryAdditional: Form elements with the `disabled` or `aria-disabled` attribute now get consistent styling and have proper color contrast.
+    affectsAccessibility: true
+    affectsStyles: true
+    githubPr: 5063
+    githubRepo: uswds
+    versionUswds: 3.5.0
+  - date: 2023-06-09
+    page: Radio buttons
+    summary: Improved consistency of disabled styles in forced colors mode.
+    summaryAdditional:
+    affectsAccessibility: true
+    affectsStyles: true
+    githubPr: 5295
+    githubRepo: uswds
+    versionUswds: 3.5.0
+  - date: 2022-08-05
+    page: Radio buttons
+    summary: Styled aria-disabled to match disabled.
+    summaryAdditional: Now disabled styling is applied whether you use `disabled` (disabled and hidden from screen readers) or `aria-disabled` (disabled and visible to screen readers).
+    isBreaking:
+    affectsAccessibility:
+    affectsAssets:
+    affectsGuidance:
+    affectsJavascript:
+    affectsMarkup:
+    affectsStyles:
+    githubPr: 4783
+    githubRepo: uswds
+    versionUswds: 3.1.0
+  - date: 2022-04-28
+    page: Radio buttons
+    summary: Updated package name to `usa-radio`.
+    affectsGuidance: true
+    githubPr: 1538
+    githubRepo: uswds-site
+  - date: 2022-04-28
+    page: Radio buttons
+    summary: Updated to Sass module syntax and new package structure.
+    isBreaking: true
+    affectsAssets: true
+    affectsJavascript: true
+    affectsStyles: true
+    githubPr: 4656
+    githubRepo: uswds
+    versionUswds: 3.0.0
+  - date: 2022-04-13
+    page: Radio buttons
+    summary: Updated package name to `form-controls`.
+    affectsGuidance: true
+    githubPr: 1497
+    githubRepo: uswds-site
+  - date: 2022-04-11
+    page: Radio buttons
+    summary: Added support for forced colors mode.
+    summaryAdditional: All our components now support proper display when users have a forced colors mode set in their operating system.
+    isBreaking: false
+    affectsAccessibility: true
+    affectsAssets: false
+    affectsGuidance: false
+    affectsJavascript: false
+    affectsMarkup: false
+    affectsStyles: true
+    githubPr: 4610
+    githubRepo: uswds
+    versionUswds: 2.13.3
+  - date: 2021-08-18
+    page: Radio buttons
+    summary: Improved whitespace sensitivity of radio and checkbox tiles.
+    summaryAdditional: Now radio and checkbox tiles will display consistently whether or not there's extra whitespace in the markup.
+    isBreaking: false
+    affectsAccessibility: false
+    affectsAssets: false
+    affectsGuidance: false
+    affectsJavascript: false
+    affectsMarkup: false
+    affectsStyles: true
+    githubPr: 4286
+    githubRepo: uswds
+    versionUswds: 2.12.1
+  - date: 2021-08-18
+    page: Radio buttons
+    summary: Improved class order sensitivity for checkbox and radio.
+    summaryAdditional: Now checkbox and radio components display properly regardless of the order of the class and modifier names.
+    isBreaking: false
+    affectsAccessibility: false
+    affectsAssets: false
+    affectsGuidance: false
+    affectsJavascript: false
+    affectsMarkup: false
+    affectsStyles: true
+    githubPr: 4262
+    githubRepo: uswds
+    versionUswds: 2.12.1
+  - date: 2021-06-16
+    page: Radio buttons
+    summary: Updated checkbox and radio buttons to include automatic accessible color.
+    summaryAdditional: Now checkbox and radio buttons will display in the proper accessible color, and adapt to the text, link, and background colors you set in your projects's settings.
+    isBreaking: false
+    affectsAccessibility: true
+    affectsAssets: false
+    affectsGuidance: false
+    affectsJavascript: false
+    affectsMarkup: false
+    affectsStyles: true
+    githubPr: 4199
+    githubRepo: uswds
+    versionUswds: 2.12.0
+  - date: 2021-06-16
+    page: Radio buttons
+    summary: Updated margins in radio tiles.
+    summaryAdditional: Now radio tiles have cleaner, more reliable styling for their margin.
+    affectsStyles: true
+    githubPr: 4181
+    githubRepo: uswds
+    versionUswds: 2.12.0
+  - date: 2021-04-28
+    page: Radio buttons
+    summary: Updated checked radio buttons to remain checked in disabled state.
+    summaryAdditional: Now the visual checked state of a checked checkbox does not change if that element is later disabled.
+    isBreaking: false
+    affectsAccessibility: false
+    affectsAssets: false
+    affectsGuidance: false
+    affectsJavascript: false
+    affectsMarkup: false
+    affectsStyles: true
+    githubPr: 4160
+    githubRepo: uswds
+    versionUswds: 2.11.2
+  - date: 2021-03-17
+    page: Radio buttons
+    summary: Fixed character display in checkboxes and radio buttons.
+    summaryAdditional: Allowed checkboxes and radio buttons to display properly regardless of character encoding.
+    isBreaking: false
+    affectsAccessibility: false
+    affectsAssets: false
+    affectsGuidance: false
+    affectsJavascript: true
+    affectsMarkup: false
+    affectsStyles: true
+    githubPr: 4080
+    githubRepo: uswds
+    versionUswds: 2.11.0

--- a/_data/changelogs/component-range-slider.yml
+++ b/_data/changelogs/component-range-slider.yml
@@ -2,64 +2,70 @@ title: Range slider
 type: component
 changelogURL:
 items:
-- date: 2023-11-09
-  summary: Added optional data attributes to customize text for screen readers.
-  summaryAdditional: The `data-text-unit` attribute provides additional context to screen reader users, and `data-text-preposition` allows for proper preposition translations on non-English pages.
-  isBreaking: false
-  affectsAccessibility: true
-  affectsGuidance: true
-  affectsJavascript: true
-  affectsMarkup: true
-  githubPr: 5472
-  githubRepo: USWDS
-  versionUswds: 3.7.0
-- date: 2023-11-09
-  summary: Removed redundant ARIA attributes to improve the screen reader experience.
-  summaryAdditional: To incorporate these changes, update your range component markup.
-  affectsAccessibility: true
-  affectsMarkup: true
-  githubPr: 5413
-  githubRepo: uswds
-  versionUswds: 3.7.0
-- date: 2023-06-09
-  summary: Improved legibility in forced colors mode.
-  summaryAdditional: Adds a consistent border in forced colors mode.
-  affectsAccessibility: true
-  affectsStyles: true
-  githubPr: 5147
-  githubRepo: uswds
-  versionUswds: 3.5.0
-- date: 2022-04-28
-  summary: Updated to Sass module syntax and new package structure.
-  isBreaking: true
-  affectsAssets: true
-  affectsJavascript: true
-  affectsStyles: true
-  githubPr: 4656
-  githubRepo: uswds
-  versionUswds: 3.0.0
-- date: 2022-04-11
-  summary: Added support for forced colors mode.
-  summaryAdditional: All our components now support proper display when users have a forced colors mode set in their operating system.
-  isBreaking: false
-  affectsAccessibility: true
-  affectsAssets: false
-  affectsGuidance: false
-  affectsJavascript: false
-  affectsMarkup: false
-  affectsStyles: true
-  githubPr: 4610
-  githubRepo: uswds
-  versionUswds: 2.13.3
-- date: 2021-08-18
-  summary: Added appropriate ARIA attributes to the `input` element.
-  isBreaking: false
-  affectsAccessibility: true
-  affectsAssets: false
-  affectsGuidance: false
-  affectsJavascript: false
-  affectsMarkup: true
-  affectsStyles: false
-  githubPr: 4270
-  githubRepo: uswds
-  versionUswds: 2.12.1
+  - date: 2023-11-09
+    page: Range slider
+    summary: Added optional data attributes to customize text for screen readers.
+    summaryAdditional: The `data-text-unit` attribute provides additional context to screen reader users, and `data-text-preposition` allows for proper preposition translations on non-English pages.
+    isBreaking: false
+    affectsAccessibility: true
+    affectsGuidance: true
+    affectsJavascript: true
+    affectsMarkup: true
+    githubPr: 5472
+    githubRepo: USWDS
+    versionUswds: 3.7.0
+  - date: 2023-11-09
+    page: Range slider
+    summary: Removed redundant ARIA attributes to improve the screen reader experience.
+    summaryAdditional: To incorporate these changes, update your range component markup.
+    affectsAccessibility: true
+    affectsMarkup: true
+    githubPr: 5413
+    githubRepo: uswds
+    versionUswds: 3.7.0
+  - date: 2023-06-09
+    page: Range slider
+    summary: Improved legibility in forced colors mode.
+    summaryAdditional: Adds a consistent border in forced colors mode.
+    affectsAccessibility: true
+    affectsStyles: true
+    githubPr: 5147
+    githubRepo: uswds
+    versionUswds: 3.5.0
+  - date: 2022-04-28
+    page: Range slider
+    summary: Updated to Sass module syntax and new package structure.
+    isBreaking: true
+    affectsAssets: true
+    affectsJavascript: true
+    affectsStyles: true
+    githubPr: 4656
+    githubRepo: uswds
+    versionUswds: 3.0.0
+  - date: 2022-04-11
+    page: Range slider
+    summary: Added support for forced colors mode.
+    summaryAdditional: All our components now support proper display when users have a forced colors mode set in their operating system.
+    isBreaking: false
+    affectsAccessibility: true
+    affectsAssets: false
+    affectsGuidance: false
+    affectsJavascript: false
+    affectsMarkup: false
+    affectsStyles: true
+    githubPr: 4610
+    githubRepo: uswds
+    versionUswds: 2.13.3
+  - date: 2021-08-18
+    page: Range slider
+    summary: Added appropriate ARIA attributes to the `input` element.
+    isBreaking: false
+    affectsAccessibility: true
+    affectsAssets: false
+    affectsGuidance: false
+    affectsJavascript: false
+    affectsMarkup: true
+    affectsStyles: false
+    githubPr: 4270
+    githubRepo: uswds
+    versionUswds: 2.12.1

--- a/_data/changelogs/component-search-accessibility.yml
+++ b/_data/changelogs/component-search-accessibility.yml
@@ -1,8 +1,9 @@
 title: Search accessibility tests
 type: component
 items:
-- date: 2024-06-19
-  summary: Added accessibility tests page.
-  affectsGuidance: true
-  githubPr: 2694
-  githubRepo: uswds-site
+  - date: 2024-06-19
+    page: Search accessibility tests
+    summary: Added accessibility tests page.
+    affectsGuidance: true
+    githubPr: 2694
+    githubRepo: uswds-site

--- a/_data/changelogs/component-search.yml
+++ b/_data/changelogs/component-search.yml
@@ -2,38 +2,42 @@ title: Search
 type: component
 changelogURL:
 items:
-- date: 2024-06-19
-  summary: Added WCAG compliance tag and accessibility test status section.
-  affectsGuidance: true
-  githubPr: 2694
-  githubRepo: uswds-site
-- date: 2023-06-09
-  summary: Improved legibility in forced colors mode.
-  summaryAdditional: Adds a consistent border in forced colors mode.
-  affectsAccessibility: true
-  affectsStyles: true
-  githubPr: 5147
-  githubRepo: uswds
-  versionUswds: 3.5.0
-- date: 2022-04-28
-  summary: Updated to Sass module syntax and new package structure.
-  isBreaking: true
-  affectsAssets: true
-  affectsJavascript: true
-  affectsStyles: true
-  githubPr: 4656
-  githubRepo: uswds
-  versionUswds: 3.0.0
-- date: 2021-12-14
-  summary:  Improved resilience of icon-only functionality.
-  summaryAdditional: Updated to add a text equivalent if the image path is broken and does not load.
-  isBreaking: true
-  affectsAccessibility: true
-  affectsAssets: false
-  affectsGuidance: false
-  affectsJavascript: false
-  affectsMarkup: true
-  affectsStyles: true
-  githubPr: 4274
-  githubRepo: uswds
-  versionUswds: 2.13.0
+  - date: 2024-06-19
+    page: Search
+    summary: Added WCAG compliance tag and accessibility test status section.
+    affectsGuidance: true
+    githubPr: 2694
+    githubRepo: uswds-site
+  - date: 2023-06-09
+    page: Search
+    summary: Improved legibility in forced colors mode.
+    summaryAdditional: Adds a consistent border in forced colors mode.
+    affectsAccessibility: true
+    affectsStyles: true
+    githubPr: 5147
+    githubRepo: uswds
+    versionUswds: 3.5.0
+  - date: 2022-04-28
+    page: Search
+    summary: Updated to Sass module syntax and new package structure.
+    isBreaking: true
+    affectsAssets: true
+    affectsJavascript: true
+    affectsStyles: true
+    githubPr: 4656
+    githubRepo: uswds
+    versionUswds: 3.0.0
+  - date: 2021-12-14
+    page: Search
+    summary: Improved resilience of icon-only functionality.
+    summaryAdditional: Updated to add a text equivalent if the image path is broken and does not load.
+    isBreaking: true
+    affectsAccessibility: true
+    affectsAssets: false
+    affectsGuidance: false
+    affectsJavascript: false
+    affectsMarkup: true
+    affectsStyles: true
+    githubPr: 4274
+    githubRepo: uswds
+    versionUswds: 2.13.0

--- a/_data/changelogs/component-select-accessibility.yml
+++ b/_data/changelogs/component-select-accessibility.yml
@@ -3,6 +3,7 @@ type: component
 changelogURL:
 items:
   - date: 2024-06-19
+    page: Select accessibility tests
     summary: Added accessibility tests page.
     summaryAdditional:
     affectsGuidance: true

--- a/_data/changelogs/component-select.yml
+++ b/_data/changelogs/component-select.yml
@@ -2,63 +2,70 @@ title: Select
 type: component
 changelogURL:
 items:
-- date: 2024-06-19
-  summary: Added WCAG compliance tag and accessibility test status section.
-  affectsGuidance: true
-  githubPr: 2702
-  githubRepo: uswds-site
-- date: 2023-08-23
-  summary: Added ellipses to overflow text in the multiple select variant.
-  summaryAdditional: This provides a clear indication to users that there is text that extends beyond the select width.
-  isBreaking: false
-  affectsAccessibility: false
-  affectsGuidance: false
-  affectsJavascript: false
-  affectsMarkup: false
-  affectsStyles: true
-  githubPr: 5268
-  githubRepo: uswds
-  versionUswds: 3.6.0
-- date: 2023-06-09
-  summary: Improved consistency and visibility of disabled styles.
-  summaryAdditional: Form elements with the `disabled` or `aria-disabled` attribute now get consistent styling and have proper color contrast.
-  affectsAccessibility: true
-  affectsStyles: true
-  githubPr: 5063
-  githubRepo: uswds
-  versionUswds: 3.5.0
-- date: 2023-06-09
-  summary: Improved consistency of disabled styles in forced colors mode.
-  summaryAdditional:
-  affectsAccessibility: true
-  affectsStyles: true
-  githubPr: 5295
-  githubRepo: uswds
-  versionUswds: 3.5.0
-- date:  2022-08-05
-  summary: Improved styling for select when the `multiple` attribute is present.
-  summaryAdditional: According to the HTML5 standard, a select element whose `multiple` attribute is present is "expected to render as an inline-block box whose height is the height necessary to contain as many rows for items as given by the element's display size, or four rows if the [size] attribute is absent." Our select now conforms to this guidance.
-  isBreaking: false
-  affectsAccessibility: false
-  affectsAssets: false
-  affectsGuidance: false
-  affectsJavascript: false
-  affectsMarkup: false
-  affectsStyles: true
-  githubPr: 4766
-  githubRepo: uswds
-  versionUswds: 3.1.0
-- date: 2022-04-28
-  summary: Updated to Sass module syntax and new package structure.
-  isBreaking: true
-  affectsAssets: true
-  affectsJavascript: true
-  affectsStyles: true
-  githubPr: 4656
-  githubRepo: uswds
-  versionUswds: 3.0.0
-- date: 2022-04-28
-  summary: Renamed component from "dropdown" to "select".
-  affectsGuidance: true
-  githubPr: 1538
-  githubRepo: uswds-site
+  - date: 2024-06-19
+    page: Select
+    summary: Added WCAG compliance tag and accessibility test status section.
+    affectsGuidance: true
+    githubPr: 2702
+    githubRepo: uswds-site
+  - date: 2023-08-23
+    page: Select
+    summary: Added ellipses to overflow text in the multiple select variant.
+    summaryAdditional: This provides a clear indication to users that there is text that extends beyond the select width.
+    isBreaking: false
+    affectsAccessibility: false
+    affectsGuidance: false
+    affectsJavascript: false
+    affectsMarkup: false
+    affectsStyles: true
+    githubPr: 5268
+    githubRepo: uswds
+    versionUswds: 3.6.0
+  - date: 2023-06-09
+    page: Select
+    summary: Improved consistency and visibility of disabled styles.
+    summaryAdditional: Form elements with the `disabled` or `aria-disabled` attribute now get consistent styling and have proper color contrast.
+    affectsAccessibility: true
+    affectsStyles: true
+    githubPr: 5063
+    githubRepo: uswds
+    versionUswds: 3.5.0
+  - date: 2023-06-09
+    page: Select
+    summary: Improved consistency of disabled styles in forced colors mode.
+    summaryAdditional:
+    affectsAccessibility: true
+    affectsStyles: true
+    githubPr: 5295
+    githubRepo: uswds
+    versionUswds: 3.5.0
+  - date: 2022-08-05
+    page: Select
+    summary: Improved styling for select when the `multiple` attribute is present.
+    summaryAdditional: According to the HTML5 standard, a select element whose `multiple` attribute is present is "expected to render as an inline-block box whose height is the height necessary to contain as many rows for items as given by the element's display size, or four rows if the [size] attribute is absent." Our select now conforms to this guidance.
+    isBreaking: false
+    affectsAccessibility: false
+    affectsAssets: false
+    affectsGuidance: false
+    affectsJavascript: false
+    affectsMarkup: false
+    affectsStyles: true
+    githubPr: 4766
+    githubRepo: uswds
+    versionUswds: 3.1.0
+  - date: 2022-04-28
+    page: Select
+    summary: Updated to Sass module syntax and new package structure.
+    isBreaking: true
+    affectsAssets: true
+    affectsJavascript: true
+    affectsStyles: true
+    githubPr: 4656
+    githubRepo: uswds
+    versionUswds: 3.0.0
+  - date: 2022-04-28
+    page: Select
+    summary: Renamed component from "dropdown" to "select".
+    affectsGuidance: true
+    githubPr: 1538
+    githubRepo: uswds-site

--- a/_data/changelogs/component-side-navigation-accessibility.yml
+++ b/_data/changelogs/component-side-navigation-accessibility.yml
@@ -2,6 +2,7 @@ title: Side navigation accessibility tests
 type: component
 items:
   - date: 2024-10-16
+    page: Side navigation accessibility tests
     summary: Added accessibility tests page.
     affectsGuidance: true
     githubPr: 2864

--- a/_data/changelogs/component-side-navigation.yml
+++ b/_data/changelogs/component-side-navigation.yml
@@ -3,12 +3,14 @@ type: component
 changelogURL:
 items:
   - date: 2024-10-16
+    page: Side navigation
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 2864
     githubRepo: uswds-site
   # 3.8.0 release
   - date: 2024-03-11
+    page: Side navigation
     summary: Added a new fallback setting for sidenavs in Documentation template.
     summaryAdditional: The new setting `$theme-sidenav-reorder` reorders the sidenav with CSS. Users should follow new markup recommendation in Documentation template's code example to avoid accessibility issues.
     isBreaking: false
@@ -25,6 +27,7 @@ items:
     versionUswds: 3.8.0
     # 3.1.0 release
   - date: 2022-08-05
+    page: Side navigation
     summary: Added `type="button"` to all non-form buttons to prevent default submit behaviors.
     summaryAdditional: This allowed us to remove `preventDefault()` from the relevant component JavaScript.
     isBreaking: true
@@ -39,6 +42,7 @@ items:
     versionUswds: 3.1.0
     # 3.0 release
   - date: 2022-04-28
+    page: Side navigation
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true
@@ -49,6 +53,7 @@ items:
     versionUswds: 3.0.0
     # 2.11.2 release
   - date: 2021-04-28
+    page: Side navigation
     summary: Fixed color of active parents in side navigation.
     summaryAdditional: Fixed a regression where parent items in `usa-sidenav` no longer receive `primary` color.
     isBreaking: false

--- a/_data/changelogs/component-site-alert-accessibility.yml
+++ b/_data/changelogs/component-site-alert-accessibility.yml
@@ -3,6 +3,7 @@ type: component
 changelogURL:
 items:
   - date: 2025-01-14
+    page: Site alert accessibility tests
     summary: Added accessibility tests page.
     affectsGuidance: true
     githubPr: 3049

--- a/_data/changelogs/component-site-alert.yml
+++ b/_data/changelogs/component-site-alert.yml
@@ -3,11 +3,13 @@ type: component
 changelogURL:
 items:
   - date: 2025-01-14
+    page: Site alert
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 3049
     githubRepo: uswds-site
   - date: 2024-10-04
+    page: Site alert
     summary: |
       Fixed a bug that caused `$theme-site-margins-width` to unexpectedly adjust the alignment inside the alert and site alert components.
     summaryAdditional: |
@@ -19,6 +21,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.9.0
   - date: 2023-11-09
+    page: Site alert
     summary: Removed the component's top margin.
     summaryAdditional:
     affectsStyles: true
@@ -26,6 +29,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.7.0
   - date: 2023-03-09
+    page: Site alert
     summary: Updated padding settings to accept any valid spacing token.
     summaryAdditional:
     affectsStyles: true
@@ -33,12 +37,14 @@ items:
     githubRepo: uswds
     versionUswds: 3.4.0
   - date: 2022-09-26
+    page: Site alert
     summary: Added guidance for using ARIA roles and ARIA labels.
     affectsGuidance: true
     githubPr: 1774
     githubRepo: uswds-site
   # 3.2.0 release
   - date: 2022-10-19
+    page: Site alert
     summary: Updated the alignment of site alert content to visually match banner content.
     summaryAdditional: The alert component was also updated.
     isBreaking: false
@@ -53,6 +59,7 @@ items:
     versionUswds: 3.2.0
   # 3.0 release
   - date: 2022-04-28
+    page: Site alert
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true
@@ -63,6 +70,7 @@ items:
     versionUswds: 3.0.0
   # 2.11.1
   - date: 2021-03-17
+    page: Site alert
     summary: Restored missing white icons.
     summaryAdditional: Restored `error--white`, `info--white`, and `warning--white` icons.
     affectsAssets: true
@@ -70,12 +78,14 @@ items:
     githubRepo: uswds
     versionUswds: 2.11.1
   - date: 2021-03-17
+    page: Site alert
     summary: Updated and improved guidance for site alert.
     affectsGuidance: true
     githubPr: 1180
     githubRepo: uswds-site
   # 2.11.0
   - date: 2021-03-17
+    page: Site alert
     summary: Provided better support for color icons that adapt to theme settings.
     summaryAdditional: Now the color of the alert icon will update automatically to adapt to the alert background, or to the color of the alert text.
     affectsAccessibility: false
@@ -89,6 +99,7 @@ items:
     versionUswds: 2.11.0
   # 2.11.0
   - date: 2021-03-17
+    page: Site alert
     summary: Added the `$theme-alert-padding-y` setting.
     summaryAdditional:
     affectsAccessibility: false

--- a/_data/changelogs/component-step-indicator.yml
+++ b/_data/changelogs/component-step-indicator.yml
@@ -4,6 +4,7 @@ changelogURL:
 
 items:
   - date: 2024-11-13
+    page: Step indicator
     summary: Removed the `aria-label` from the wrapper of the step indicator component.
     summaryAdditional: This resolves an error related to having an invalid attribute on a `div` element.
     affectsAccessibility: true
@@ -13,6 +14,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.10.0
   - date: 2023-03-09
+    page: Step indicator
     summary: Improved contrast on pending items.
     summaryAdditional: Graphical elements related to pending items now meet accessibility standards for contrast ratio.
     isBreaking: false
@@ -22,6 +24,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.4.0
   - date: 2022-04-28
+    page: Step indicator
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAccessibility: true

--- a/_data/changelogs/component-summary-box-accessibility.yml
+++ b/_data/changelogs/component-summary-box-accessibility.yml
@@ -2,6 +2,7 @@ title: Summary box accessibility tests
 type: component
 items:
   - date: 2024-12-17
+    page: Summary box accessibility tests
     summary: Added accessibility tests page.
     affectsGuidance: true
     githubPr: 3016

--- a/_data/changelogs/component-summary-box.yml
+++ b/_data/changelogs/component-summary-box.yml
@@ -6,12 +6,14 @@ changelogURL:
 
 items:
   - date: 2024-12-17
+    page: Summary box
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 3016
     githubRepo: uswds-site
   # 3.0 release
   - date: 2022-04-28
+    page: Summary box
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true
@@ -22,6 +24,7 @@ items:
     versionUswds: 3.0.0
   # 2.11.2 release
   - date: 2021-04-28
+    page: Summary box
     summary: Added missing summary box Sass package.
     summaryAdditional: Now you can add a summary box package to your project with `packages/usa-summary-box`.
     isBreaking: false

--- a/_data/changelogs/component-table-accessibility.yml
+++ b/_data/changelogs/component-table-accessibility.yml
@@ -3,6 +3,7 @@ type: component
 changelogURL:
 items:
   - date: 2024-03-20
+    page: Table accessibility tests
     summary: Added accessibility tests page.
     affectsGuidance: true
     githubPr: 2538

--- a/_data/changelogs/component-table.yml
+++ b/_data/changelogs/component-table.yml
@@ -5,6 +5,7 @@ changelogURL:
 
 items:
   - date: 2024-12-18
+    page: Table
     summary: Updated table header styles to be consistent across all table elements.
     summaryAdditional: Now, all `thead th`, `tbody th`, and `tfoot th` cells will have the same visual styles. Teams should confirm that their tables display as expected.
     isBreaking: false
@@ -13,11 +14,13 @@ items:
     githubRepo: uswds
     versionUswds: 3.11.0
   - date: 2024-03-20
+    page: Table
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 2538
     githubRepo: uswds-site
   - date: 2024-03-11
+    page: Table
     summary: Created the `.usa-table--sticky-header` variant to allow sticky positioning on table headers.
     summaryAdditional: Also added the `$theme-table-sticky-top-offset` setting, which controls the top position of sticky headers.
     affectsStyles: true
@@ -26,6 +29,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.8.0
   - date: 2024-03-11
+    page: Table
     summary: Added the `$theme-table-background-color` setting.
     summaryAdditional: Use this setting to declare the table background color at a theme level.
     affectsStyles: true
@@ -34,14 +38,16 @@ items:
     githubRepo: uswds
     versionUswds: 3.8.0
   - date: 2024-03-11
+    page: Table
     summary: Simplified the structure of the scrollable table component example.
-    summaryAdditional:  Empty headers in the complex table example were causing accessibility issues.
+    summaryAdditional: Empty headers in the complex table example were causing accessibility issues.
     isBreaking: false
     affectsContent: true
     githubPr: 5783
     githubRepo: uswds
     versionUswds: 3.8.0
   - date: 2023-09-29
+    page: Table
     summary: Fixed a bug that prevented VoiceOver from reading stacked table content while using Safari.
     affectsAccessibility: true
     affectsStyles: true
@@ -49,12 +55,14 @@ items:
     githubRepo: uswds
     versionUswds: 3.6.1
   - date: 2023-07-17
+    page: Table
     summary: Restored standard and striped table component previews to guidance page.
     summaryAdditional:
     affectsGuidance: true
     githubPr: 2143
     githubRepo: uswds-site
   - date: 2023-06-09
+    page: Table
     summary: Fixed a typo in the sortable table JavaScript that caused the `aria-label` in table headers to have an unnecessary single quote.
     summaryAdditional:
     isBreaking: false
@@ -69,6 +77,7 @@ items:
     versionUswds: 3.5.0
   # 3.0.2 release
   - date: 2022-06-17
+    page: Table
     summary: Updated table border settings to work as expected.
     summaryAdditional: Theme table settings are now consistently applied to table styles.
     isBreaking: false
@@ -83,6 +92,7 @@ items:
     versionUswds: 3.0.2
   # 3.0 release
   - date: 2022-04-28
+    page: Table
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true
@@ -92,17 +102,20 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.0
   - date: 2021-05-19
+    page: Table
     summary: Added guidance for making scrollable tables more accessible with `tabindex`.
     affectsGuidance: true
     githubPr: 1227
     githubRepo: uswds-site
   - date: 2021-03-17
+    page: Table
     summary: Added guidance for sortable tables.
     affectsGuidance: true
     githubPr: 1180
     githubRepo: uswds-site
   # 2.11.0 release
   - date: 2021-03-17
+    page: Table
     summary: Released sortable table.
     summaryAdditional: A sorted column changes the row ordering based on alphabetical or numeric cell values.
     isBreaking: false
@@ -116,6 +129,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.11.0
   - date: 2021-03-17
+    page: Table
     summary: Updated default values for table settings.
     summaryAdditional: Changed values of `$theme-table-border-color`, `$theme-table-header-text-color`, `$theme-table-stripe-text-color`, and `$theme-table-text-color` from `default` to `ink`.
     affectsStyles: true
@@ -123,6 +137,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.11.0
   - date: 2021-03-17
+    page: Table
     summary: Added new table settings.
     summaryAdditional: Added `$theme-table-sorted-header-background-color`, `$theme-table-sorted-background-color`, `$theme-table-sorted-stripe-background-color`, and `$theme-table-sorted-icon-color`, and `$theme-table-unsorted-icon-color` .
     affectsStyles: true

--- a/_data/changelogs/component-tag-accessibility.yml
+++ b/_data/changelogs/component-tag-accessibility.yml
@@ -3,6 +3,7 @@ type: component
 changelogURL:
 items:
   - date: 2024-05-15
+    page: Tag accessibility tests
     summary: Added accessibility tests page.
     affectsGuidance: true
     githubPr: 2645

--- a/_data/changelogs/component-tag.yml
+++ b/_data/changelogs/component-tag.yml
@@ -3,11 +3,13 @@ type: component
 changelogURL:
 items:
   - date: 2024-05-15
+    page: Tag
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 2645
     githubRepo: uswds-site
   - date: 2022-04-28
+    page: Tag
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true

--- a/_data/changelogs/component-text-input-accessibility.yml
+++ b/_data/changelogs/component-text-input-accessibility.yml
@@ -2,6 +2,7 @@ title: Text input accessibility tests
 type: component
 items:
   - date: 2024-06-19
+    page: Text input accessibility tests
     summary: Added accessibility tests page.
     affectsGuidance: true
     githubPr: 2697

--- a/_data/changelogs/component-text-input.yml
+++ b/_data/changelogs/component-text-input.yml
@@ -4,6 +4,7 @@ type: component
 changelogURL:
 items:
   - date: 2024-12-18
+    page: Text input
     summary: Moved `.usa-input--[width]` classes into the `usa-input` package from `usa-form`.
     summaryAdditional: These classes can now be used without the `usa-form` package and `.usa-form` parent element.
     affectsStyles: true
@@ -11,11 +12,13 @@ items:
     githubRepo: uswds
     versionUswds: 3.11.0
   - date: 2024-06-19
+    page: Text input
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 2697
     githubRepo: uswds-site
   - date: 2024-03-11
+    page: Text input
     summary: Added `textarea` support to the validation component.
     summaryAdditional:
     isBreaking: false
@@ -26,11 +29,13 @@ items:
     githubRepo: uswds
     versionUswds: 3.8.0
   - date: 2023-11-16
+    page: Text input
     summary: Updated the listed values for `.usa-input--[width]`.
     affectsGuidance: true
     githubPr: 2291
     githubRepo: uswds-site
   - date: 2023-06-09
+    page: Text input
     summary: Improved consistency and visibility of disabled styles.
     summaryAdditional: Form elements with the `disabled` or `aria-disabled` attribute now get consistent styling and have proper color contrast.
     affectsAccessibility: true
@@ -39,6 +44,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-06-09
+    page: Text input
     summary: Improved consistency of disabled styles in forced colors mode.
     summaryAdditional:
     affectsAccessibility: true
@@ -48,6 +54,7 @@ items:
     versionUswds: 3.5.0
   # 3.0.2 release
   - date: 2022-06-17
+    page: Text input
     summary: Improved form group error display.
     summaryAdditional: Form group margins are the same whether or not the form group is in an error state.
     isBreaking: false
@@ -61,12 +68,14 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.2
   - date: 2022-04-28
+    page: Text input
     summary: Updated package name to `usa-input`.
     affectsGuidance: true
     githubPr: 1538
     githubRepo: uswds-site
   # 3.0 release
   - date: 2022-04-28
+    page: Text input
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true
@@ -76,11 +85,13 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.0
   - date: 2022-04-13
+    page: Text input
     summary: Updated package name to `form-controls`.
     affectsGuidance: true
     githubPr: 1497
     githubRepo: uswds-site
   - date: 2021-03-17
+    page: Text input
     summary: Updated and improved guidance for text input.
     affectsGuidance: true
     githubPr: 1180

--- a/_data/changelogs/component-time-picker-accessibility.yml
+++ b/_data/changelogs/component-time-picker-accessibility.yml
@@ -1,8 +1,9 @@
 title: Time picker accessibility tests
 type: component
 items:
- - date: 2024-11-07
-   summary: Added accessibility tests page.
-   affectsGuidance: true
-   githubPr: 2921
-   githubRepo: uswds-site
+  - date: 2024-11-07
+    page: Time picker accessibility tests
+    summary: Added accessibility tests page.
+    affectsGuidance: true
+    githubPr: 2921
+    githubRepo: uswds-site

--- a/_data/changelogs/component-time-picker.yml
+++ b/_data/changelogs/component-time-picker.yml
@@ -4,6 +4,7 @@ changelogURL:
 
 items:
   - date: 2024-11-13
+    page: Time picker
     summary: Updated the time picker hint text to improve clarity.
     summaryAdditional: This update allows the component to meet the success criteria in [WCAG 3.3.2](https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html).
     affectsAccessibility: true
@@ -12,12 +13,14 @@ items:
     githubRepo: uswds
     versionUswds: 3.10.0
   - date: 2024-11-07
+    page: Time picker
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 2921
     githubRepo: uswds-site
   # 3.0 release
   - date: 2022-04-28
+    page: Time picker
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAccessibility: true
@@ -28,12 +31,14 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.0
   - date: 2022-04-11
+    page: Time picker
     summary: Added documentation for the `value` property.
     affectsGuidance: true
     githubPr: 1516
     githubRepo: uswds-site
   # 2.13.3
   - date: 2022-04-11
+    page: Time picker
     summary: Allow default `value` in time picker.
     summaryAdditional: The input `value` is now used on initialization if set.
     isBreaking: false

--- a/_data/changelogs/component-tooltip-accessibility.yml
+++ b/_data/changelogs/component-tooltip-accessibility.yml
@@ -3,6 +3,7 @@ type: component
 changelogURL:
 items:
   - date: 2024-06-07
+    page: Tooltip accessibility tests
     summary: Added accessibility tests page.
     affectsGuidance: true
     githubPr: 2646

--- a/_data/changelogs/component-tooltip.yml
+++ b/_data/changelogs/component-tooltip.yml
@@ -4,11 +4,13 @@ type: component
 changelogURL:
 items:
   - date: 2024-06-07
+    page: Tooltip
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 2646
     githubRepo: uswds-site
   - date: 2024-05-31
+    page: Tooltip
     summary: Updated component behavior to close active tooltips when the `escape` key is pressed.
     summaryAdditional: This allows the component to meet the "dismissible" standard outlined in [WCAG 1.4.13](https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus).
     affectsAccessibility: true
@@ -17,6 +19,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.8.1
   - date: 2024-05-31
+    page: Tooltip
     summary: Updated component behavior to allow users to hover over tooltip content.
     summaryAdditional: This allows the component to meet the "hoverable" standard outlined in [WCAG 1.4.13](https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus).
     affectsAccessibility: true
@@ -26,6 +29,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.8.1
   - date: 2023-09-29
+    page: Tooltip
     summary: "Restored the `opacity: 0` style rule to the tooltip's initial state."
     summaryAdditional: This prevents the component from flickering if its position needs to be recalculated.
     affectsStyles: true
@@ -33,6 +37,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.6.1
   - date: 2023-06-09
+    page: Tooltip
     summary: Fixed a bug that removed default positioning.
     summaryAdditional: If the `data-position` attribute is not specified, the tooltip position will now default to "top".
     affectsJavascript: true
@@ -41,6 +46,7 @@ items:
     versionUswds: 3.5.0
   # 3.2.0 release
   - date: 2022-10-19
+    page: Tooltip
     summary: Updated tooltip to allow for dynamic initialization.
     summaryAdditional: Tooltip initializes on first interaction and checks if component has been initialized before toggling. If it hasn't initialized properly it will call a setup attributes function.
     affectsAccessibility: false
@@ -54,6 +60,7 @@ items:
     versionUswds: 3.2.0
   # 3.0 release
   - date: 2022-04-28
+    page: Tooltip
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true
@@ -64,6 +71,7 @@ items:
     versionUswds: 3.0.0
   # 2.12.2
   - date: 2021-11-01
+    page: Tooltip
     summary: Added automatic sanitizing.
     summaryAdditional: The design system now automatically sanitizes content in elements we compose with JavaScript. This means that components like combo box, tooltip, file input, and date picker will sanitize any content passed to them. This helps protect any design system implementation against malicious XSS attacks through these components.
     affectsJavascript: true
@@ -72,6 +80,7 @@ items:
     versionUswds: 2.12.2
   # 2.11.0
   - date: 2021-03-17
+    page: Tooltip
     summary: Fixed tooltip positioning.
     summaryAdditional: We fixed an issue that prevented some longer tooltips in some positions to display incorrectly.
     affectsJavascript: true

--- a/_data/changelogs/component-typography-accessibility.yml
+++ b/_data/changelogs/component-typography-accessibility.yml
@@ -3,6 +3,7 @@ type: component
 changelogURL:
 items:
   - date: 2024-03-20
+    page: Typography accessibility tests
     summary: Added accessibility tests page.
     affectsGuidance: true
     githubPr: 2540

--- a/_data/changelogs/component-typography.yml
+++ b/_data/changelogs/component-typography.yml
@@ -5,11 +5,13 @@ changelogURL:
 
 items:
   - date: 2024-03-20
+    page: Typography
     summary: Added WCAG compliance tag.
     affectsGuidance: true
     githubPr: 2540
     githubRepo: uswds-site
   - date: 2023-06-09
+    page: Typography
     summary: Stopped using font smoothing.
     summaryAdditional: No longer use font smoothing for dark backgrounds and disabled buttons.
     affectsStyles: true
@@ -17,6 +19,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-03-09
+    page: Typography
     summary: Use only `woff2` in our `@font-face` declarations.
     summaryAdditional: Since modern browsers only need the `woff2` font format, we now only output `woff2` fonts in our `@font-face` rules. If you need `woff` and `ttf` for IE11 compatibility, set `$theme-font-browser-compatibility` to `true` in settings.
     affectsAccessibility:
@@ -31,6 +34,7 @@ items:
     versionUswds: 3.4.0
   # 3.0 release
   - date: 2022-04-28
+    page: Typography
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true

--- a/_data/changelogs/component-validation.yml
+++ b/_data/changelogs/component-validation.yml
@@ -3,8 +3,9 @@ type: component
 changelogURL:
 items:
   - date: 2024-05-31
+    page: Validation
     summary: Fixed a bug which caused non-interactive checklist items to receive focus on tab.
-    summaryAdditional:  Now, only the interactive input will receive focus.
+    summaryAdditional: Now, only the interactive input will receive focus.
     isBreaking: false
     affectsAccessibility: true
     affectsJavascript: true
@@ -12,12 +13,14 @@ items:
     githubRepo: uswds
     versionUswds: 3.8.1
   - date: 2024-03-13
+    page: Validation
     summary: Added known issues section.
     summaryAdditional:
     affectsGuidance: true
     githubPr: 2402
     githubRepo: uswds-site
   - date: 2024-03-11
+    page: Validation
     summary: Added `textarea` support to the validation component.
     isBreaking: false
     affectsAccessibility: false
@@ -27,6 +30,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.8.0
   - date: 2022-12-21
+    page: Validation
     summary: Clarified implementation guidance and removed the `#` from the example `data-validation-element` value.
     summaryAdditional:
     isBreaking:
@@ -41,6 +45,7 @@ items:
     versionUswds:
   # 3.2.0 release
   - date: 2022-10-19
+    page: Validation
     summary: Improved status updates about the completion of validation requirements for users of assistive technologies.
     summaryAdditional: Component JavaScript generates the appropriate elements and ARIA attributes that help improve the experience of receiving status updates.
     isBreaking: false
@@ -54,12 +59,14 @@ items:
     githubRepo: uswds
     versionUswds: 3.2.0
   - date: 2022-04-28
+    page: Validation
     summary: Updated package name to `usa-validation`.
     affectsGuidance: true
     githubPr: 1538
     githubRepo: uswds-site
   # 3.0 release
   - date: 2022-04-28
+    page: Validation
     summary: Updated to Sass module syntax and new package structure.
     isBreaking: true
     affectsAssets: true
@@ -69,6 +76,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.0
   - date: 2021-06-07
+    page: Validation
     summary: Updated package name to `validation`.
     affectsGuidance: true
     githubPr: 1219

--- a/_data/changelogs/design-principles.yml
+++ b/_data/changelogs/design-principles.yml
@@ -3,6 +3,7 @@ type: documentation
 changelogURL:
 items:
   - date: 2025-01-22
+    page: Design principles
     summary: Updated the url for the "Delivering Excellent, Equitable, and Secure Federal Services and Customer Experience" link.
     affectsGuidance: true
     githubPr: 3068

--- a/_data/changelogs/docs-accessibility.yml
+++ b/_data/changelogs/docs-accessibility.yml
@@ -3,12 +3,14 @@ type: documentation
 changelogURL:
 items:
   - date: 2024-03-29
+    page: Accessibility
     summary: Updated all page content.
     summaryAdditional:
     affectsGuidance: true
     githubPr: 2561
     githubRepo: uswds-site
   - date: 2021-05-20
+    page: Accessibility
     summary: Added new accessibility guidance and resources.
     summaryAdditional:
     isBreaking:

--- a/_data/changelogs/docs-component-lifecycle.yml
+++ b/_data/changelogs/docs-component-lifecycle.yml
@@ -3,6 +3,7 @@ type: documentation
 changelogURL:
 items:
   - date: 2024-02-15
+    page: Component lifecycle
     summary: Added component lifecycle page.
     affectsGuidance: true
     githubPr: 2491

--- a/_data/changelogs/docs-component-status.yml
+++ b/_data/changelogs/docs-component-status.yml
@@ -3,6 +3,7 @@ type: documentation
 changelogURL:
 items:
   - date: 2024-02-15
+    page: Component status
     summary: Added component status page.
     affectsGuidance: true
     githubPr: 2491

--- a/_data/changelogs/docs-getting-started-designers.yml
+++ b/_data/changelogs/docs-getting-started-designers.yml
@@ -3,11 +3,13 @@ type: documentation
 changelogURL:
 items:
   - date: 2025-01-08
+    page: Getting started for designers
     summary: Added information about USWDS design kit for Figma.
     summaryAdditional: Added download link and direct link to file hosted on Figma community. Removed links to third-party Figma kits.
     githubPr: 3041
     githubRepo: uswds-site
   - date: 2025-01-08
+    page: Getting started for designers
     summary: Updated information about USWDS design kit for Adobe XD.
     summaryAdditional: Noted that we have stopped maintaining these assets since XD is no longer supported by Adobe.
     githubPr: 3041

--- a/_data/changelogs/docs-getting-started-devs-overview.yml
+++ b/_data/changelogs/docs-getting-started-devs-overview.yml
@@ -3,6 +3,7 @@ type: documentation
 changelogURL:
 items:
   - date: 2022-04-28
+    page: Getting started for developers
     summary: Added note that USWDS no longer supports Internet Explorer 11.
     summaryAdditional:
     isBreaking:
@@ -15,6 +16,7 @@ items:
     githubPr: 1538
     githubRepo: uswds-site
   - date: 2022-01-27
+    page: Getting started for developers
     summary: Moved "Before getting started" content to "How to use USWDS" page.
     summaryAdditional:
     isBreaking:
@@ -28,6 +30,7 @@ items:
     githubRepo: uswds-site
     versionUswds:
   - date: 2021-12-06
+    page: Getting started for developers
     summary: Added "Getting started for developers" guide.
     summaryAdditional:
     isBreaking:

--- a/_data/changelogs/docs-getting-started-devs-phase-1.yml
+++ b/_data/changelogs/docs-getting-started-devs-phase-1.yml
@@ -1,8 +1,9 @@
-title: "Phase 1: Install"
+title: "Getting started for developers: Phase 1"
 type: documentation
 changelogURL:
 items:
   - date: 2022-04-28
+    page: "Getting started for developers: Phase 1"
     summary: Updated `uswds` package references to `@uswds/uswds`.
     summaryAdditional:
     isBreaking:
@@ -15,6 +16,7 @@ items:
     githubPr: 1538
     githubRepo: uswds-site
   - date: 2021-12-06
+    page: "Getting started for developers: Phase 1"
     summary: Added "Getting started for developers" guide.
     summaryAdditional:
     isBreaking:

--- a/_data/changelogs/docs-getting-started-devs-phase-2.yml
+++ b/_data/changelogs/docs-getting-started-devs-phase-2.yml
@@ -1,38 +1,45 @@
-title: "Phase 2: Compile"
+title: "Getting started for developers: Phase 2"
 type: documentation
 changelogURL:
-items:  
+items:
   - date: 2024-12-18
+    page: "Getting started for developers: Phase 2"
     summary: Added documentation for `settings.compile.sassDeprecationWarnings`.
     affectsGuidance: true
     githubPr: 3006
     githubRepo: uswds-site
   - date: 2024-09-05
+    page: "Getting started for developers: Phase 2"
     summary: Added documentation for `settings.compile.browserslist` and `settings.compile.sassSourcemaps`.
     affectsGuidance: true
     githubPr: 2750
     githubRepo: uswds-site
   - date: 2024-09-05
+    page: "Getting started for developers: Phase 2"
     summary: Removed the version number from "Gulp 4" references.
     affectsGuidance: true
     githubPr: 2750
     githubRepo: uswds-site
   - date: 2024-04-26
+    page: "Getting started for developers: Phase 2"
     summary: Replaced outdated references to `paths.dist.sass` with `paths.dist.theme`.
     affectsGuidance: true
     githubPr: 2401
     githubRepo: uswds-site
   - date: 2024-04-26
+    page: "Getting started for developers: Phase 2"
     summary: Added documentation for `paths.src.projectIcons` and `sprite.projectIconsOnly`.
     affectsGuidance: true
     githubPr: 2401
     githubRepo: uswds-site
   - date: 2023-07-28
+    page: "Getting started for developers: Phase 2"
     summary: Added clarity to the instructions for custom compilers.
     affectsGuidance: true
     githubPr: 2123
     githubRepo: uswds-site
   - date: 2023-05-11
+    page: "Getting started for developers: Phase 2"
     summary: Replaced references to `copySetup` with `copyTheme`.
     summaryAdditional:
     isBreaking:
@@ -45,6 +52,7 @@ items:
     githubPr: 2071
     githubRepo: uswds-site
   - date: 2022-10-11
+    page: "Getting started for developers: Phase 2"
     summary: Restructured content to add clarity.
     summaryAdditional:
     isBreaking:
@@ -57,6 +65,7 @@ items:
     githubPr: 1766
     githubRepo: uswds-site
   - date: 2022-08-16
+    page: "Getting started for developers: Phase 2"
     summary: Fixed typo by replacing `_index.html` with `_index.scss`.
     summaryAdditional:
     isBreaking:
@@ -69,6 +78,7 @@ items:
     githubPr: 1740
     githubRepo: uswds-site
   - date: 2022-06-17
+    page: "Getting started for developers: Phase 2"
     summary: Added warning and success note for `gulp init`.
     summaryAdditional:
     isBreaking:
@@ -81,6 +91,7 @@ items:
     githubPr: 1667
     githubRepo: uswds-site
   - date: 2022-06-03
+    page: "Getting started for developers: Phase 2"
     summary: Updated the example compile settings with values that do not generate warnings.
     summaryAdditional:
     isBreaking:
@@ -93,6 +104,7 @@ items:
     githubPr: 1597
     githubRepo: uswds-site
   - date: 2022-04-28
+    page: "Getting started for developers: Phase 2"
     summary: Updated documentation to use Sass module syntax and updated settings table.
     summaryAdditional:
     isBreaking:
@@ -105,6 +117,7 @@ items:
     githubPr: 1538
     githubRepo: uswds-site
   - date: 2022-03-10
+    page: "Getting started for developers: Phase 2"
     summary: |
       Replaced the outdated text: `paths.dist.sass` with updated: `paths.dist.theme`.
     summaryAdditional:
@@ -118,6 +131,7 @@ items:
     githubPr: 1473
     githubRepo: uswds-site
   - date: 2022-03-10
+    page: "Getting started for developers: Phase 2"
     summary: |
       Replaced the outdated text: `uswds-gulp` with updated: `uswds-compile`.
     summaryAdditional:
@@ -131,6 +145,7 @@ items:
     githubPr: 1424
     githubRepo: uswds-site
   - date: 2021-12-14
+    page: "Getting started for developers: Phase 2"
     summary: Added clarity to guidance.
     summaryAdditional:
     isBreaking:
@@ -143,6 +158,7 @@ items:
     githubPr: 1370
     githubRepo: uswds-site
   - date: 2021-12-06
+    page: "Getting started for developers: Phase 2"
     summary: Added "Getting started for developers" guide.
     summaryAdditional:
     isBreaking:

--- a/_data/changelogs/docs-getting-started-devs-phase-3.yml
+++ b/_data/changelogs/docs-getting-started-devs-phase-3.yml
@@ -1,8 +1,9 @@
-title: "Phase 3: Customize"
+title: "Getting started for developers: Phase 3"
 type: documentation
 changelogURL:
 items:
   - date: 2022-06-17
+    page: "Getting started for developers: Phase 3"
     summary: |
       Replaced the outdated text: `_theme-settings.scss` with updated: `_uswds-theme.scss`.
     summaryAdditional:
@@ -16,6 +17,7 @@ items:
     githubPr: 1667
     githubRepo: uswds-site
   - date: 2022-04-28
+    page: "Getting started for developers: Phase 3"
     summary: Updated theming instructions.
     summaryAdditional:
     isBreaking:
@@ -28,6 +30,7 @@ items:
     githubPr: 1538
     githubRepo: uswds-site
   - date: 2022-03-10
+    page: "Getting started for developers: Phase 3"
     summary: |
       Replaced the outdated text: `uswds-gulp` with updated: `uswds-compile`.
     summaryAdditional:
@@ -41,6 +44,7 @@ items:
     githubPr: 1424
     githubRepo: uswds-site
   - date: 2022-02-17
+    page: "Getting started for developers: Phase 3"
     summary: Moved resources documentation to its own page.
     summaryAdditional:
     isBreaking:
@@ -53,6 +57,7 @@ items:
     githubPr: 1422
     githubRepo: uswds-site
   - date: 2021-12-14
+    page: "Getting started for developers: Phase 3"
     summary: Added guidance for `uswds-gulp`.
     summaryAdditional:
     isBreaking:
@@ -65,6 +70,7 @@ items:
     githubPr: 1370
     githubRepo: uswds-site
   - date: 2021-12-06
+    page: "Getting started for developers: Phase 3"
     summary: Added "Getting started for developers" guide.
     summaryAdditional:
     isBreaking:

--- a/_data/changelogs/docs-getting-started-devs-resources.yml
+++ b/_data/changelogs/docs-getting-started-devs-resources.yml
@@ -1,8 +1,9 @@
-title: Resources
+title: "Getting started for developers: Resources"
 type: documentation
 changelogURL:
 items:
   - date: 2022-02-17
+    page: "Getting started for developers: Resources"
     summary: Added resources page.
     summaryAdditional:
     isBreaking:

--- a/_data/changelogs/docs-how-to-use-uswds.yml
+++ b/_data/changelogs/docs-how-to-use-uswds.yml
@@ -3,6 +3,7 @@ type: documentation
 changelogURL:
 items:
   - date: 2022-01-27
+    page: "How to use USWDS"
     summary: Brought in "Before getting started" content from "Getting started for developers".
     summaryAdditional:
     isBreaking:

--- a/_data/changelogs/docs-implementations.yml
+++ b/_data/changelogs/docs-implementations.yml
@@ -3,6 +3,7 @@ type: documentation
 changelogURL:
 items:
   - date: 2023-07-11
+    page: Implementations
     summary: Added entry for "Comet".
     summaryAdditional:
     isBreaking:
@@ -15,6 +16,7 @@ items:
     githubPr: 2152
     githubRepo: uswds-site
   - date: 2023-03-09
+    page: Implementations
     summary: Added entry for "sam.gov" implementations.
     summaryAdditional:
     isBreaking:
@@ -27,6 +29,7 @@ items:
     githubPr: 1714
     githubRepo: uswds-site
   - date: 2022-10-11
+    page: Implementations
     summary: Added entry for "ngx-uswds".
     summaryAdditional:
     isBreaking:
@@ -40,6 +43,7 @@ items:
     githubRepo: uswds-site
     versionUswds:
   - date: 2022-07-06
+    page: Implementations
     summary: Added entry for "USWDS Components".
     summaryAdditional:
     isBreaking:
@@ -53,6 +57,7 @@ items:
     githubRepo: uswds-site
     versionUswds:
   - date: 2021-10-04
+    page: Implementations
     summary: Added entry for "USWDS Drupal base theme".
     summaryAdditional:
     isBreaking:
@@ -66,6 +71,7 @@ items:
     githubRepo: uswds-site
     versionUswds:
   - date: 2021-07-27
+    page: Implementations
     summary: Added entry for "USWDS CKEditor Integration" and "USWDS Paragraph Components".
     summaryAdditional:
     isBreaking:
@@ -79,6 +85,7 @@ items:
     githubRepo: uswds-site
     versionUswds:
   - date: 2021-07-27
+    page: Implementations
     summary: Added column for implementation status.
     summaryAdditional:
     isBreaking:
@@ -92,6 +99,7 @@ items:
     githubRepo: uswds-site
     versionUswds:
   - date: 2021-05-19
+    page: Implementations
     summary: Removed entry for "us_web_design_standards gem".
     summaryAdditional:
     isBreaking:
@@ -105,6 +113,7 @@ items:
     githubRepo: uswds-site
     versionUswds:
   - date: 2020-09-11
+    page: Implementations
     summary: Added entry for "uswds-sf-lightning-community".
     summaryAdditional:
     isBreaking:
@@ -118,6 +127,7 @@ items:
     githubRepo: uswds-site
     versionUswds:
   - date: 2020-08-12
+    page: Implementations
     summary: Added entry for "tailwindcss-uswds".
     summaryAdditional:
     isBreaking:
@@ -131,6 +141,7 @@ items:
     githubRepo: uswds-site
     versionUswds:
   - date: 2020-07-28
+    page: Implementations
     summary: Added entry for "react-uswds".
     summaryAdditional:
     isBreaking:

--- a/_data/changelogs/docs-maturity-model.yml
+++ b/_data/changelogs/docs-maturity-model.yml
@@ -3,6 +3,7 @@ type: documentation
 changelogURL:
 items:
   - date: 2022-03-10
+    page: Maturity model
     summary: |
       Replaced the outdated text: `uswds-gulp` with updated: `uswds-compile`.
     summaryAdditional:

--- a/_data/changelogs/docs-migration-v3.yml
+++ b/_data/changelogs/docs-migration-v3.yml
@@ -3,11 +3,13 @@ type: documentation
 changelogURL:
 items:
   - date: 2024-06-07
+    page: Migrating to 3.0
     summary: Added note about Autoprefixer to Sass compilation section.
     affectsGuidance: true
     githubPr: 2319
     githubRepo: uswds-site
   - date: 2022-07-17
+    page: Migrating to 3.0
     summary: Added note about error handling for `@use "uswds-core" with ()`.
     summaryAdditional:
     isBreaking:
@@ -21,6 +23,7 @@ items:
     githubRepo: uswds-site
     versionUswds:
   - date: 2022-08-29
+    page: Migrating to 3.0
     summary: Added instructions for users migrating from USWDS 1.x.
     summaryAdditional:
     isBreaking:
@@ -34,6 +37,7 @@ items:
     githubRepo: uswds-site
     versionUswds:
   - date: 2022-05-04
+    page: Migrating to 3.0
     summary: Added clarity to migration page.
     summaryAdditional:
     isBreaking:
@@ -47,6 +51,7 @@ items:
     githubRepo: uswds-site
     versionUswds:
   - date: 2022-04-28
+    page: Migrating to 3.0
     summary: Added "Migrating to USWDS 3.0" guide.
     summaryAdditional:
     isBreaking:

--- a/_data/changelogs/docs-packages.yml
+++ b/_data/changelogs/docs-packages.yml
@@ -3,6 +3,7 @@ type: documentation
 changelogURL:
 items:
   - date: 2022-04-28
+    page: Packages
     summary: Updated instructions for using packages with USWDS 3.0.
     summaryAdditional: Added Sass module syntax, updated package list, and updated load paths.
     isBreaking:

--- a/_data/changelogs/docs-sample-contract-language.yml
+++ b/_data/changelogs/docs-sample-contract-language.yml
@@ -3,6 +3,7 @@ type: documentation
 changelogURL:
 items:
   - date: 2024-04-09
+    page: Sample contract language
     summary: Updated Federal Web Council representative link.
     affectsGuidance: true
     githubPr: 2604

--- a/_data/changelogs/docs-settings.yml
+++ b/_data/changelogs/docs-settings.yml
@@ -3,16 +3,18 @@ type: utility
 changelogURL:
 items:
   - date: 2024-10-04
+    page: Settings
     summary: Added new `$theme-utility-breakpoints-custom` setting.
-    summaryAdditional:  Users can now set custom breakpoints which will generate utilities alongside the default system breakpoints.
+    summaryAdditional: Users can now set custom breakpoints which will generate utilities alongside the default system breakpoints.
     affectsSettings: true
     affectsStyles: true
     githubPr: 6048
     githubRepo: uswds
     versionUswds: 3.9.0
   - date: 2024-03-11
+    page: Settings
     summary: Added new sidenav setting to temporarily address visual regression in new markup guidance.
-    summaryAdditional:  The new setting `$theme-sidenav-reorder` allows users to temporarily reorder the sidenav with CSS. Users should follow new markup recommendation in code example to avoid accessibility issues.
+    summaryAdditional: The new setting `$theme-sidenav-reorder` allows users to temporarily reorder the sidenav with CSS. Users should follow new markup recommendation in code example to avoid accessibility issues.
     isBreaking: false
     affectsAccessibility: true
     affectsAssets:
@@ -26,6 +28,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.8.0
   - date: 2024-03-11
+    page: Settings
     summary: Added `$theme-table-background-color` and `$theme-table-sticky-top-offset` settings.
     summaryAdditional:
     affectsStyles: true
@@ -34,14 +37,16 @@ items:
     githubRepo: uswds
     versionUswds: 3.8.0
   - date: 2024-03-11
+    page: Settings
     summary: Added color contrast checks for disabled tokens.
-    summaryAdditional:  On compilation, USWDS will test disabled element color contrast and provide a fallback color if minimum contrast is not met. If the fallback does not meet minimum requirements, USWDS will provide a warning in the terminal.
+    summaryAdditional: On compilation, USWDS will test disabled element color contrast and provide a fallback color if minimum contrast is not met. If the fallback does not meet minimum requirements, USWDS will provide a warning in the terminal.
     affectsAccessibility: true
     affectsStyles: true
     githubPr: 5455
     githubRepo: uswds
     versionUswds: 3.8.0
   - date: 2024-03-11
+    page: Settings
     summary: Added button icon gap setting.
     summaryAdditional: You can now customize the size of the gap between a button's text and icon with `$theme-button-icon-gap`.
     affectsStyles: true
@@ -50,12 +55,14 @@ items:
     githubRepo: uswds
     versionUswds: 3.8.0
   - date: 2023-12-08
+    page: Settings
     summary: Fixed a bug that prevented `$theme-max-header-width` from accepting a value of "none".
     affectsStyles: true
     githubPr: 5624
     githubRepo: uswds
     versionUswds: 3.7.1
   - date: 2023-11-09
+    page: Settings
     summary: Fixed a bug that prevented `$theme-site-margins-width` from accepting expected token values.
     affectsSettings: true
     affectsStyles: true
@@ -63,6 +70,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.7.0
   - date: 2023-11-09
+    page: Settings
     summary: Fixed a bug that prevented `$theme-card-padding-y` from accepting expected token values.
     affectsSettings: true
     affectsStyles: true
@@ -70,6 +78,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.7.0
   - date: 2023-08-23
+    page: Settings
     summary: Updated default disabled color settings values and added `$theme-color-disabled-lighter` and `$theme-color-disabled-darker`.
     summaryAdditional: If your project customizes disabled color settings, you probably need to update your configuration.
     isBreaking: true
@@ -79,6 +88,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.6.0
   - date: 2023-08-23
+    page: Settings
     summary: Fixed configuration errors with disabled color settings.
     summaryAdditional: All disabled color settings should now be configurable and accept hex color values.
     affectsSettings: true
@@ -87,18 +97,21 @@ items:
     githubRepo: uswds
     versionUswds: 3.6.0
   - date: 2023-08-23
+    page: Settings
     summary: Fixed a bug that prevented `$theme-body-font-size` from accepting `2xs` and `3xs` size tokens.
     affectsStyles: true
     githubPr: 5363
     githubRepo: uswds
     versionUswds: 3.6.0
   - date: 2023-07-28
+    page: Settings
     summary: Added a note about configuring settings that are described using dot notation.
     summaryAdditional:
     affectsGuidance: true
     githubPr: 2122
     githubRepo: uswds-site
   - date: 2023-06-09
+    page: Settings
     summary: Added accordion color settings.
     summaryAdditional: You can now customize accordion button and content background colors with `$theme-accordion-button-background-color` and `$theme-accordion-background-color`.
     affectsAccessibility:
@@ -112,6 +125,7 @@ items:
     githubRepo: uswds-site
     versionUswds: 3.5.0
   - date: 2023-06-09
+    page: Settings
     summary: Added settings for announcing external links.
     summaryAdditional: Added `$theme-external-link-sr-label-tab-same` and `$theme-external-link-sr-label-tab-new` to control how screen readers announce external links.
     affectsSettings: true
@@ -120,6 +134,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-06-09
+    page: Settings
     summary: Updated individual Sass map settings without affecting defaults.
     summaryAdditional: Now adjusting a single Sass map setting no longer sets all other values in the map to `false`. Users can now update only the map values they wish to change.
     isBreaking: true
@@ -129,6 +144,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-03-20
+    page: Settings
     summary: Updated settings information to match what is found in USWDS.
     summaryAdditional:
     affectsAccessibility:
@@ -140,6 +156,7 @@ items:
     githubPr: 2016
     githubRepo: uswds-site
   - date: 2023-03-09
+    page: Settings
     summary: Added `$theme-font-browser-compatibility` setting.
     summaryAdditional: We now only output `woff2` fonts in our `@font-face` rules. If you need `woff` and `ttf` for IE11 compatibility, set this new setting to `true`.
     affectsAccessibility:
@@ -153,6 +170,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.4.0
   - date: 2023-03-09
+    page: Settings
     summary: Removed `woff` and `ttf` file format requirements from custom font source settings.
     summaryAdditional:
     affectsAccessibility:
@@ -165,6 +183,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.4.0
   - date: 2022-09-16
+    page: Settings
     summary: Fixed typos in `primary-vivid` and `secondary-vivid` variable names.
     summaryAdditional:
     affectsAccessibility:
@@ -176,6 +195,7 @@ items:
     githubPr: 1767
     githubRepo: uswds-site
   - date: 2022-09-26
+    page: Settings
     summary: Clarified instructions for settings configuration.
     summaryAdditional:
     affectsAccessibility:
@@ -187,6 +207,7 @@ items:
     githubPr: 1755
     githubRepo: uswds-site
   - date: 2022-08-29
+    page: Settings
     summary: Added documentation for `$theme-footer-max-width`.
     summaryAdditional:
     affectsAccessibility:
@@ -198,6 +219,7 @@ items:
     githubPr: 1719
     githubRepo: uswds-site
   - date: 2022-08-05
+    page: Settings
     summary: Updated the value of `$theme-hero-image`.
     summaryAdditional: We replaced our default hero image (PNG) with an optimized image (JPG).
     isBreaking: true
@@ -211,6 +233,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.1.0
   - date: 2022-07-17
+    page: Settings
     summary: Added note about error handling for `@use "uswds-core" with ()`.
     summaryAdditional:
     affectsAccessibility:
@@ -222,6 +245,7 @@ items:
     githubPr: 1698
     githubRepo: uswds-site
   - date: 2022-06-17
+    page: Settings
     summary: Updated value of `$theme-table-border-color` from `default` to `ink`.
     summaryAdditional:
     affectsAccessibility:
@@ -234,6 +258,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.2
   - date: 2022-06-17
+    page: Settings
     summary: Fixed errors related to `$theme-body-background-color`.
     summaryAdditional: Updated icons so that custom background colors no longer cause compile failures.
     affectsAccessibility:
@@ -246,6 +271,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.2
   - date: 2022-06-17
+    page: Settings
     summary: Fixed precedence issue related to `$theme-global-content-styles` and `$theme-global-paragraph-styles`.
     summaryAdditional:
     affectsAccessibility:
@@ -258,6 +284,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.2
   - date: 2022-04-28
+    page: Settings
     summary: |
       Replaced the outdated text: `$output-all-utilities` with updated: `$output-these-utilities`.
     summaryAdditional: This setting allows users to create a list of the utility modules they want to include in the project.
@@ -272,6 +299,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.0
   - date: 2022-04-28
+    page: Settings
     summary: Updated the settings page to use USWDS 3.0 conventions.
     summaryAdditional:
     affectsAccessibility:
@@ -283,6 +311,7 @@ items:
     githubPr: 1538
     githubRepo: uswds-site
   - date: 2022-03-11
+    page: Settings
     summary: Updated value of `$theme-modal-lg-max-width` from `800px` to `880px`.
     summaryAdditional:
     affectsAccessibility:
@@ -294,6 +323,7 @@ items:
     githubPr: 1474
     githubRepo: uswds-site
   - date: 2021-06-16
+    page: Settings
     summary: Updated input settings.
     summaryAdditional: Added `$theme-input-background-color`; removed `$theme-input-tile-background-color-selected`, `$theme-input-tile-border-color`, and `$theme-input-tile-border-color-selected`.
     isBreaking:
@@ -307,6 +337,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.12.0
   - date: 2021-06-16
+    page: Settings
     summary: Added pagination settings.
     summaryAdditional:
     isBreaking:
@@ -320,6 +351,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.12.0
   - date: 2021-06-16
+    page: Settings
     summary: Updated values for `$theme-color-success-dark` and `$theme-color-success-darker`.
     summaryAdditional:
     isBreaking:
@@ -333,6 +365,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.12.0
   - date: 2021-04-28
+    page: Settings
     summary: Updated our docs and settings to remove `$theme-site-max-width`.
     summaryAdditional: In its place, use `$theme-grid-container-max-width`.
     isBreaking:
@@ -346,6 +379,7 @@ items:
     githubRepo: uswds-site
     versionUswds:
   - date: 2021-03-17
+    page: Settings
     summary: Added `$theme-prefix-separator`.
     summaryAdditional: This setting allows you to output any character or string for the separator between the prefix and main class.
     affectsAccessibility:
@@ -358,6 +392,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.11.0
   - date: 2021-03-17
+    page: Settings
     summary: Added `$theme-alert-padding-y`.
     summaryAdditional:
     affectsAccessibility:
@@ -370,6 +405,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.11.0
   - date: 2021-03-17
+    page: Settings
     summary: Added sortable table settings and updated values of other table settings.
     summaryAdditional:
     affectsAccessibility:
@@ -382,6 +418,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.11.0
   - date: 2021-03-17
+    page: Settings
     summary: Added modal settings.
     summaryAdditional:
     affectsAccessibility:
@@ -394,6 +431,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.11.0
   - date: 2021-03-17
+    page: Settings
     summary: Added icon list settings.
     summaryAdditional:
     affectsAccessibility:
@@ -406,6 +444,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.11.0
   - date: 2021-03-03
+    page: Settings
     summary: Improved use of `$theme-text-` and `$theme-link-` settings in components and variants like `usa-dark-background` and `usa-section--dark`.
     summaryAdditional:
     isBreaking:
@@ -419,6 +458,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.10.2
   - date: 2021-02-19
+    page: Settings
     summary: Added new settings and updated settings values to repair color contrast issues.
     summaryAdditional: Added `$theme-body-background-color`, `$theme identifier-primary-link-color`, `$theme-text-` settings, and `$theme-alert-` settings; changed the value of `$theme-breadcrumb-background-color`.
     isBreaking:
@@ -432,6 +472,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.10.1
   - date: 2021-02-19
+    page: Settings
     summary: Replaced hard-coded value for alert component icon size with `$theme-alert-icon-size`.
     summaryAdditional: This update also changes the default value of the `$theme-alert-icon-size` from `4` to `5`.
     isBreaking: true
@@ -445,6 +486,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.10.1
   - date: 2020-12-17
+    page: Settings
     summary: Added support for custom bold font weight by defining theme bold styles with `$theme-font-weight-bold`.
     summaryAdditional:
     isBreaking:

--- a/_data/changelogs/docs-showcase.yml
+++ b/_data/changelogs/docs-showcase.yml
@@ -3,11 +3,13 @@ type: documentation
 changelogURL:
 items:
   - date: 2024-12-18
+    page: Showcase
     summary: Removed broken link to VA Caseflow.
     affectsGuidance: true
     githubPr: 3031
     githubRepo: uswds-site
   - date: 2024-04-26
+    page: Showcase
     summary: Remove broken links that have no alternate for redirects.
     summaryAdditional: Correct misspelling that Siteimprove noted.
     affectsGuidance: true

--- a/_data/changelogs/docs-web-standards.yml
+++ b/_data/changelogs/docs-web-standards.yml
@@ -3,6 +3,7 @@ type: documentation
 changelogURL:
 items:
   - date: 2024-09-26
+    page: Website standards
     summary: Updated content to reflect move to standards.digital.gov.
     affectsGuidance: true
     githubPr: 2843

--- a/_data/changelogs/pattern-complex-form-establish-trust.yml
+++ b/_data/changelogs/pattern-complex-form-establish-trust.yml
@@ -3,6 +3,7 @@ type: pattern
 changelogURL:
 items:
   - date: 2022-11-14
+    page: "Pattern: Establish trust"
     summary: Pattern published.
     affectsGuidance: true
     githubRepo: uswds-site

--- a/_data/changelogs/pattern-complex-form-keep-a-record.yml
+++ b/_data/changelogs/pattern-complex-form-keep-a-record.yml
@@ -3,12 +3,14 @@ type: pattern
 changelogURL:
 items:
   - date: 2024-11-05
+    page: "Pattern: Keep a record"
     summary: Usability guidance content updated.
     affectsGuidance: true
     githubRepo: uswds-site
     githubPr: 2939
     versionUswds: 3.9.0
   - date: 2022-11-14
+    page: "Pattern: Keep a record"
     summary: Pattern published.
     affectsGuidance: true
     githubRepo: uswds-site

--- a/_data/changelogs/pattern-complex-form-progress-easily.yml
+++ b/_data/changelogs/pattern-complex-form-progress-easily.yml
@@ -3,11 +3,13 @@ type: pattern
 changelogURL:
 items:
   - date: 2024-10-15
+    page: "Pattern: Progress easily"
     summary: Added guidance for error messages and disabled states to the "what to do" and "what not to do" sections.
     affectsGuidance: true
     githubRepo: uswds-site
     githubPr: 2744
   - date: 2022-11-14
+    page: "Pattern: Progress easily"
     summary: Pattern published.
     affectsGuidance: true
     githubRepo: uswds-site

--- a/_data/changelogs/pattern-inclusive-design.yml
+++ b/_data/changelogs/pattern-inclusive-design.yml
@@ -3,6 +3,7 @@ type: documentation
 changelogURL:
 items:
   - date: 2025-01-22
+    page: Inclusive design
     summary: Updated the urls for the "Priority 2 Executive Order" and "Executive Order 13985" links.
     affectsGuidance: true
     githubPr: 3068

--- a/_data/changelogs/pattern-select-language-language-preferences.yml
+++ b/_data/changelogs/pattern-select-language-language-preferences.yml
@@ -3,11 +3,13 @@ type: pattern
 changelogURL:
 items:
   - date: 2025-01-22
+    page: "Pattern: Language preferences"
     summary: Updated the url for the "OMB memorandum m-17-06" link.
     affectsGuidance: true
     githubPr: 3068
     githubRepo: uswds-site
   - date: 2022-11-14
+    page: "Pattern: Language preferences"
     summary: Pattern published.
     affectsGuidance: true
     githubRepo: uswds-site

--- a/_data/changelogs/pattern-select-language-selected-content.yml
+++ b/_data/changelogs/pattern-select-language-selected-content.yml
@@ -3,11 +3,13 @@ type: pattern
 changelogURL:
 items:
   - date: 2024-04-11
+    page: "Pattern: Selected content"
     summary: Fixed broken component preview links.
     affectsGuidance: true
     githubPr: 2566
     githubRepo: uswds-site
   - date: 2022-11-14
+    page: "Pattern: Selected content"
     summary: Pattern published.
     affectsGuidance: true
     githubRepo: uswds-site

--- a/_data/changelogs/pattern-select-language-three-or-more-languages.yml
+++ b/_data/changelogs/pattern-select-language-three-or-more-languages.yml
@@ -3,11 +3,13 @@ type: pattern
 changelogURL:
 items:
   - date: 2024-04-11
+    page: "Pattern: Three or more languages"
     summary: Fixed broken component preview links.
     affectsGuidance: true
     githubPr: 2566
     githubRepo: uswds-site
   - date: 2022-11-14
+    page: "Pattern: Three or more languages"
     summary: Pattern published.
     affectsGuidance: true
     githubRepo: uswds-site

--- a/_data/changelogs/pattern-select-language-two-languages.yml
+++ b/_data/changelogs/pattern-select-language-two-languages.yml
@@ -3,11 +3,13 @@ type: pattern
 changelogURL:
 items:
   - date: 2024-04-11
+    page: "Pattern: Two languages"
     summary: Fixed broken component preview links.
     affectsGuidance: true
     githubPr: 2566
     githubRepo: uswds-site
   - date: 2022-11-14
+    page: "Pattern: Two languages"
     summary: Pattern published.
     affectsGuidance: true
     githubRepo: uswds-site

--- a/_data/changelogs/pattern-user-profile-address.yml
+++ b/_data/changelogs/pattern-user-profile-address.yml
@@ -3,6 +3,7 @@ type: pattern
 changelogURL:
 items:
   - date: 2022-11-14
+    page: "Pattern: Address"
     summary: Pattern published.
     affectsGuidance: true
     githubRepo: uswds-site

--- a/_data/changelogs/pattern-user-profile-contact-preferences.yml
+++ b/_data/changelogs/pattern-user-profile-contact-preferences.yml
@@ -3,6 +3,7 @@ type: pattern
 changelogURL:
 items:
   - date: 2022-11-14
+    page: "Pattern: Contact preferences"
     summary: Pattern published.
     affectsGuidance: true
     githubRepo: uswds-site

--- a/_data/changelogs/pattern-user-profile-date-of-birth.yml
+++ b/_data/changelogs/pattern-user-profile-date-of-birth.yml
@@ -3,6 +3,7 @@ type: pattern
 changelogURL:
 items:
   - date: 2022-11-14
+    page: "Pattern: Date of birth"
     summary: Pattern published.
     affectsGuidance: true
     githubRepo: uswds-site

--- a/_data/changelogs/pattern-user-profile-email-address.yml
+++ b/_data/changelogs/pattern-user-profile-email-address.yml
@@ -3,6 +3,7 @@ type: pattern
 changelogURL:
 items:
   - date: 2022-11-14
+    page: "Pattern: Email address"
     summary: Pattern published.
     affectsGuidance: true
     githubRepo: uswds-site

--- a/_data/changelogs/pattern-user-profile-gender-identity-and-sex.yml
+++ b/_data/changelogs/pattern-user-profile-gender-identity-and-sex.yml
@@ -3,6 +3,7 @@ type: pattern
 changelogURL:
 items:
   - date: 2025-01-22
+    page: "Pattern: Gender identity and sex"
     summary: Updated the urls for broken links.
     summaryAdditional: |
       Replaced the urls for "Executive Order 14075",
@@ -12,62 +13,70 @@ items:
     githubPr: 3068
     githubRepo: uswds-site
   - date: 2023-03-09
+    page: "Pattern: Gender identity and sex"
     summary: Added new White House report.
     summaryAdditional: Added new White House report on collection of Sexual Orientation and Gender Identity (SOGI) information for statistical purposes.
     affectsGuidance: true
     githubPr: 1994
     githubRepo: uswds-site
   - date: 2023-03-09
+    page: "Pattern: Gender identity and sex"
     summary: Added information on how some states collect sex data.
     summaryAdditional: Added information and a reference link for how some states collect sex data on birth certificates and other legal documents.
     affectsGuidance: true
     githubPr: 1994
     githubRepo: uswds-site
   - date: 2023-03-09
+    page: "Pattern: Gender identity and sex"
     summary: Added more detail supporting specific use cases for collecting sex data.
     summaryAdditional: Added more detail about the most common use cases — matching an original birth certificate ("Sex listed at birth") or matching current legal documents ("Legal sex").
     affectsGuidance: true
     githubPr: 1994
     githubRepo: uswds-site
   - date: 2023-03-09
+    page: "Pattern: Gender identity and sex"
     summary: Added Sex pattern safety and transparency guidance.
     summaryAdditional: Added additional guidance to promote using tested translations on multilingual forms, and providing helper text to explain data usage and sharing.
     affectsGuidance: true
     githubPr: 1994
     githubRepo: uswds-site
   - date: 2023-03-09
+    page: "Pattern: Gender identity and sex"
     summary: Updated usage of "gender identity" and "sex" to be more consistent throughout.
     affectsGuidance: true
     githubPr: 1994
     githubRepo: uswds-site
   - date: 2023-03-09
+    page: "Pattern: Gender identity and sex"
     summary: Updated usage for "sex listed at birth."
     summaryAdditional: Updated our use of "sex listed at birth" to refer to original birth certificate information specifically.
     affectsGuidance: true
     githubPr: 1994
     githubRepo: uswds-site
   - date: 2023-03-09
+    page: "Pattern: Gender identity and sex"
     summary: Updated description of documented pattern use cases.
     summaryAdditional: Updated our background section to focus on documented use cases for collecting gender identity and sex data.
     affectsGuidance: true
     githubPr: 1994
     githubRepo: uswds-site
   - date: 2023-03-09
+    page: "Pattern: Gender identity and sex"
     summary: Updated information on Form DS-11.
     summaryAdditional: Added more detail about how the Department of State collects gender information on Form DS-11 and displays this information on passports.
     affectsGuidance: true
     githubPr: 1994
     githubRepo: uswds-site
   - date: 2023-03-09
+    page: "Pattern: Gender identity and sex"
     summary: Updated Sex pattern preview.
     summaryAdditional: Show the most common use cases of matching documents — either an original birth certificate ("Sex listed at birth") or current legal documents ("Legal sex") — and include explanation of why and how the data is used in the hint text.
     affectsGuidance: true
     githubPr: 1994
     githubRepo: uswds-site
   - date: 2022-11-14
+    page: "Pattern: Gender identity and sex"
     summary: Pattern published.
     affectsGuidance: true
     githubRepo: uswds-site
     versionUswds: 3.3.0
-
-

--- a/_data/changelogs/pattern-user-profile-name.yml
+++ b/_data/changelogs/pattern-user-profile-name.yml
@@ -3,6 +3,7 @@ type: pattern
 changelogURL:
 items:
   - date: 2022-11-14
+    page: "Pattern: Name"
     summary: Pattern published.
     affectsGuidance: true
     githubRepo: uswds-site

--- a/_data/changelogs/pattern-user-profile-phone-number.yml
+++ b/_data/changelogs/pattern-user-profile-phone-number.yml
@@ -3,6 +3,7 @@ type: pattern
 changelogURL:
 items:
   - date: 2022-11-14
+    page: "Pattern: Phone number"
     summary: Pattern published.
     affectsGuidance: true
     githubRepo: uswds-site

--- a/_data/changelogs/pattern-user-profile-pronouns.yml
+++ b/_data/changelogs/pattern-user-profile-pronouns.yml
@@ -3,16 +3,19 @@ type: pattern
 changelogURL:
 items:
   - date: 2025-01-23
+    page: "Pattern: Pronouns"
     summary: De-linked dead hyperlink in references.
     summaryAdditional: De-linked pronouns reference link.
     githubRepo: uswds-site
     githubPr: 3078
   - date: 2024-03-11
+    page: "Pattern: Pronouns"
     summary: Replaced dead hyperlink with archived copy.
     summaryAdditional: Replaced reference to `practicemakesprogress.org` with plain text and a link to the archived page on archive.org.
     githubRepo: uswds-site
     githubPr: 2478
   - date: 2022-11-14
+    page: "Pattern: Pronouns"
     summary: Pattern published.
     affectsGuidance: true
     githubRepo: uswds-site

--- a/_data/changelogs/pattern-user-profile-race-and-ethnicity.yml
+++ b/_data/changelogs/pattern-user-profile-race-and-ethnicity.yml
@@ -3,18 +3,21 @@ type: pattern
 changelogURL:
 items:
   - date: 2022-11-16
+    page: "Pattern: Race and ethnicity"
     summary: Updated preview to remove ethnicity from race question.
     summaryAdditional: We removed `Hispanic, Latinx, or Spanish` from the Race question so we don't combine race and ethnicity in the same question, per current OMB requirements. Updated references to this preview.
     affectsGuidance: true
     githubPr: 1906
     githubRepo: uswds-site
   - date: 2022-11-16
+    page: "Pattern: Race and ethnicity"
     summary: Updated guidance to clarify race and ethnicity question format and requirements.
     summaryAdditional: Added link to guidance on asking for race and ethnicity as a two-part question as currently required by OMB. Removed suggested link to working group considering a combined question. Removed list of combined race and ethnicity categories tested in the 2020 Census to prevent confusion.
     affectsGuidance: true
     githubPr: 1906
     githubRepo: uswds-site
   - date: 2022-11-14
+    page: "Pattern: Race and ethnicity"
     summary: Pattern published.
     affectsGuidance: true
     githubRepo: uswds-site

--- a/_data/changelogs/pattern-user-profile-social-security-number.yml
+++ b/_data/changelogs/pattern-user-profile-social-security-number.yml
@@ -3,6 +3,7 @@ type: pattern
 changelogURL:
 items:
   - date: 2022-11-14
+    page: "Pattern: Social Security Number"
     summary: Pattern published.
     affectsGuidance: true
     githubRepo: uswds-site

--- a/_data/changelogs/patterns.yml
+++ b/_data/changelogs/patterns.yml
@@ -3,6 +3,7 @@ type: pattern
 changelogURL:
 items:
   - date: 2025-01-23
+    page: "Patterns overview"
     summary: Removed report link and introduction.
     summaryAdditional: Removed content related to the January 20, 2025 Executive Order, \"Ending Radical And Wasteful Government DEI Programs And Preferencing\".
     githubRepo: uswds-site

--- a/_data/changelogs/template-404.yml
+++ b/_data/changelogs/template-404.yml
@@ -2,6 +2,7 @@ title: 404 page
 type: template
 items:
   - date: 2023-03-09
+    page: "Template: 404 page"
     summary: Updated template copy to follow parallel structure and use active voice.
     summaryAdditional:
     isBreaking:
@@ -15,6 +16,7 @@ items:
     githubRepo: uswds
     versionUswds:
   - date: 2021-06-16
+    page: "Template: 404 page"
     summary: Added Spanish variant.
     summaryAdditional:
     isBreaking:
@@ -28,6 +30,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.12.0
   - date: 2021-03-17
+    page: "Template: 404 page"
     summary: Added 404 page template.
     summaryAdditional:
     isBreaking:

--- a/_data/changelogs/template-create-account.yml
+++ b/_data/changelogs/template-create-account.yml
@@ -1,7 +1,8 @@
-title: Multiple sign-in options
+title: Create account
 type: template
 items:
   - date: 2024-10-04
+    page: "Template: Create account"
     summary: Added the `autocomplete="email"` attribute to the email input element.
     summaryAdditional: This allows the component to meet all the standards outlined in [WCAG 1.3.5](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html).
     affectsAccessibility: true
@@ -10,6 +11,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.9.0
   - date: 2021-06-16
+    page: "Template: Create account"
     summary: Added Spanish variant.
     summaryAdditional:
     isBreaking:
@@ -23,6 +25,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.12.0
   - date: 2020-12-17
+    page: "Template: Create account"
     summary: Added authentication templates.
     summaryAdditional:
     isBreaking:

--- a/_data/changelogs/template-documentation.yml
+++ b/_data/changelogs/template-documentation.yml
@@ -2,6 +2,7 @@ title: Documentation page
 type: template
 items:
   - date: 2024-03-11
+    page: "Template: Documentation page"
     summary: Added a fallback theme setting for reordering sidenav in Documentation template.
     summaryAdditional: A new setting `$theme-sidenav-reorder` allows users to reorder the sidenav to avoid visual regressions. Users should follow new markup recommendation in code example to avoid accessibility issues.
     isBreaking: false
@@ -17,6 +18,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.8.0
   - date: 2024-03-11
+    page: "Template: Documentation page"
     summary: Updated the order of the side navigation markup to match the visual order.
     summaryAdditional:
     isBreaking: true

--- a/_data/changelogs/template-multiple-sign-in.yml
+++ b/_data/changelogs/template-multiple-sign-in.yml
@@ -2,6 +2,7 @@ title: Multiple sign-in options
 type: template
 items:
   - date: 2021-06-16
+    page: "Template: Multiple sign-in options"
     summary: Added Spanish variant.
     summaryAdditional:
     isBreaking:
@@ -15,6 +16,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.12.0
   - date: 2020-12-17
+    page: "Template: Multiple sign-in options"
     summary: Added authentication templates.
     summaryAdditional:
     isBreaking:

--- a/_data/changelogs/template-sign-in.yml
+++ b/_data/changelogs/template-sign-in.yml
@@ -2,6 +2,7 @@ title: Sign-in
 type: template
 items:
   - date: 2021-06-16
+    page: "Template: Sign-in"
     summary: Added Spanish variant.
     summaryAdditional:
     isBreaking:
@@ -15,6 +16,7 @@ items:
     githubRepo: uswds
     versionUswds: 2.12.0
   - date: 2020-12-17
+    page: "Template: Sign-in"
     summary: Added authentication templates.
     summaryAdditional:
     isBreaking:

--- a/_data/changelogs/tokens-color-state.yml
+++ b/_data/changelogs/tokens-color-state.yml
@@ -3,11 +3,13 @@ type: token
 changelogURL:
 items:
   - date: 2024-05-15
+    page: State color tokens
     summary: Updated guidance for configuring color settings.
     affectsGuidance: true
     githubPr: 2377
     githubRepo: uswds-site
   - date: 2023-08-23
+    page: State color tokens
     summary: Updated the default values for all disabled tokens and added `disabled-lighter` and `disabled-darker` tokens.
     summaryAdditional: If your project uses disabled tokens, you probably need to update your token references.
     isBreaking: true
@@ -16,6 +18,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.6.0
   - date: 2021-12-21
+    page: State color tokens
     summary: Updated the documentation for `success-dark` and `success-darker` to match the current USWDS values.
     summaryAdditional:
     isBreaking:
@@ -29,6 +32,7 @@ items:
     githubRepo: uswds-site
     versionUswds:
   - date: 2021-06-16
+    page: State color tokens
     summary: Updated the values of `success-dark` from `green-cool-50` to `green-cool-50v` and `success-darker` from `green-cool-60` to `green-cool-60v`.
     summaryAdditional:
     isBreaking:

--- a/_data/changelogs/tokens-color-system.yml
+++ b/_data/changelogs/tokens-color-system.yml
@@ -3,6 +3,7 @@ type: token
 changelogURL:
 items:
   - date: 2024-05-15
+    page: System color tokens
     summary: Updated the token references in the "Using color tokens" code examples.
     affectsGuidance: true
     githubPr: 2377

--- a/_data/changelogs/tokens-color-theme.yml
+++ b/_data/changelogs/tokens-color-theme.yml
@@ -3,17 +3,20 @@ type: token
 changelogURL:
 items:
   - date: 2024-05-15
+    page: Theme color tokens
     summary: Updated guidance for configuring color settings.
     affectsGuidance: true
     githubPr: 2377
     githubRepo: uswds-site
   - date: 2024-05-15
+    page: Theme color tokens
     summary: Updated the documented value of the `secondary-lighter` token.
     summaryAdditional:
     affectsGuidance: true
     githubPr: 2377
     githubRepo: uswds-site
   - date: 2024-05-15
+    page: Theme color tokens
     summary: Removed emergency color examples.
     summaryAdditional: These colors are instead documented on the state color page.
     affectsGuidance: true

--- a/_data/changelogs/tokens-color.yml
+++ b/_data/changelogs/tokens-color.yml
@@ -3,6 +3,7 @@ type: token
 changelogURL:
 items:
   - date: 2022-06-03
+    page: Color tokens
     summary: Updated the minimum luminance for color grade 40.
     summaryAdditional:
     isBreaking:
@@ -15,6 +16,7 @@ items:
     githubPr: 1631
     githubRepo: uswds-site
   - date: 2021-12-29
+    page: Color tokens
     summary: Added tools section.
     summaryAdditional:
     isBreaking:

--- a/_data/changelogs/tokens-shadow.yml
+++ b/_data/changelogs/tokens-shadow.yml
@@ -3,6 +3,7 @@ type: token
 changelogURL:
 items:
   - date: 2021-05-25
+    page: Shadow tokens
     summary: Replaced entry for token `0` with token `none`.
     summaryAdditional:
     isBreaking:

--- a/_data/changelogs/tokens-spacing.yml
+++ b/_data/changelogs/tokens-spacing.yml
@@ -3,12 +3,13 @@ type: token
 changelogURL:
 items:
   - date: 2023-08-23
-    summary: Updated `0` token values to include units when needed.  
-    summaryAdditional: Now, `units(0)` can be used in `calc()` functions. 
+    page: Spacing tokens
+    summary: Updated `0` token values to include units when needed.
+    summaryAdditional: Now, `units(0)` can be used in `calc()` functions.
     isBreaking:
     affectsAccessibility:
     affectsAssets:
-    affectsGuidance: 
+    affectsGuidance:
     affectsJavascript:
     affectsMarkup:
     affectsStyles: true
@@ -16,6 +17,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.6.0
   - date: 2023-02-24
+    page: Spacing tokens
     summary: Corrected alternate token name for token `05`.
     summaryAdditional:
     isBreaking:
@@ -29,6 +31,7 @@ items:
     githubRepo: uswds-site
     versionUswds:
   - date: 2022-03-11
+    page: Spacing tokens
     summary: Reverted value of `tablet-lg` to `880px`.
     summaryAdditional:
     isBreaking:
@@ -42,6 +45,7 @@ items:
     githubRepo: uswds-site
     versionUswds:
   - date: 2022-02-24
+    page: Spacing tokens
     summary: Updated value of `tablet-lg` from `880px` to `800px`.
     summaryAdditional:
     isBreaking:

--- a/_data/changelogs/tokens-type-font-family.yml
+++ b/_data/changelogs/tokens-type-font-family.yml
@@ -3,11 +3,13 @@ type: token
 changelogURL:
 items:
   - date: 2024-05-15
+    page: Typesetting tokens
     summary: Updated settings configuration code example.
     affectsGuidance: true
     githubPr: 2379
     githubRepo: uswds-site
   - date: 2022-01-18
+    page: Typesetting tokens
     summary: Added instructions for adding custom fonts to USWDS.
     summaryAdditional:
     isBreaking:
@@ -21,6 +23,7 @@ items:
     githubRepo: uswds-site
     versionUswds:
   - date: 2021-03-17
+    page: Typesetting tokens
     summary: Added default font stacks.
     summaryAdditional:
     isBreaking:

--- a/_data/changelogs/tokens-type-font-weight.yml
+++ b/_data/changelogs/tokens-type-font-weight.yml
@@ -3,6 +3,7 @@ type: token
 changelogURL:
 items:
   - date: 2024-05-15
+    page: Font weight tokens
     summary: Updated the settings code example in "Using weight tokens" section.
     affectsGuidance: true
     githubPr: 2379

--- a/_data/changelogs/tokens-type-letterspacing.yml
+++ b/_data/changelogs/tokens-type-letterspacing.yml
@@ -3,11 +3,13 @@ type: token
 changelogURL:
 items:
   - date: 2024-05-15
+    page: Letterspacing tokens
     summary: Updated documented value for `auto` token.
     affectsGuidance: true
     githubPr: 2379
     githubRepo: uswds-site
   - date: 2024-05-15
+    page: Letterspacing tokens
     summary: Removed the settings code example in "Using letterspacing tokens" section.
     affectsGuidance: true
     githubPr: 2379

--- a/_data/changelogs/tokens-type-measure.yml
+++ b/_data/changelogs/tokens-type-measure.yml
@@ -3,6 +3,7 @@ type: token
 changelogURL:
 items:
   - date: 2024-05-15
+    page: Measure tokens
     summary: Updated the setting code example in "Using measure tokens" section.
     affectsGuidance: true
     githubPr: 2379

--- a/_data/changelogs/tokens-type.yml
+++ b/_data/changelogs/tokens-type.yml
@@ -1,8 +1,9 @@
-title: Typesetting tokens
+title: Type tokens
 type: token
 changelogURL:
 items:
   - date: 2024-05-15
+    page: Type tokens
     summary: Updated the value for `$theme-font-role-ui` in the settings configuration example.
     affectsGuidance: true
     githubPr: 2379

--- a/_data/changelogs/tokens.yml
+++ b/_data/changelogs/tokens.yml
@@ -3,11 +3,13 @@ type: token
 changelogURL:
 items:
   - date: 2023-12-04
+    page: Tokens
     summary: Updated token references in "Using design tokens" section.
     affectsGuidance: true
     githubPr: 2366
     githubRepo: uswds-site
   - date: 2023-12-04
+    page: Tokens
     summary: Updated the settings configuration code example.
     affectsGuidance: true
     githubPr: 2366

--- a/_data/changelogs/utilities-display.yml
+++ b/_data/changelogs/utilities-display.yml
@@ -1,8 +1,9 @@
-title: Display utility
+title: Display utilities
 type: utility
 changelogURL:
 items:
   - date: 2023-12-08
+    page: Display utilities
     summary: Fixed a bug that prevented the CSS from generating `.left-full`, `.right-full`, and `.top-full` utility classes.
     summaryAdditional:
     isBreaking:
@@ -11,6 +12,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.7.1
   - date: 2022-06-08
+    page: Display utilities
     summary: Updated demonstration of `display:none`.
     summaryAdditional:
     isBreaking:

--- a/_data/changelogs/utilities-font-size.yml
+++ b/_data/changelogs/utilities-font-size.yml
@@ -1,8 +1,9 @@
-title: Font size and family
+title: Font size and family utilities
 type: utility
 changelogURL:
 items:
   - date: 2023-08-23
+    page: Font size and family utilities
     summary: Fixed a bug that caused `font-[family]-[size]` utility classes to not generate font-family rules.
     summaryAdditional:
     affectsStyles: true

--- a/_data/changelogs/utilities-height-width.yml
+++ b/_data/changelogs/utilities-height-width.yml
@@ -1,8 +1,9 @@
-title: Height and width utility
+title: Height and width utilities
 type: utility
 changelogURL:
 items:
   - date: 2022-08-05
+    page: Height and width utilities utilities
     summary: Updated `add-aspect` utility to use CSS `aspect-ratio`.
     summaryAdditional:
     isBreaking:
@@ -16,6 +17,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.1.0
   - date: 2021-10-20
+    page: Height and width utilities utilities
     summary: Added the `responsive` tag to the width utility.
     summaryAdditional: This update clarified that width utilities ship with responsive styles by default.
     isBreaking:

--- a/_data/changelogs/utilities-layout-grid.yml
+++ b/_data/changelogs/utilities-layout-grid.yml
@@ -1,8 +1,9 @@
-title: Layout grid utility
+title: Layout grid utilities
 type: utility
 changelogURL:
 items:
   - date: 2024-11-06
+    page: Layout grid utilities
     summary: Refactored guidance page.
     summaryAdditional: Improved layout for easier scanning and consistency across other utility pages.
     affectsGuidance: true
@@ -10,6 +11,7 @@ items:
     githubRepo: uswds-site
     versionUswds:
   - date: 2022-03-11
+    page: Layout grid utilities
     summary: Updated value of `tablet-lg` from `800px` to `880px`.
     summaryAdditional:
     isBreaking:
@@ -23,6 +25,7 @@ items:
     githubRepo: uswds-site
     versionUswds:
   - date: 2021-12-02
+    page: Layout grid utilities
     summary: Updated value of `desktop` from `1040px` to `1024px`.
     summaryAdditional:
     isBreaking:

--- a/_data/changelogs/utilities-margin-padding.yml
+++ b/_data/changelogs/utilities-margin-padding.yml
@@ -3,6 +3,7 @@ type: utility
 changelogURL:
 items:
   - date: 2021-12-21
+    page: Margin and padding utilities
     summary: Added documentation for values `10`, `15`, and `margin-neg-4` through `margin-neg-15`.
     summaryAdditional:
     isBreaking:
@@ -16,6 +17,7 @@ items:
     githubRepo: uswds-site
     versionUswds:
   - date: 2021-12-21
+    page: Margin and padding utilities
     summary: Fixed the example display for "Padding on all sides".
     summaryAdditional:
     isBreaking:
@@ -29,6 +31,7 @@ items:
     githubRepo: uswds-site
     versionUswds:
   - date: 2021-06-16
+    page: Margin and padding utilities
     summary: Added `margin-neg-4` through `margin-neg-15` to the default set.
     summaryAdditional:
     isBreaking:
@@ -41,4 +44,3 @@ items:
     githubPr: 4212
     githubRepo: uswds
     versionUswds: 2.12.0
-

--- a/_data/changelogs/utilities-text-styles.yml
+++ b/_data/changelogs/utilities-text-styles.yml
@@ -1,8 +1,9 @@
-title: Display utility
+title: Text utilities
 type: utility
 changelogURL:
 items:
   - date: 2021-05-25
+    page: Text utilities utilities
     summary: Corrected the value of `.text-ls-1` to `0.025em` from `0.05em`.
     summaryAdditional:
     isBreaking:

--- a/_data/changelogs/utilities.yml
+++ b/_data/changelogs/utilities.yml
@@ -3,6 +3,7 @@ type: utility
 changelogURL:
 items:
   - date: 2024-06-26
+    page: Utilities
     summary: Fixed example in settings.
     summaryAdditional: Added missing comma to color example in `$output-these-utilities`.
     isBreaking: false
@@ -18,6 +19,7 @@ items:
     githubRepo: uswds-site
     versionUswds:
   - date: 2023-06-09
+    page: Utilities
     summary: Removed unused utility builder comments from compiled CSS.
     summaryAdditional: This update significantly reduces the compiled file size.
     affectsStyles: true
@@ -25,6 +27,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-06-09
+    page: Utilities
     summary: Updated sass map instructions to reflect new pattern.
     summaryAdditional: Users are now instructed to define only the variable they wish to change instead of having to define the entire map.
     isBreaking: true
@@ -38,6 +41,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.5.0
   - date: 2023-03-09
+    page: Utilities
     summary: Outline utility and mixin now accept the 05 token.
     summaryAdditional: Now, the `.outline-05` utility class and the `u-outline('05')` mixin should work as expected.
     isBreaking:
@@ -51,6 +55,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.4.0
   - date: 2022-05-04
+    page: Utilities
     summary: Added `margin-horizontal` and `margin-vertical` utility modules.
     summaryAdditional:
     isBreaking:
@@ -64,6 +69,7 @@ items:
     githubRepo: uswds-site
     versionUswds:
   - date: 2022-04-28
+    page: Utilities
     summary: |
       Replaced the outdated text: `$output-all-utilities` with updated: `$output-these-utilities`.
     summaryAdditional:
@@ -78,6 +84,7 @@ items:
     githubRepo: uswds
     versionUswds: 3.0.0
   - date: 2022-04-28
+    page: Utilities
     summary: Added documentation for using the `uswds-utilities` package, customizing utilities settings, and understanding utility modules.
     summaryAdditional:
     isBreaking:
@@ -91,6 +98,7 @@ items:
     githubRepo: uswds-site
     versionUswds:
   - date: 2021-06-16
+    page: Utilities
     summary: Added state color tokens to default utilities.
     summaryAdditional:
     isBreaking:

--- a/_includes/consolidated-changelog-table.html
+++ b/_includes/consolidated-changelog-table.html
@@ -1,0 +1,101 @@
+{% assign col1Title = 'Date' %}
+{% assign col1Classes = 'tablet:grid-col' %}
+{% assign col2Title = 'USWDS version' %}
+{% assign col2Classes = 'tablet:grid-col tablet:padding-left-0' %}
+{% assign col3Title = 'Page' %}
+{% assign col3Classes = 'tablet:grid-col' %}
+{% assign col4Title = 'Breaking' %}
+{% assign col4Classes = 'tablet:grid-col site-changelog--hide-tablet' %}
+{% assign col5Title = 'Description' %}
+{% assign col5Classes = 'tablet:grid-col-6' %}
+
+<table class="usa-table--borderless site-table-responsive site-table-simple">
+  <thead>
+    <tr>
+      <th scope="col" class="{{ col1Classes }}">{{ col1Title }}</th>
+      <th scope="col" class="{{ col2Classes }}">{{ col2Title }}</th>
+      <th scope="col" class="{{ col3Classes }}">{{ col3Title }}</th>
+      <th scope="col" class="{{ col4Classes }}">{{ col4Title }}</th>
+      <th scope="col" class="{{ col5Classes }}">{{ col5Title }}</th>
+    </tr>
+  </thead>
+  <tbody class="font-lang-3xs">
+    {% for item in changelogItems %}
+    <tr>
+      <td data-title="{{ col1Title }}" class="{{ col1Classes }}">
+        {% if item.date %}
+          <span class="font-mono-3xs">{{ item.date }}</span>
+        {% endif %}
+      </td>
+      <td data-title="{{ col2Title }}" class="{{ col2Classes }}">
+        {% if item.versionUswds %}
+        <span class="font-mono-3xs">
+          <a href="https://github.com/uswds/uswds/releases/tag/v{{ item.versionUswds }}">
+            {{ item.versionUswds }}
+          </a>
+        </span>
+        {% else %}
+        N/A
+        {% endif %}
+      </td>
+      <td data-title="{{ col3Title }}" class="{{ col3Classes }}">
+        <ul class="add-list-reset">
+          {{ item.page }}
+        </ul>
+      </td>
+      <td data-title="{{ col4Title }}" class="{{ col4Classes }}">
+        {% if item.isBreaking %}
+          <span class="output-false">Breaking</span>
+        {% else %}
+          No
+        {% endif %}
+      </td>
+      <td data-title="{{ col5Title }}" class="{{ col5Classes }}">
+        {% if item.summary %}
+        <p class="measure-6">
+          {% if item.isBreaking %}
+            <span class="site-changelog--show-tablet output-false">Breaking</span>
+          {% endif %}
+          {% if item.affectsAccessibility %}
+            <span class="output-warning">Accessibility</span> 
+          {% endif %}
+          {% if item.affectsAssets %}
+            <span class="output-neutral">Assets</span> 
+          {% endif %}
+          {% if item.affectsContent %}
+            <span class="output-neutral">Content</span> 
+          {% endif %}
+          {% if item.affectsGuidance %}
+            <span class="output-neutral">Guidance</span> 
+          {% endif %}
+          {% if item.affectsJavascript %}
+            <span class="output-neutral">JavaScript</span> 
+          {% endif %}
+          {% if item.affectsMarkup %}
+            <span class="output-warning">Markup</span> 
+          {% endif %}
+          {% if item.affectsStyles %}
+            <span class="output-neutral">Styles</span> 
+          {% endif %}
+          {% if item.affectsSettings %}
+            <span class="output-neutral">Settings</span> 
+          {% endif %}
+          <strong>
+            {{ item.summary | markdownify | remove: '<p>' | remove: '</p>' }}
+          </strong>
+          {% if item.summaryAdditional %}
+            {{ item.summaryAdditional | markdownify | remove: '<p>' | remove: '</p>' }}
+          {% endif %}
+          {% if item.githubPr %}
+            More information:
+            <a href="https://github.com/uswds/{{ item.githubRepo }}/pull/{{ item.githubPr }}">
+              {{ item.githubRepo }}#{{ item.githubPr }}
+            </a>
+          {% endif %}
+        </p>
+        {% endif %}
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>

--- a/_includes/consolidated-changelog-table.html
+++ b/_includes/consolidated-changelog-table.html
@@ -4,8 +4,8 @@
 {% assign col2Classes = 'tablet:grid-col tablet:padding-left-0' %}
 {% assign col3Title = 'Page' %}
 {% assign col3Classes = 'tablet:grid-col' %}
-{% assign col4Title = 'Breaking' %}
-{% assign col4Classes = 'tablet:grid-col site-changelog--hide-tablet' %}
+{% assign col4Title = 'Affects' %}
+{% assign col4Classes = 'tablet:grid-col' %}
 {% assign col5Title = 'Description' %}
 {% assign col5Classes = 'tablet:grid-col-6' %}
 
@@ -44,42 +44,39 @@
         </ul>
       </td>
       <td data-title="{{ col4Title }}" class="{{ col4Classes }}">
-        {% if item.isBreaking %}
-          <span class="output-false">Breaking</span>
-        {% else %}
-          No
-        {% endif %}
+        <ul class="add-list-reset">
+          {% if item.isBreaking %}
+            <li><span class="output-false">Breaking</span></li>
+          {% endif %}
+          {% if item.affectsAccessibility %}
+            <li><span class="output-warning">Accessibility</span></li>
+          {% endif %}
+          {% if item.affectsAssets %}
+            <li><span class="output-neutral">Assets</span></li>
+          {% endif %}
+          {% if item.affectsContent %}
+            <li><span class="output-neutral">Content</span></li>
+          {% endif %}
+          {% if item.affectsGuidance %}
+            <li><span class="output-neutral">Guidance</span></li>
+          {% endif %}
+          {% if item.affectsJavascript %}
+            <li><span class="output-neutral">JavaScript</span></li>
+          {% endif %}
+          {% if item.affectsMarkup %}
+            <li><span class="output-warning">Markup</span></li>
+          {% endif %}
+          {% if item.affectsStyles %}
+            <li><span class="output-neutral">Styles</span></li>
+          {% endif %}
+          {% if item.affectsSettings %}
+            <li><span class="output-neutral">Settings</span></li>
+          {% endif %}
+        </ul>
       </td>
       <td data-title="{{ col5Title }}" class="{{ col5Classes }}">
         {% if item.summary %}
         <p class="measure-6">
-          {% if item.isBreaking %}
-            <span class="site-changelog--show-tablet output-false">Breaking</span>
-          {% endif %}
-          {% if item.affectsAccessibility %}
-            <span class="output-warning">Accessibility</span> 
-          {% endif %}
-          {% if item.affectsAssets %}
-            <span class="output-neutral">Assets</span> 
-          {% endif %}
-          {% if item.affectsContent %}
-            <span class="output-neutral">Content</span> 
-          {% endif %}
-          {% if item.affectsGuidance %}
-            <span class="output-neutral">Guidance</span> 
-          {% endif %}
-          {% if item.affectsJavascript %}
-            <span class="output-neutral">JavaScript</span> 
-          {% endif %}
-          {% if item.affectsMarkup %}
-            <span class="output-warning">Markup</span> 
-          {% endif %}
-          {% if item.affectsStyles %}
-            <span class="output-neutral">Styles</span> 
-          {% endif %}
-          {% if item.affectsSettings %}
-            <span class="output-neutral">Settings</span> 
-          {% endif %}
           <strong>
             {{ item.summary | markdownify | remove: '<p>' | remove: '</p>' }}
           </strong>

--- a/pages/whats-new/overview.md
+++ b/pages/whats-new/overview.md
@@ -57,7 +57,7 @@ in_page_nav_headings: "h2"
 
 {% assign changelogItems = changelogItems | sort: 'date' | reverse %}
 
-{% include changelog-table-simple.html %}
+{% include consolidated-changelog-table.html %}
 
 ---
 

--- a/pages/whats-new/overview.md
+++ b/pages/whats-new/overview.md
@@ -55,7 +55,7 @@ in_page_nav_headings: "h2"
   {% assign changelogItems = changelogItems | concat: items %}
 {% endfor %}
 
-{% assign changelogItems = changelogItems | sort: 'date' | reverse %}
+{% assign changelogItems = changelogItems | sort: 'date' | reverse | slice: 0,150 %}
 
 {% include consolidated-changelog-table.html %}
 

--- a/pages/whats-new/overview.md
+++ b/pages/whats-new/overview.md
@@ -44,11 +44,20 @@ in_page_nav_headings: "h2"
 %}
 
 {:.margin-top-2.text-normal.font-lang-md.text-gray-70}
+
 ## News and updates
 
-{% for post in site.posts limit:4 %}
-  {% include post-preview.html post=post heading="h3"%}
+{% assign changelogs = site.data.changelogs %}
+{% assign changelogsItems = "" | split: "," %}
+
+{% for file in changelogs %}
+  {% assign items = file[1].items %}
+  {% assign changelogItems = changelogItems | concat: items %}
 {% endfor %}
+
+{% assign changelogItems = changelogItems | sort: 'date' | reverse %}
+
+{% include changelog-table-simple.html %}
 
 ---
 

--- a/pages/whats-new/overview.md
+++ b/pages/whats-new/overview.md
@@ -43,9 +43,11 @@ in_page_nav_headings: "h2"
   listItemClasses="desktop:grid-col-6"
 %}
 
-{:.margin-top-2.text-normal.font-lang-md.text-gray-70}
 
-## News and updates
+{: .site-component-section-title #changelog }
+## Latest changes to USWDS
+
+Meaningful code and guidance updates across the design system are listed in the following table:
 
 {% assign changelogs = site.data.changelogs %}
 {% assign changelogsItems = "" | split: "," %}
@@ -56,6 +58,7 @@ in_page_nav_headings: "h2"
 {% endfor %}
 
 {% assign changelogItems = changelogItems | sort: 'date' | reverse | slice: 0,150 %}
+
 
 {% include consolidated-changelog-table.html %}
 


### PR DESCRIPTION
## Summary

**Add consolidated changelog.** Add a view to the What's New page so design system users know what's changed across the design system.

There've been many changes to the design system in the last couple weeks, and we're in the process of [adding content change alerts](https://github.com/uswds/uswds-site/pull/3090) to content affected by recent executive orders and policy guidance.

It's important that design system users know how the design system is changing. We have changelogs on individual pages, but there's currently no way to see all the changes in a single view. 

This PR adds a consolidated changelog to our What's New page so design system users can better keep up to date with these changes. This new view will show the last 150 changes to the design system.

## Related issue

None

## Preview links

[Preview](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/dw-whats-new-newsfeed/about/whats-new/) → 

## How to test

Visit the What's New page and check for the new view at the after the two content cards. Check that it's an accurate log of the most recent changes to the design system.