### PR TITLE
Update CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,5 @@
 version: 2.1
 
-orbs:
-  snyk: snyk/snyk@2.2.0
-
 executors:
   my-executor:
     resource_class: large
@@ -92,8 +89,6 @@ jobs:
           command: |
             bundle config set --local path '~/project/vendor/bundle'
             bundle exec rspec
-      - snyk/scan:
-          organization: uswds
   test_a11y_desktop:
     executor: my-executor
     parallelism: 2


### PR DESCRIPTION
## Summary

Removed the Snyk orb and scan step from CircleCI configuration to eliminate authentication timeouts and simplify the CI pipeline. The repository continues to use Snyk security scanning through GitHub webhook integrations.

## Related issue

Closes #3218

Preview link

N/A

## Problem statement

The CircleCI build was failing during the Snyk scan step with authentication timeout errors. The Snyk orb was configured to use the uswds organization on standard Snyk (app.snyk.io), but the CI environment lacked proper authentication credentials (SNYK_TOKEN). This caused builds to hang while attempting an interactive OAuth login flow, which cannot complete in a non-interactive CI environment.

Additionally, the repository already has active Snyk webhook integrations, making the CircleCI scan redundant.

## Solution

Removed the Snyk orb declaration and the snyk/scan step from the test_build job in .circleci/config.yml. This eliminates the authentication timeout issue while maintaining security scanning through the existing Snyk GitHub webhook integrations.

The webhook integrations provide continuous monitoring on push and pull request events, posting results directly to   GitHub PRs and the Snyk dashboard. This approach is more integrated with the GitHub workflow and doesn't require   managing additional CI environment variables.

## Testing and review

** IMPORTANT ** the build is expected to fail on this branch because CircleCI is configured to use the workflow version that exists on the `develop` branch. The expectation is the site will build successfully only after it is merged to the develop branch.

1. Confirm that existing Snyk webhook integrations continue to function (check recent PRs for Snyk status checks)
1. Review the repository webhooks to ensure the Snyk scan remains active