### PR TITLE
USWDS-Site: Card Accessibility Checklist

### DIFF
--- a/_components/card/accessibility-tests.md
+++ b/_components/card/accessibility-tests.md
@@ -1,0 +1,11 @@
+---
+permalink: /components/card/accessibility-tests/
+layout: accessibility-test
+component:
+ name: card
+title: Card accessibility tests
+category: Components
+lead: Any USWDS card component should pass these manual accessibility tests.
+changelog:
+ key: 'component-card-accessibility'
+---

--- a/_components/card/card.md
+++ b/_components/card/card.md
@@ -14,16 +14,8 @@ redirect_from:
 layout: component
 lead: Cards contain content and actions about a single subject.
 subnav:
-- text: Preview
-  href: '#card-preview'
-- text: Code
-  href: '#card-code'
-- text: Guidance
-  href: '#card-guidance'
-- text: Package
-  href: '#card-package'
-- text: Latest updates
-  href: '#changelog'
+- text: Card accessibility tests
+  href: /components/card/accessibility-tests/
 type: component
 variants:
   - variant: "`.usa-card--flag`"

--- a/_data/accessibility-tests/card.yml
+++ b/_data/accessibility-tests/card.yml
@@ -77,7 +77,7 @@ test_items:
     test_type: screen_reader
     version_tested: 3.8.1
     wcag_criterion: 1.3.1
-  - summary: Card contents is announced in the same order it appears on the page.
+  - summary: Card content is announced in the same order it appears on the page.
     summary_additional: When you navigate through card content with a screen reader, the announced content matches the visual presentation.
     test_status: pass
     test_type: screen_reader

--- a/_data/accessibility-tests/card.yml
+++ b/_data/accessibility-tests/card.yml
@@ -110,7 +110,7 @@ test_items:
       When you use a screen reader and tab through the card's interactive elements,
       you hear each element's role announced.
       If there are links, you will hear if the link has been visited or not.
-    test_status: conditional
+    test_status: pass
     test_type: screen_reader
     version_tested: 3.8.2
     wcag_criterion: 4.1.2

--- a/_data/accessibility-tests/card.yml
+++ b/_data/accessibility-tests/card.yml
@@ -3,19 +3,24 @@ component_status: pass
 test_items:
 # General tests
   - summary: Color is not the only method used to convey meaning.
-    summary_additional: When you view the elements in a card, you can see and read text, and do not have to rely on color alone for meaning.
+    summary_additional: |
+      When you view the elements in a card,
+      you can see and read text, and do not have to rely on color alone for meaning.
     test_status: conditional
     test_type: general
     version_tested: 3.8.2
     wcag_criterion: 1.4.1
   - summary: Card content meets color contrast requirements.
-    summary_additional: When you look at a card and use ANDI or another color contrast analyzer, contrast between the text and background color is at least 4:5:1.
-    test_status: conditional
+    summary_additional: |
+      When you look at a card and use a color contrast analyzer,
+      contrast between the text and background color is at least 4:5:1.
+    test_status: pass
     test_type: general
     version_tested: 3.8.2
     wcag_criterion: 1.4.3
   - summary: Links provide direct location description.
-    summary_additional: You can read the text of any link in a card to understand where the link will take you.
+    summary_additional: |
+      You can read the text of any link in a card to understand where the link will take you.
     test_status: conditional
     test_type: general
     version_tested: 3.8.2
@@ -27,66 +32,85 @@ test_items:
     version_tested: 3.8.2
     wcag_criterion: 2.4.6
   - summary: Touch target size for all clickable elements meets height and width requirements.
-    summary_additional: When you use the browser inspect tool, the size and spacing of the touch target are at least 24px wide and 24px tall.
+    summary_additional: |
+      When you use the browser inspect tool,
+      the size and spacing of the touch target are at least 24px wide and 24px tall.
     test_status: pass
     test_type: general
     version_tested: 3.8.2
     wcag_criterion: 2.5.8
 # Zoom/screen magnification tests
   - summary: Using zoom does not obstruct the card elements.
