### PR TITLE
USWDS-Site - Research: Add newer research links

### DIFF
--- a/pages/about/research/overview.md
+++ b/pages/about/research/overview.md
@@ -68,10 +68,12 @@ Other more ad hoc research helps us answer specific questions or solve certain p
 Explore some of our past research work:
 
 {:.usa-list}
-- [Usability testing](https://github.com/uswds/uswds/wiki/Usability-research-findings-for-Q3-2023) (August and September 2023): Testing components with visually impaired participants. We also discussed this research at the [October 2023 USWDS monthly call](https://youtu.be/_uNXQpu6Dwg?feature=shared).
+- ["Zebra" component usability testing](https://github.com/uswds/uswds/wiki/%E2%80%9CZebra-batch%E2%80%9D-component-usability-research-findings-Q1-2024) (spring 2024): Testing another batch of components with participants with various disabilities.
+- ["Buffalo" component usability testing](https://github.com/uswds/uswds/wiki/Usability-research-findings-for-Q3-2023) (summer 2023): Testing components with visually impaired participants. We also discussed this research at the [October 2023 USWDS monthly call](https://youtu.be/_uNXQpu6Dwg?feature=shared).
 - [Usability testing day checklist](https://github.com/uswds/uswds/wiki/Usability-testing-day-checklist): Steps to follow on the day of testing. This checklist also prepares researchers to account for assistive technology like screen readers.
-- [Top Tasks](https://digital.gov/event/2023/04/20/uswds-monthly-call-april-2023/) (March 2023): Finding out what matters most to USWDS users.
-- [Transforming the American digital experience]({{ site.baseurl }}/next/) (March 2021): Supporting emergency response efforts related to the COVID-19 and identifying strategies for advancing the design system through agency collaboration.
+- [Disabled states literature review](https://github.com/uswds/uswds/wiki/Disabled-States-Research-Findings-2023) (summer 2023): Finding out whether disabled states should be used and how.
+- [Top Tasks](https://digital.gov/event/2023/04/20/uswds-monthly-call-april-2023/) (spring 2023): Finding out what matters most to USWDS users.
+- [Transforming the American digital experience]({{ site.baseurl }}/next/) (spring 2021): Supporting emergency response efforts related to the COVID-19 and identifying strategies for advancing the design system through agency collaboration.
 
 ## How to participate in research
 


### PR DESCRIPTION
# Summary

Updated the "Key research and research operations" list on the Research page with the newer, team-approved research links, so visitors can find the design system's most recent research.

## Related issue

Closes #2819

## Problem statement

The Research page's list of past research stopped at 2023 and was missing newer work. The USWDS team wrote and approved updated copy in the issue, but it had not been added to the page yet, so visitors saw an out-of-date picture of the team's research.

## Solution

Replaced the old four-item list with the six-item list approved in the issue: it adds the "Zebra" component usability testing (spring 2024) and the disabled states literature review, renames the Q3-2023 testing to "Buffalo," and switches month names to seasons for easier scanning. One small adaptation: the "Transforming the American digital experience" link keeps the page's existing internal-link style instead of a hard-coded absolute URL — it lands in the same place.

## Testing and review

- All seven links in the new list were checked and respond successfully (HTTP 200).
- The site builds cleanly (`bundle exec jekyll build`) and the rendered page shows the new list.
- `bundle exec rspec` passes (10 examples, 0 failures).
- To review: open the About → Research page and compare the "Explore some of our past research work" list against the copy approved in issue #2819.
