### PR TITLE
USWDS-Site - Checkbox: Update changelog date for tile variant entry

### DIFF
--- a/_data/changelogs/component-checkbox.yml
+++ b/_data/changelogs/component-checkbox.yml
@@ -2,6 +2,13 @@ title: Checkbox
 type: component
 changelogURL:
 items:
+  - date: 2026-07-07
+    summary: Added missing tile variant description to checkbox.
+    summaryAdditional: The class usa-checkbox__input--tile is now represented.
+    affectsGuidance: true
+    githubPr: 3216
+    githubRepo: uswds-site
+    versionUswds: 3.13.0
   - date: 2025-03-07
     summary: Updated the width of the label's target area to match the width of the content.
     summaryAdditional: Previously, the interactive area extended the full width of the container.
@@ -123,10 +130,3 @@ items:
     githubPr: 4080
     githubRepo: uswds
     versionUswds: 2.11.0
-  - date: NNNN-NN-NN
-    summary: Added missing tile variant description to checkbox.
-    summaryAdditional: The class usa-checkbox__input--tile is now represented.
-    affectsGuidance: true
-    githubPr: 3216
-    githubRepo: uswds-site
-    versionUswds: 3.13.0


### PR DESCRIPTION
## Summary

Updated the checkbox changelog so the tile variant entry appears with the correct 2026-07-07 date. This helps the changelog accurately document the checkbox tile variant guidance added in USWDS-Site #3216.

## Related issue

Related to #3216 and #2662

## Preview URL

https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/task/changelog-date/components/checkbox/

## Problem statement

The checkbox changelog included the tile variant entry with a placeholder date of `NNNN-NN-NN`, which prevented the changelog from accurately reflecting when the update was released.

## Solution

Moved the checkbox tile variant changelog entry into chronological order and replaced the placeholder date with `2026-07-07`.

## Testing and review

Review `_data/changelogs/component-checkbox.yml` and confirm that the checkbox tile variant changelog entry:

- Uses the date `2026-07-07`.
- Appears before older checkbox changelog entries.