### PR TITLE
USWDS-Site - Security: Fix highlighted nav item for security subpages

### DIFF
--- a/_includes/nav/current.html
+++ b/_includes/nav/current.html
@@ -4,8 +4,6 @@
   {% assign _current = true %}
 {% elsif include.primary and include.page.category == page.category %}
   {% assign _current = true %}
-{% elsif page.collection and include.page.subnav.type == page.collection %}
-  {% assign _current = true %}
 {% comment %}
   Use the page's `type` data key to connect the sidenav to a collection.
   This sets "current" for the pages inside the _posts directory.

--- a/pages/about/security.md
+++ b/pages/about/security.md
@@ -4,14 +4,13 @@ layout: styleguide
 title: Security
 category: About
 lead: Developing and using USWDS with security in mind
-subnav:
-  type: security_updates
+type: security_updates
 redirect_from:
 - /security/
 - /about/security-information/
 subnav:
 - text: Latest updates
-  href: '#changelog'
+  href: '/about/security/#changelog'
 changelog:
   key: about-security
 ---


### PR DESCRIPTION
# Summary

**Security subnav item hightlighted on Security subpages.** Updated the sidenav logic to properly highlight the Security sidenav item while on the security_updates pages.

## Related issue

Closes [#2974](https://github.com/uswds/uswds-site/issues/2974)

## Preview link

Preview link:
_Not available_

## Problem statement

The Security page provides links to two subpages -- Sanitized Combo Box content, and Automatic sanitizing for all JavaScript components.
As subpages of Security, the Security sidenav item should be highlighted (class="usa-current") while visiting these pages.
Instead, the sidenav has no highlighted items so users can easily get turned around.

## Solution

As suggested in [issue #2974](https://github.com/uswds/uswds-site/issues/2974), the solution was to remove `subnav.type: security_updates` in favor of `type: security_updates`.
Maybe it was in use once, but as of this PR there are no remnants of subnav.type remaining in the repo.
After implementing that change, it was noticed that the "Latest updates" subnav list item didn't do anything.
I've explicitly listed the path to `/about/security/#changelog` so users who click on it are navigated to the Security Latest Updates section.
An alternative would be to update the path of the Security subpages to exist under /about/security/updates/, and enable them to show as subnav items.

## Major changes

_Not applicable_

## Testing and review

Run this branch locally and navigate to /about/security/.
Click either of the "Security updates" links.
<img width="685" height="365" alt="image" src="https://github.com/user-attachments/assets/6ed7e1c4-7863-4f93-a2a4-e9d8baa898d0" />

Note the highlighted sidenav item:
<img width="975" height="540" alt="image" src="https://github.com/user-attachments/assets/5dd651d7-d7a1-4b64-97d5-e47ff2b49f4b" />
<img width="1095" height="547" alt="image" src="https://github.com/user-attachments/assets/12dacb55-bf00-49cf-8c23-62cc8e19f77d" />

Compare to [the active site](https://designsystem.digital.gov/security_updates/santized-combo-box-content/) where no sidenav item is highlighted:
<img width="1006" height="555" alt="image" src="https://github.com/user-attachments/assets/c90e73ee-7b71-4bfa-b8bc-562fd400104b" />
