### PR TITLE
USWDS-Site - Migration: Remove extra webpack load path

### DIFF
--- a/pages/documentation/migration-V3.md
+++ b/pages/documentation/migration-V3.md
@@ -324,7 +324,6 @@ const uswds = require("@uswds/compile");
     sourceMap: true,
     sassOptions: {
       includePaths: [
-        "./node_modules/@uswds",
         "./node_modules/@uswds/uswds/packages",
       ],
     },


### PR DESCRIPTION
# Summary

Removed an extra, unneeded load path from the webpack example on the Migrating to USWDS 3.0 page, so it matches every other official webpack example.

## Related issue

Closes #2308

## Problem statement

The webpack example on the migration page listed two load paths: `"./node_modules/@uswds"` and `"./node_modules/@uswds/uswds/packages"`. The uswds README, the component packages page, and even the migration guide's own guidance one paragraph below all say only the packages path is needed. The contradiction left developers unsure which setup is correct.

## Solution

Deleted the extra `"./node_modules/@uswds",` line — a one-line change. The example now matches the three other official examples and the guide's own instructions.

## Testing and review

- The site builds cleanly and the rendered migration page shows the single-path example.
- `bundle exec rspec` passes (10 examples, 0 failures).
- To review: compare the webpack snippet in the "Migrating to USWDS 3.0" page against the webpack example on the component packages page — they now agree.

Note for maintainers: this PR touches lines adjacent to the change in the PR for #3055 (modern Sass API naming). The changes compose cleanly, but whichever merges second may need a trivial conflict resolution.
