### PR TITLE
USWDS-Site - Website policies and notices: Fix nested list in Redistribution of code section

### DIFF
--- a/pages/about/website-policies-and-notices.md
+++ b/pages/about/website-policies-and-notices.md
@@ -110,13 +110,13 @@ We use open-source software and free or low cost, commercial application program
 
 3.  All source code as defined above may be shared with the general public via a highly visible, easily accessible online source code community (such as Github or npm) that facilitates the code's reuse. Source code won't be released if any of the following conditions are met:
 
-1.  The USWDS core team determines that the code is too crude to merit distribution or provide value to the broader community.
+    -   The USWDS core team determines that the code is too crude to merit distribution or provide value to the broader community.
 
-2.  The government doesn't have the rights to reproduce and release the item. The government has public release rights when the software is developed by government personnel, when the government receives an unlimited license  in software developed by a contractor at the government's expense, or when the government modifies existing OSS.
+    -   The government doesn't have the rights to reproduce and release the item. The government has public release rights when the software is developed by government personnel, when the government receives an unlimited license  in software developed by a contractor at the government's expense, or when the government modifies existing OSS.
 
-3.  The public release of the item is restricted by other law or regulation, such as the Export Administration Regulations or the International Traffic in Arms Regulation.
+    -   The public release of the item is restricted by other law or regulation, such as the Export Administration Regulations or the International Traffic in Arms Regulation.
 
-4.  GSA cybersecurity staff determines that the public release of such code would pose an unacceptable risk to GSA's operational security.
+    -   GSA cybersecurity staff determines that the public release of such code would pose an unacceptable risk to GSA's operational security.
 
 ## Privacy and security policies
 


### PR DESCRIPTION
# Summary

Fixed nested list rendering in the "Redistribution of code" section of the Website policies and notices page so the four conditions under item 3 display as indented sub-bullets instead of continuing the top-level numbered list.

## Related issue

Closes #3197

## Problem statement

On the Website policies and notices page, the "Redistribution of code" section's source markdown had four conditions (the "won't be released if…" list) written as unindented `1. 2. 3. 4.` items immediately after item 3. kramdown rendered them as continuation of the top-level `<ol>`, so the page showed seven flat numbered items (1–7) instead of three numbered items with a nested sub-list under item 3. This obscures the logical hierarchy between the redistribution rule and its exceptions.

## Solution

Indented those four items by 4 spaces and replaced the `1. 2. 3. 4.` markers with `-   ` hyphen-bullets (matching the unordered-bullet style used elsewhere in the same file). kramdown now renders item 3 with a nested `<ul>` containing the four conditions, preserving the intended hierarchy. Prose is unchanged.

## Testing and review

- `npm run lint` passes (no JS/SCSS regressions).
- Rendered the page via kramdown locally and verified the output is one `<ol>` with three `<li>` items, the third containing a nested `<ul>` of four `<li>` items.
- Diff is 4 lines: indentation and list markers only. Prose is byte-identical, including the pre-existing double space in "unlimited license  in software".