### PR TITLE
USWDS-site: fix typo in Performance section

### DIFF
--- a/pages/documentation/guidance/performance/why.md
+++ b/pages/documentation/guidance/performance/why.md
@@ -50,4 +50,4 @@ Measuring performance ensures the team:
 
 ## Conclusion
 
-As technology becomes more prevalent in the Unites States, it's more common that the primary way Americans interact with the government is through the web. Ensuring that government sites perform quickly for all ensures that all Americans have a good user experience and aren't blocked from the web services they require. Tracking and improving a site's performance is a first step towards ensuring that a site can reach as wide of an audience as possible.
+As technology becomes more prevalent in the United States, it's more common that the primary way Americans interact with the government is through the web. Ensuring that government sites perform quickly for all ensures that all Americans have a good user experience and aren't blocked from the web services they require. Tracking and improving a site's performance is a first step towards ensuring that a site can reach as wide of an audience as possible.


### PR DESCRIPTION
# Summary

Fixed singular typo in "United States" located in the conclusion

## Related issue

Closes #3196 (first attempt filed then deleted in #3198)

## Problem statement
Of all the typos to make :sweat_smile: — this sure was one. 

Ensures the name of our nation stands correctly on the USWDS site.

## Testing and review
1. Confirm that the new spelling is correct
1. Confirm that the bug outlined in issue #3196 has been fixed.