### PR TITLE
USWDS-Site - [public Slack form link]: [replacing chat.18f.gov due to 404s]

### DIFF
--- a/_next/05-get-involved.md
+++ b/_next/05-get-involved.md
@@ -28,7 +28,7 @@ chapter: true
 
 - Use the conversation starters throughout this report to prompt discussions with your managers and team members
 
-- Join the [USWDS community](https://chat.18f.gov/) and get involved
+- Join the [USWDS community](https://docs.google.com/forms/d/e/1FAIpQLSfFoLTRV00g1iIEZv404wJ0BRwNc6CPKbyXMCeXLjDKDv9g4Q/viewform) and get involved
 
 ### Thought-leaders can:
 


### PR DESCRIPTION
Replacing all references to chat.18f.gov since 18f.gov has been abruptly decommissioned. Directly linking to the form instead.

# Summary
Replacing all references to chat.18f.gov since 18f.gov has been abruptly decommissioned, resulting in 404s. Now linking directly to the form.

## Preview link

Preview link:
<!-- If available, provide a link to a demo of the solution in action. -->


## Major changes

Replaces all instances where chat.18f.gov appears, including site Include and individual pages.

## Testing and review

Check all the above for functionality of the new link.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Create a changelog entry for any user-facing changes. Learn more about creating changelogs in [_data/changelogs/_CHANGELOG-README.md](https://github.com/uswds/uswds-site/blob/main/_data/changelogs/_CHANGELOG-README.md).
-->