### PR TITLE
USWDS-Site - Components: Add captions to Latest updates tables

### DIFF
--- a/_includes/changelog-table-simple.html
+++ b/_includes/changelog-table-simple.html
@@ -3,6 +3,7 @@
 {% assign col2Title = 'Description' %}
 
 <table class="usa-table--borderless site-table-responsive site-table-simple">
+  <caption class="usa-sr-only">Latest updates for {{ changelog.title }}</caption>
   <thead>
     <tr>
       <th scope="col" class="{{ col1Classes }}">

--- a/_includes/changelog-table.html
+++ b/_includes/changelog-table.html
@@ -10,6 +10,7 @@
 {% assign col5Classes = 'tablet:grid-col-6' %}
 
 <table class="usa-table--borderless site-table-responsive site-table-simple">
+  <caption class="usa-sr-only">Latest updates for {{ changelog.title }}</caption>
   <thead>
     <tr>
       <th scope="col" class="{{ col1Classes }}">{{ col1Title }}</th>


### PR DESCRIPTION
# Summary

Added a screen-reader-only caption to the shared "Latest updates" table templates, giving the changelog table on every component, pattern, and documentation page an accessible name.

## Related issue

Closes #2755

## Problem statement

Accessibility checkers (like ANDI) flag the "Latest updates" table on every component page as a "Data Table with No Name." Screen reader users landing on these tables get no announcement of what the table contains. Because the table comes from shared templates, every component page had the same problem.

## Solution

Added one `<caption class="usa-sr-only">Latest updates for {page title}</caption>` line to each of the two shared includes that render these tables (`_includes/changelog-table.html` and `_includes/changelog-table-simple.html`). Fixing the two templates fixes all pages at once — the caption now renders on 165 built pages.

The caption is screen-reader-only (rather than the visible caption suggested in the issue) because a visible one would duplicate the "Latest updates" heading that already sits directly above the table. The `usa-sr-only` approach matches the site's existing pattern in other includes. The caption text is specific per page (for example, "Latest updates for Accordion").

## Testing and review

- The site builds cleanly; rendered pages (Accordion, Banner, Migration) show the caption as the first child of the table.
- `bundle exec rspec` passes (10 examples, 0 failures).
- To review: run ANDI (or any accessibility checker) on any component page's "Latest updates" table — the "Data Table with No Name" flag is resolved.
