### PR TITLE
USWDS-site - Patterns changelog year typo correction

### DIFF
--- a/_data/changelogs/patterns-user-profile.yml
+++ b/_data/changelogs/patterns-user-profile.yml
@@ -2,13 +2,13 @@ title: User profile
 type: pattern
 changelogURL:
 items:
-  - date: 2022-02-11
+  - date: 2025-02-11
     summary: Removed Pronouns pattern.
     summaryAdditional: Removed content related to the January 20, 2025 Executive Order, \"Defending Women from Gender Ideology Extremism And Restoring Biological Truth To The Federal Government\".
     isBreaking: yes
     githubRepo: uswds-site
     githubPr: 3099
-  - date: 2022-02-11
+  - date: 2025-02-11
     summary: Updated link to Sex pattern.
     summaryAdditional: Removed content related to the January 20, 2025 Executive Order, \"Defending Women from Gender Ideology Extremism And Restoring Biological Truth To The Federal Government\".
     isBreaking: yes


### PR DESCRIPTION
Correct the year typo in last changelog dates (typo of 2022 corrected to 2025) on Create a user profile page