### PR TITLE
Format modal guidance id as code

### DIFF
--- a/_components/modal/guidance/implementation.md
+++ b/_components/modal/guidance/implementation.md
@@ -1,4 +1,4 @@
-- **Use unique ids.** Each `.usa-modal` must have a unique id so that openers can associate them with their `aria-controls` attribute.
+- **Use unique ids.** Each `.usa-modal` must have a unique `id` so that openers can associate them with their `aria-controls` attribute.
 
 - **Openers.** A single modal can have multiple openers. Each opener requires `data-open-modal` and `aria-controls=”[modal_id]”` attributes. Openers can be coded as either `<button>` or `<a>` elements. Using `<a>` helps link to modals in the event JavaScript fails.
 


### PR DESCRIPTION
This updates the modal implementation guidance so `id` is formatted as code in the "Use unique ids" sentence.\n\nFixes #1388.