### PR TITLE
USWDS-Site - Accordion/accessibility tests: update WCAG criteria

### DIFF
--- a/_data/accessibility-tests/accordion.yml
+++ b/_data/accessibility-tests/accordion.yml
@@ -167,7 +167,7 @@ test_items:
     test_status: pass
     test_type: screen_reader
     version_tested: 3.8.0
-    wcag_criterion: 2.4.6
+    wcag_criterion: 1.3.1
   - summary: Screen reader announces "expanded" state.
     summary_additional: |
       When you use a screen reader and navigate to an open panel,


### PR DESCRIPTION
# Summary
"Screen reader announces “collapsed” state" is more accurate: changed from 2.4.6 to 1.3.1
_Provide a one or two sentence summary of the update that can be used in the changelog._

## Preview link
(will snag after posting)
Preview link:
<!-- If available, provide a link to a demo of the solution in action. -->

## Testing and review
1. view preview, ensure intended change matches