-    summary_additional: When you zoom in at 400%, you can see the card content and scroll up and down. It does not overlap with other page content and there is no loss of information.
+    summary_additional: |
+      When you zoom in at 400%, you can see the card content and scroll up and down.
+      It does not overlap with other page content and there is no loss of information.
     test_status: pass
     test_type: zoom
     version_tested: 3.8.2
     wcag_criterion: 1.4.10
 # Keyboard navigation tests
   - summary: Content is accessible through keyboard alone.
-    summary_additional: When you use only a keyboard, all links and buttons in the card are accessible.
+    summary_additional: |
+      When you use only a keyboard, all links and buttons in the card are accessible.
     test_status: pass
     test_type: keyboard
     version_tested: 3.8.2
     wcag_criterion: 2.1.1
   - summary: Keyboard actions will not trap focus.
-    summary_additional: When you use a keyboard, you can tab into and out of each card, and you can easily move in and out of content.
+    summary_additional: |
+      When you use a keyboard, you can tab into and out of each card,
+      and you can easily move in and out of content.
     test_status: pass
     test_type: keyboard
     version_tested: 3.8.2
     wcag_criterion: 2.1.2
   - summary: Focus follows a logical content order.
-    summary_additional: When you navigate through the card with a keyboard, the focus follows a logical order in relation to other card content.
+    summary_additional: |
+      When you navigate through the card with a keyboard,
+      the focus follows a logical order in relation to other card content.
     test_status: pass
     test_type: keyboard
     version_tested: 3.8.2
     wcag_criterion: 2.4.3
   - summary: Focus indicator is clearly visible around card interactive elements.
-    summary_additional: When you use a keyboard to tab into the card's interactive elements, there is a visible outline or other clear indication of focus.
+    summary_additional: |
+      When you use a keyboard to tab into the card's interactive elements,
+      there is a visible outline or other clear indication of focus.
     test_status: pass
     test_type: keyboard
     version_tested: 3.8.2
     wcag_criterion: 2.4.7
 # Screen reader tests
-  - summary: Screen readers announce groups of cards as an unordered list.
-    summary_additional: When you use a screen reader, you hear each card in a group announced as a list item.
+  - summary: Screen reader announces groups of cards as an unordered list.
+    summary_additional: |
+      When you use a screen reader to navigate through a card component,
+      you hear each card in a group announced as a list item.
     test_status: conditional
     test_type: screen_reader
     version_tested: 3.8.2
     wcag_criterion: 1.3.1
   - summary: Screen reader announces card content.
-    summary_additional: When you use a screen reader, you hear the hierarchy of headings and interactive elements as they are presented on the page.
+    summary_additional: |
+      When you use a screen reader to navigate through a card component,
+      you hear the hierarchy of headings and interactive elements as they are presented on the page.
     test_status: conditional
     test_type: screen_reader
     version_tested: 3.8.1
     wcag_criterion: 1.3.1
   - summary: Card content is announced in the same order it appears on the page.
-    summary_additional: When you navigate through card content with a screen reader, the announced content matches the visual presentation.
+    summary_additional: |
+      When you navigate through card content with a screen reader,
+      the announced content matches the visual presentation.
     test_status: pass
     test_type: screen_reader
     version_tested: 3.8.2
     wcag_criterion: 1.3.2
   - summary: Screen reader announces roles and states of links.
-    summary_additional: When you use a screen reader and tab through the card's interactive elements, you hear each element's role announced. If there are links, you will hear if the link has been visited or not.
+    summary_additional: |
+      When you use a screen reader and tab through the card's interactive elements,
+      you hear each element's role announced.
+      If there are links, you will hear if the link has been visited or not.
     test_status: conditional
     test_type: screen_reader
     version_tested: 3.8.2
     wcag_criterion: 4.1.2
-    

