### PR TITLE
USWDS-Site - Time Picker: Remove irrelevant copy and pasted guideline

### DIFF
--- a/_components/time-picker/guidance/usability.md
+++ b/_components/time-picker/guidance/usability.md
@@ -1,4 +1,3 @@
-- **Use option strings familiar to users.** The combo box filters by matching strings. Include option text that includes familiar strings or spellings (i.e. if using the combobox with a state list, include the postal abbreviation in the option text: District of Columbia (DC)).
 - **Make sure to test.** Test select menus thoroughly with members of your target audience. Several usability experts suggest they should be the “UI of last resort.” Many users find them confusing and difficult to use.
 - **Avoid dependent options.** Avoid making options in one select menu change based on the input to another. Users often don’t understand how choosing an item in one impacts another
 - **Use a good default.** When most users will (or should) pick a particular option, make it the default: `<option selected="selected">Default</option>`.


### PR DESCRIPTION
# Summary

**Removed guideline which doesn't apply to Time Picker.** The guideline removed applied broadly to select components, but was not relevant to the Time Picker component where the options are predetermined.

## Related issue

Closes [#1398](https://github.com/uswds/uswds-site/issues/1398)

## Preview link

_Not available_

## Problem statement

When the Time Picker component was added, some documentation was borrowed/copy and pasted from another component. The guideline removed in this PR is relevant for most selects, but not for this Time Picker because the options are predetermined.
This guideline should not appear as it makes it seem like the options are editable.

## Solution

Simply removed the guideline.

## Major changes

_Not applicable_

## Testing and review

I am running the site locally and it is rendering successfully.
<img width="753" height="520" alt="image" src="https://github.com/user-attachments/assets/79318e50-0772-45ea-8d96-df2dca474a5e" />
