### PR TITLE
USWDS-Site - Documentation: Use modern Sass API in compile examples

### DIFF
--- a/pages/documentation/migration-V3.md
+++ b/pages/documentation/migration-V3.md
@@ -170,7 +170,7 @@ Once you've noted the version of USWDS you're currently using, you can update to
 {:.border-top-2px.border-base-lighter.padding-top-1}
 USWDS 3.0 requires the use of [Sass Load Paths](https://sass-lang.com/documentation/at-rules/use#load-paths) to compile properly.
 
-USWDS 3.0 load paths must include a path to the `@uswds/uswds/packages` directory, typically by updating an `IncludePaths` setting to include `node_modules/@uswds/uswds/packages`.
+USWDS 3.0 load paths must include a path to the `@uswds/uswds/packages` directory, typically by updating a `loadPaths` setting to include `node_modules/@uswds/uswds/packages`. (This setting is called `includePaths` in the legacy Sass API.)
 
 Add this load path to your compiler settings, or update any old paths if your compiler already includes them. We have guidance for a few common compiler setups.
 
@@ -221,7 +221,7 @@ or
 + const USWDS = "./node_modules/@uswds/uswds";
       {%- endhighlight %}
     </li>
-    <li><p>Search for references to <code>${uswds}</code> in the <code>includePaths</code> and <code>gulp.src()</code> found in your project’s gulp files. These paths tell the Sass compiler where to look for USWDS source files.</p>
+    <li><p>Search for references to <code>${uswds}</code> in the <code>includePaths</code> and <code>gulp.src()</code> found in your project’s gulp files. These paths tell the Sass compiler where to look for USWDS source files. The latest versions of <code>gulp-sass</code> use the modern Sass API, which renames <code>includePaths</code> to <code>loadPaths</code>.</p>
       <p>Some of our file directories have moved in USWDS 3.0, and it is necessary to point gulp to the correct location inside the <code>@uswds/uswds</code> package. Below are snippets from the standard USWDS Gulp references and their necessary updates. If your code uses <code>USWDS</code> instead of <code>uswds</code>, just keep the case you have.</p>
       {% highlight diff -%}
 // location of theme files:
@@ -241,7 +241,8 @@ or
 + gulp.src(`${uswds}/dist/js/**/**`)
 ...
 // Sass's load paths:
-includePaths: [
+- includePaths: [
++ loadPaths: [
   PROJECT_SASS_SRC,
 - `${uswds}/scss`,
 + `${uswds}`,
@@ -284,12 +285,12 @@ const uswds = require("@uswds/compile");
   </button>
 </h4>
 <div id="m-a8" class="usa-accordion__content site-prose" markdown="1">
-1. Search for references to USWDS in the `includePaths` and `src()` found in your project’s gulp files. These paths tell the Sass compiler where to look for USWDS source files. The `includePaths` section may look like the following:
+1. Search for references to USWDS in the `loadPaths` (called `includePaths` in the legacy Sass API) and `src()` found in your project’s gulp files. These paths tell the Sass compiler where to look for USWDS source files. The `loadPaths` section may look like the following:
 
     ```
     .pipe(
       sass({
-        includePaths: [
+        loadPaths: [
           PROJECT_SASS_SRC,
           `${USWDS}`,
           `${USWDS}/uswds/packages`,
@@ -298,7 +299,7 @@ const uswds = require("@uswds/compile");
     )
     ```
 
-1. Make sure `includePaths` includes `node_modules/@uswds/uswds/packages` in its array.
+1. Make sure `loadPaths` includes `node_modules/@uswds/uswds/packages` in its array.
 1. Update any `src()` references to point to the correct `node_modules/@uswds/uswds` location. Some of the file directories have moved in USWDS 3.0, so confirm that you are accounting for these new locations in your paths.
     - **Fonts:** `@uswds/uswds/dist/fonts`
     - **Images:** `@uswds/uswds/dist/img`
@@ -316,14 +317,14 @@ const uswds = require("@uswds/compile");
   </button>
 </h4>
 <div id="m-a9" class="usa-accordion__content site-prose" markdown="1">
-  In webpack, include `includePaths` within the `sassOptions` of your Sass loader:
+  In webpack, include `loadPaths` within the `sassOptions` of your Sass loader:
 
   ```js
   loader: "sass-loader",
   options: {
     sourceMap: true,
     sassOptions: {
-      includePaths: [
+      loadPaths: [
         "./node_modules/@uswds",
         "./node_modules/@uswds/uswds/packages",
       ],

--- a/pages/ui-components/packages.md
+++ b/pages/ui-components/packages.md
@@ -150,22 +150,22 @@ Using USWDS 3.0 and packages requires compiling your Sass with load paths. Load 
 "./node_modules/@uswds/uswds/packages"
 ```
 
-In a gulpfile, use `includePaths` in your `sass()` function.
+In a gulpfile, use `loadPaths` in your `sass()` function.
 ```js
   sass({
-    includePaths: [
+    loadPaths: [
       "./node_modules/@uswds/uswds/packages",
     ],
   })
 ```
 
-In webpack, include `includePaths` within the sassOptions of your Sass loader:
+In webpack, include `loadPaths` within the sassOptions of your Sass loader:
 
 ```js
 loader: "sass-loader",
 options: {
   sassOptions: {
-    includePaths: [
+    loadPaths: [
       "./node_modules/@uswds/uswds/packages",
     ],
   },


### PR DESCRIPTION
# Summary

Updated the Sass compile examples to the modern Sass API (`loadPaths`), matching how core USWDS now compiles, so developers following the docs don't copy deprecated setup code.

## Related issue

Closes #3055

## Problem statement

The migration guide and the component packages page still taught the legacy `includePaths` Sass setup. Core USWDS moved to the modern API (`loadPaths`) in uswds/uswds#6285, so developers following our docs were being taught a deprecated pattern that newer versions of `gulp-sass` and `sass-loader` no longer use.

## Solution

Renamed `includePaths` to `loadPaths` in the gulp and webpack examples on two pages, following the exact patterns from the merged core PR (uswds/uswds#6285):

- **Migrating to USWDS 3.0** (`pages/documentation/migration-V3.md`): updated the intro prose, the USWDS Gulp diff snippet, the custom gulp workflow example, and the webpack `sassOptions` example.
- **Component packages** (`pages/ui-components/packages.md`): updated the gulpfile and webpack examples.

`includePaths` still appears in a few places on the migration page on purpose — always labeled as the legacy Sass API name — because developers migrating from v2 will literally have `includePaths` in their old gulpfiles and need to know what to search for.

## Testing and review

- The site builds cleanly and the rendered pages show the updated examples.
- `bundle exec rspec` passes (10 examples, 0 failures).
- To review: compare the gulp/webpack snippets on the two pages against `tasks/sass.js` in core USWDS (which uses `loadPaths`).

Note for maintainers: this PR touches lines adjacent to the change in the PR for #2308 (removing an extra webpack path). The changes compose cleanly, but whichever merges second may need a trivial conflict resolution.
