### PR TITLE
USWDS-Site - Table: Update caption guidance to use caption as the table title

### DIFF
--- a/_components/table/guidance/accessibility.md
+++ b/_components/table/guidance/accessibility.md
@@ -1,6 +1,7 @@
 - **Simple tables can have up to two rows of headers.** Each header cell should have `scope="col"` or `scope="row"`.
 - **Complex tables have more than two levels of headers.** Each header should have a unique `id` and each data cell should have a `headers` attribute with each related header cell’s `id` listed.
-- **Add title and attribution in a caption.** When adding a title, attribution, or a last-updated date to a table, include it in the `<caption>` tag inside of the `<table>` element.
+- **Use a caption to describe the purpose of the table.** When adding a title, attribution, or a last-updated date to a table, include it in the `<caption>` tag inside of the `<table>` element. Keep the caption wording short.
+- **Ensure sighted users are able to identify the caption as the title of the table.** Make the caption style larger than the body style of the table text. Don’t match an existing heading level or other style (such as an H2 or H3). Caption styles should be noticeable yet distinct.
 - **Add an `aria-live` region to the page when enabling row sorting.** An `aria-live` region immediately following the `<table>` element automatically announces when the sort state changes for visitors using screen readers, but it must be added to the HTML document before load:
 `<div class="usa-sr-only usa-table__announcement-region" aria-live="polite"></div>`
 - **Don’t add `aria-label` attributes to sortable column headers.** Enabling row sorting automatically adds `aria-label` attributes to the sortable column headers and their toggle sort buttons via JavaScript. These labels are updated to reflect each column’s current sort state (ascending, descending, or unsorted) whenever sort changes.

--- a/_data/changelogs/component-table.yml
+++ b/_data/changelogs/component-table.yml
@@ -4,6 +4,13 @@ type: component
 changelogURL:
 
 items:
+  - date: 2026-07-07
+    summary: Updated caption guidance to use the caption as the table title.
+    summaryAdditional: Use a `caption` to describe the purpose of the table, and style it so sighted users can identify it as the title of the table.
+    affectsAccessibility: true
+    affectsGuidance: true
+    githubPr: 3236
+    githubRepo: uswds-site
   - date: 2024-12-18
     summary: Updated table header styles to be consistent across all table elements.
     summaryAdditional: Now, all `thead th`, `tbody th`, and `tfoot th` cells will have the same visual styles. Teams should confirm that their tables display as expected.

--- a/spec/component_guidance_spec.rb
+++ b/spec/component_guidance_spec.rb
@@ -1,0 +1,54 @@
+RSpec.describe 'component guidance content' do
+  GUIDANCE_FILES = Dir.glob('./_components/*/guidance/*.md').sort.freeze
+
+  # Accessibility and usability guidance renders as scannable bullet lists;
+  # each bullet is expected to lead with a bolded summary phrase. Files listed
+  # here predate the convention — don't add new ones.
+  BOLD_LEAD_EXCEPTIONS = ['./_components/sidenav/guidance/accessibility.md'].freeze
+
+  it 'finds guidance files to check' do
+    expect(GUIDANCE_FILES).not_to be_empty
+  end
+
+  GUIDANCE_FILES.each do |path|
+    describe path do
+      let(:lines) { File.readlines(path) }
+
+      # Empty guidance files are valid placeholders, so no emptiness check.
+      it 'has balanced bold markers on every line' do
+        lines.each_with_index do |line, index|
+          expect(line.scan('**').size).to be_even,
+            "#{path}:#{index + 1} has an unclosed ** bold marker"
+        end
+      end
+    end
+  end
+
+  (Dir.glob('./_components/*/guidance/{accessibility,usability}.md').sort - BOLD_LEAD_EXCEPTIONS).each do |path|
+    it "#{path} starts each top-level bullet with a bolded lead phrase" do
+      File.readlines(path).each_with_index do |line, index|
+        next unless line.start_with?('- ')
+
+        expect(line).to start_with('- **'),
+          "#{path}:#{index + 1} bullet is missing its bolded lead phrase"
+      end
+    end
+  end
+
+  describe 'table caption guidance' do
+    let(:content) { File.read('./_components/table/guidance/accessibility.md') }
+
+    # https://github.com/uswds/uswds-site/issues/3100 — approved copy asks
+    # tables to use a caption as their title in almost all cases and to style
+    # it distinctly, rather than only mentioning captions for attribution.
+    it 'tells authors to use a caption to describe the purpose of the table' do
+      expect(content).to include('**Use a caption to describe the purpose of the table.**')
+      expect(content).to include('Keep the caption wording short.')
+    end
+
+    it 'tells authors to style the caption as a visually distinct title' do
+      expect(content).to include('**Ensure sighted users are able to identify the caption as the title of the table.**')
+      expect(content).to include('noticeable yet distinct')
+    end
+  end
+end


### PR DESCRIPTION
# Summary

Updated table guidance to recommend using a `caption` element to describe the purpose of the table and to style it as a visually distinct title, helping all users identify what a table is about.

## Related issue

Closes #3100

## Problem statement

The table page's accessibility guidance only mentioned captions for titles and attribution ("Add title and attribution in a caption"). It didn't explain that the caption serves as the table's title, that it should be used in almost all cases, or how it should look so sighted users recognize it as the title. Without this, teams may skip captions or style them so they blend into the table body.

## Solution

Replaced the single caption bullet in the table accessibility guidance with the copy approved in #3100 (the issue carries the "Copy Approved" label):

- **Use a caption to describe the purpose of the table.** Keep the wording short, and include title, attribution, or last-updated dates in the `<caption>` tag.
- **Ensure sighted users are able to identify the caption as the title of the table.** Make the caption style larger than the table's body text, distinct from existing heading styles, and noticeable yet distinct.

Also added `spec/component_guidance_spec.rb`, which pins this approved copy and guards all component guidance files against Markdown mistakes (unclosed `**` bold markers, and accessibility/usability bullets missing their bolded lead phrase) — following the content-spec pattern started in `spec/lifecycle_status_spec.rb`.

One heads-up for reviewers: the related product issue uswds/uswds#6253 (default `caption` styles render smaller than body text) is still open, so USWDS's default styling doesn't yet match this guidance. This guidance helps teams style captions correctly in the meantime.

## Testing and review

1. Run `bundle exec rspec` — 333 examples, 0 failures (10 pre-existing + 323 new guidance checks).
2. Run `bundle exec jekyll build` and open the built table component page — both new bullets render with bold lead phrases under Accessibility guidance.
3. Compare the new copy against the approved draft in #3100 — it matches word for word.