### PR TITLE
USWDS-Site [Link]: fix broken link to docx in link example

### DIFF
--- a/_components/link/guidance/usability-should.md
+++ b/_components/link/guidance/usability-should.md
@@ -42,7 +42,7 @@
     > GSA published a report, [Transforming the American Digital Experience [PDF, 18 pages]](https://designsystem.digital.gov/files/next/Transforming-the-American-digital-experience.pdf)
 
     **Example 2:**
-    > Download the [Revised 508 Standards Applicability Checklist [DOCX, 2 pages]](https://assets.section508.gov/files/508-standards-applicability-checklist.docx)
+    > Download the [Revised 508 Standards Applicability Checklist [DOCX, 2 pages]](https://assets.section508.gov/assets/files/508-standards-applicability-checklist.docx)
 
     **Example 3:**
     > Download the [USWDS 2.11.2 Design Kit for Sketch [ZIP, 13.3 MB]](https://github.com/uswds/uswds-for-designers/releases/download/v2.4.0/uswds-for-designers-v2.4.0.zip)


### PR DESCRIPTION
# Summary

The example `docx` link in the documentation was broken. This PR fixes that by replacing it with a working link.

## Related issue

Closes #3131

## Preview link

[Preview link 👀 ](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/mh/fix-broken-link-to-508/components/link/)