--- a/_data/accessibility-tests/card.yml
+++ b/_data/accessibility-tests/card.yml
@@ -1,0 +1,92 @@
+title: Card
+component_status: pass
+test_items:
+# General tests
+  - summary: Color is not the only method used to convey meaning.
+    summary_additional: When you view the elements in a card, you can see and read text, and do not have to rely on color alone for meaning.
+    test_status: conditional
+    test_type: general
+    version_tested: 3.8.2
+    wcag_criterion: 1.4.1
+  - summary: Card content meets color contrast requirements.
+    summary_additional: When you look at a card and use ANDI or another color contrast analyzer, contrast between the text and background color is at least 4:5:1.
+    test_status: conditional
+    test_type: general
+    version_tested: 3.8.2
+    wcag_criterion: 1.4.3
+  - summary: Links provide direct location description.
+    summary_additional: You can read the text of any link in a card to understand where the link will take you.
+    test_status: conditional
+    test_type: general
+    version_tested: 3.8.2
+    wcag_criterion: 2.4.4
+  - summary: Headings are clear and descriptive.
+    summary_additional: When you view a card, the heading is clear and concise.
+    test_status: conditional
+    test_type: general
+    version_tested: 3.8.2
+    wcag_criterion: 2.4.6
+  - summary: Touch target size for all clickable elements meets height and width requirements.
+    summary_additional: When you use the browser inspect tool, the size and spacing of the touch target are at least 24px wide and 24px tall.
+    test_status: pass
+    test_type: general
+    version_tested: 3.8.2
+    wcag_criterion: 2.5.8
+# Zoom/screen magnification tests
+  - summary: Using zoom does not obstruct the card elements.
+    summary_additional: When you zoom in at 400%, you can see the card content and scroll up and down. It does not overlap with other page content and there is no loss of information.
+    test_status: pass
+    test_type: zoom
+    version_tested: 3.8.2
+    wcag_criterion: 1.4.10
+# Keyboard navigation tests
+  - summary: Content is accessible through keyboard alone.
+    summary_additional: When you use only a keyboard, all links and buttons in the card are accessible.
+    test_status: pass
+    test_type: keyboard
+    version_tested: 3.8.2
+    wcag_criterion: 2.1.1
+  - summary: Keyboard actions will not trap focus.
+    summary_additional: When you use a keyboard, you can tab into and out of each card, and you can easily move in and out of content.
+    test_status: pass
+    test_type: keyboard
+    version_tested: 3.8.2
+    wcag_criterion: 2.1.2
+  - summary: Focus follows a logical content order.
+    summary_additional: When you navigate through the card with a keyboard, the focus follows a logical order in relation to other card content.
+    test_status: pass
+    test_type: keyboard
+    version_tested: 3.8.2
+    wcag_criterion: 2.4.3
+  - summary: Focus indicator is clearly visible around card interactive elements.
+    summary_additional: When you use a keyboard to tab into the card's interactive elements, there is a visible outline or other clear indication of focus.
+    test_status: pass
+    test_type: keyboard
+    version_tested: 3.8.2
+    wcag_criterion: 2.4.7
+# Screen reader tests
+  - summary: Screen readers announce groups of cards as an unordered list.
+    summary_additional: When you use a screen reader, you hear each card in a group announced as a list item.
+    test_status: conditional
+    test_type: screen_reader
+    version_tested: 3.8.2
+    wcag_criterion: 1.3.1
+  - summary: Screen reader announces card content.
+    summary_additional: When you use a screen reader, you hear the hierarchy of headings and interactive elements as they are presented on the page.
+    test_status: conditional
+    test_type: screen_reader
+    version_tested: 3.8.1
+    wcag_criterion: 1.3.1
+  - summary: Card contents is announced in the same order it appears on the page.
+    summary_additional: When you navigate through card content with a screen reader, the announced content matches the visual presentation.
+    test_status: pass
+    test_type: screen_reader
+    version_tested: 3.8.2
+    wcag_criterion: 1.3.2
+  - summary: Screen reader announces roles and states of links.
+    summary_additional: When you use a screen reader and tab through the card's interactive elements, you hear each element's role announced. If there are links, you will hear if the link has been visited or not.
+    test_status: conditional
+    test_type: screen_reader
+    version_tested: 3.8.2
+    wcag_criterion: 4.1.2
+    

