### PR TITLE
USWDS-Site - Alert: Add semantic heading guidance

### DIFF
--- a/_components/alert/guidance/accessibility.md
+++ b/_components/alert/guidance/accessibility.md
@@ -1,4 +1,5 @@
 - **Don’t visually hide alert messages and then make them visible when they are needed.** Users of older assistive technologies may still be able to perceive the alert messages even if they are not currently applicable.
+- **Use semantic headings.** While our examples use an `<h4>` in the alert heading, use the appropriate heading level based on your page’s structure. As long as your heading uses the class name `usa-alert__heading`, the font size will always remain the same size as our example, whether it is an `<h1>` or an `<h6>`.
 - **Use the proper ARIA role.** The ARIA `role` attribute can notify assistive technologies of time-sensitive and important messages. To elevate the importance of the alert, choose the appropriate `role` from the [ARIA roles table](#alert-aria-roles) and add it to the `.usa-alert` element.
 
 {% assign col1Title = 'Attribute' %}

--- a/_data/changelogs/component-alert.yml
+++ b/_data/changelogs/component-alert.yml
@@ -5,7 +5,7 @@ items:
   - date: 2026-07-16
     summary: Added guidance on using semantic heading levels in the alert heading.
     affectsGuidance: true
-    githubPr:
+    githubPr: 3246
     githubRepo: uswds-site
   - date: 2025-01-14
     summary: Added WCAG compliance tag and accessibility test status section.

--- a/_data/changelogs/component-alert.yml
+++ b/_data/changelogs/component-alert.yml
@@ -2,6 +2,11 @@ title: Alert
 type: component
 changelogURL:
 items:
+  - date: 2026-07-16
+    summary: Added guidance on using semantic heading levels in the alert heading.
+    affectsGuidance: true
+    githubPr:
+    githubRepo: uswds-site
   - date: 2025-01-14
     summary: Added WCAG compliance tag and accessibility test status section.
     affectsGuidance: true


### PR DESCRIPTION
# Summary

Added accessibility guidance to the Alert component clarifying that any semantic heading level (h1–h6) can be used in an alert — not just the h4 shown in the examples.

## Related issue

Closes #2086

## Problem statement

The Alert examples all use an `<h4>` for the alert heading, and nothing on the page said this was just an example. Implementers could reasonably conclude the h4 is required, leading them to break their page's heading order — a real accessibility problem for screen reader users who navigate by headings.

## Solution

Added one bullet to the Alert component's accessibility guidance, using the wording drafted in the issue: use the heading level appropriate to your page's structure; as long as the heading uses the `usa-alert__heading` class, it will look the same whether it's an h1 or an h6. Also added a changelog entry to the Alert component's "Latest updates" (dated with this change; the PR number field can be backfilled with this PR's number).

## Testing and review

- The site builds cleanly; the rendered Alert page shows the new bullet between the existing accessibility bullets, and the new changelog row renders at the top of "Latest updates."
- `bundle exec rspec` passes (10 examples, 0 failures).
- To review: check the Accessibility section of the Alert component page.
