### PR TITLE
USWDS-Site - Navigation: Remove redundant "navigation" from aria-labels

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -13,7 +13,7 @@
     <button type="button" class="usa-menu-btn">Menu</button>
   </div>
 </header>
-<nav aria-label="Primary navigation" class="usa-nav site-nav sticky">
+<nav aria-label="Primary" class="usa-nav site-nav sticky">
   <div class="usa-nav__inner site-nav__inner">
     <button type="button" class="usa-nav__close">
       <img src="{{ site.baseurl }}/assets/img/usa-icons/close.svg" role="img" alt="Close">

--- a/_includes/next/next-prefooter.html
+++ b/_includes/next/next-prefooter.html
@@ -34,7 +34,7 @@
 {% assign findings_pages = next_collection | where:"parent", "Findings" %}
 {% assign opportunity_pages = next_collection | where:"slug", "opportunity" %}
 
-<nav class="grid-container margin-y-5 padding-bottom-2 padding-top-3" aria-label="Page navigation">
+<nav class="grid-container margin-y-5 padding-bottom-2 padding-top-3" aria-label="Page">
   <div class="grid-row">
     <div class="grid-col-12 text-center tablet:grid-col-10 tablet:margin-x-auto desktop-lg:grid-col-12 margin-bottom-2">
       <h2>Continue reading this report</h2>

--- a/_layouts/next-content.html
+++ b/_layouts/next-content.html
@@ -29,7 +29,7 @@ report_title: Transforming the American digital experience
   {% endif %}
 </section>
 
-<nav class="next-internal-nav usa-dark-background" aria-label="Next report internal navigation">
+<nav class="next-internal-nav usa-dark-background" aria-label="Next report internal">
   <div class="grid-container">
     <ul id="internal-nav" class="next-internal-nav__list">
       {% for item in site.next %}

--- a/_next/01-summary.md
+++ b/_next/01-summary.md
@@ -74,7 +74,7 @@ summary_sections:
 </section>
 
 <!-- maybe componentize this -- NOTE: it is different from the one on next-content layout -->
-<nav class="next-internal-nav usa-dark-background" aria-label="Next report internal navigation">
+<nav class="next-internal-nav usa-dark-background" aria-label="Next report internal">
   <div class="grid-container">
     <ul id="internal-nav" class="next-internal-nav__list">
       {% for item in site.next %}

--- a/spec/navigation_aria_label_spec.rb
+++ b/spec/navigation_aria_label_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe 'navigation landmark labels' do
+  TEMPLATE_FILES = Dir.glob('./**/*.{html,md}')
+                      .reject { |path| path.match?(%r{\A\./(_site|node_modules|vendor)/}) }
+                      .sort.freeze
+
+  # Screen readers announce the navigation role after the label, so a label
+  # containing "navigation" on a navigation landmark is read twice
+  # ("Primary navigation navigation").
+  # https://github.com/uswds/uswds-site/issues/3059
+  it 'does not repeat "navigation" in aria-labels on navigation landmarks' do
+    offenders = []
+
+    TEMPLATE_FILES.each do |path|
+      File.read(path).scan(/<nav(?![\w-])[^>]*|<[a-z-]+\b[^>]*role=["']navigation["'][^>]*/i) do |tag|
+        label = tag[/aria-label=["']([^"']*)["']/i, 1]
+        offenders << "#{path}: aria-label=\"#{label}\"" if label&.match?(/navigation/i)
+      end
+    end
+
+    expect(offenders).to be_empty,
+      "aria-label repeats the announced navigation role in:\n#{offenders.join("\n")}"
+  end
+end


### PR DESCRIPTION
# Summary

Removed the redundant word "navigation" from aria-labels on the site's navigation landmarks so screen readers announce each landmark once instead of twice (e.g. "Primary navigation navigation").

## Related issue

Closes #3059

## Problem statement

Screen readers announce an element's navigation role after reading its label. Site templates labeled their `<nav>` landmarks with phrases ending in "navigation" ("Primary navigation", "Page navigation", "Next report internal navigation"), so users of screen readers heard the word twice on every page — the exact redundancy [MDN's navigation role guidance](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/navigation_role) says to avoid.

## Solution

Stripped the trailing "navigation" from every site-owned navigation landmark, so what's announced is exactly what each label originally intended, once:

- `_includes/navbar.html` — "Primary navigation" → "Primary" (the site-wide top nav)
- `_includes/next/next-prefooter.html` — "Page navigation" → "Page"
- `_layouts/next-content.html` and `_next/01-summary.md` — "Next report internal navigation" → "Next report internal"

Deliberately left unchanged, with reasons:

- The two `<aside>` labels (`_layouts/pattern.html`, `_layouts/styleguide.html`) — asides announce as "complementary", not "navigation", so there's no redundancy there. The in-page-nav component also builds its own inner `<nav>` labeled from `data-title-text`, not the aside's label.
- Component example previews (like the Footer preview flagged in the issue) render markup from the `@uswds/uswds` package — those labels are covered by uswds/uswds#6301 and should be fixed there.

Also added `spec/navigation_aria_label_spec.rb`, which scans every site-owned `.html` and `.md` file for navigation landmarks whose aria-label still contains "navigation" — it caught the fourth offender in `_next/01-summary.md` during development and guards against the redundancy coming back.

## Testing and review

1. Run `bundle exec rspec` — 11 examples, 0 failures.
2. Run `bundle exec jekyll build` — the built homepage renders `aria-label="Primary"` and the /next/ report pages render the shortened labels; no site-owned nav landmark retains the redundant word.
3. With a screen reader or rotor on any page, the top nav now announces "Primary, navigation" instead of "Primary navigation navigation".