--- a/_data/changelogs/component-card-accessibility.yml
+++ b/_data/changelogs/component-card-accessibility.yml
@@ -1,0 +1,8 @@
+title: Card accessibility tests
+type: component
+items:
+ - date: NNNN-NN-NN
+   summary: Added accessibility tests page.
+   affectsGuidance: true
+   githubPr: [Related PR number]
+   githubRepo: uswds-site

--- a/_data/changelogs/component-card-accessibility.yml
+++ b/_data/changelogs/component-card-accessibility.yml
@@ -4,5 +4,5 @@ items:
  - date: NNNN-NN-NN
    summary: Added accessibility tests page.
    affectsGuidance: true
-   githubPr: [Related PR number]
+   githubPr: 3101
    githubRepo: uswds-site

--- a/_data/changelogs/component-card-accessibility.yml
+++ b/_data/changelogs/component-card-accessibility.yml
@@ -1,7 +1,7 @@
 title: Card accessibility tests
 type: component
 items:
- - date: NNNN-NN-NN
+ - date: 2025-02-14
    summary: Added accessibility tests page.
    affectsGuidance: true
    githubPr: 3101

--- a/_data/changelogs/component-card.yml
+++ b/_data/changelogs/component-card.yml
@@ -2,7 +2,7 @@ title: Card
 type: component
 changelogURL:
 items:
-  - date: NNNN-NN-NN
+  - date: 2025-02-14
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
     githubPr: 3101

--- a/_data/changelogs/component-card.yml
+++ b/_data/changelogs/component-card.yml
@@ -2,6 +2,11 @@ title: Card
 type: component
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Added WCAG compliance tag and accessibility test status section.
+    affectsGuidance: true
+    githubPr: [Related PR number]
+    githubRepo: uswds-site
   - date: 2024-10-04
     summary: Fixed a bug that caused the component to ignore the `$theme-card-font-family` setting.
     summaryAdditional: Confirm that your implementation of the card component displays with the expected font family.

--- a/_data/changelogs/component-card.yml
+++ b/_data/changelogs/component-card.yml
@@ -5,7 +5,7 @@ items:
   - date: NNNN-NN-NN
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true
-    githubPr: [Related PR number]
+    githubPr: 3101
     githubRepo: uswds-site
   - date: 2024-10-04
     summary: Fixed a bug that caused the component to ignore the `$theme-card-font-family` setting.


### PR DESCRIPTION
# Summary

Added accessibility test page for card component

> [!Important]
> We need to update changelog dates before merge

## Related issue

Closes #2911 

## Preview link
[Card Component Page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/rc-card-accessibility-checklist/components/card/)
[Card Accessibility Tests Page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/rc-card-accessibility-checklist/components/card/accessibility-tests/)


## Testing and review
Follow these steps:

1. Confirm that both the main component page and the accessibility tests page have the correct compliance tag at the top.
2. Confirm that the main component page links to the accessibility tests page in the side navigation.
3. Confirm that the main component page links to the accessibility tests page from the accessibility guidance section.
4. Confirm that the main component page shows the accessibility tests summary.
5. Check that accessibility tests page provides the correct counts for each test status type.
6. Confirm the test checklist summaries and data are accurate.
7. Confirm no visual issues.
8. Confirm there is an appropriate changelog entry on both the main component page and the accessibility tests page.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [X] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [X] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `main`).
- [X] Run `npm run prettier:scss` to format any Sass updates.
- [X] Run `npm test` and confirm that all tests pass.
- [X] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->