### PR TITLE
USWDS-Site - Time Picker: Add combo box to time picker dependencies

### DIFF
--- a/_data/packages.yml
+++ b/_data/packages.yml
@@ -363,6 +363,7 @@
     - "usa-label"
     - "usa-hint"
     - "usa-input"
+    - "usa-combo-box"
 - name: "usa-tooltip"
   fullSize: 7
   sourceSize: 1


### PR DESCRIPTION
# Summary

Adds `usa-combo-box` to time picker dependencies
## Related issue

https://github.com/uswds/uswds/issues/6560

## Related PR

https://github.com/uswds/uswds/pull/6634

## Testing and review

<img width="689" height="177" alt="Package usage: @forward 'usa-time-picker';Dependencies: uswds-fonts, usa-label, usa-hint, usa-input, usa-combo-box" src="https://github.com/user-attachments/assets/a20a3814-026d-4967-b37d-623c737a4b39" />

---

- [ ] Create a changelog entry for any user-facing changes. Learn more about creating changelogs in [_data/changelogs/_CHANGELOG-README.md](https://github.com/uswds/uswds-site/blob/main/_data/changelogs/_CHANGELOG-README.md).
- [x] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `main`).
- [x] Run `npm run prettier:scss` to format any Sass updates.
- [x] Run `npm test` and confirm that all tests pass.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.