### PR TITLE
USWDS-Site - Banner: Add web component accessibility testing guidance

### DIFF
--- a/_data/accessibility-tests/banner.yml
+++ b/_data/accessibility-tests/banner.yml
@@ -83,6 +83,16 @@ test_items:
     test_type: keyboard
     version_tested: 3.8.0
     wcag_criterion: 2.4.7
+  - summary: In the web component variant, keyboard focus moves into and out of the shadow DOM.
+    summary_additional: |
+      When you navigate to the web component variant with a keyboard,
+      you can use `tab` to reach the "Here's how you know" button inside the component's shadow DOM,
+      use `enter` and `spacebar` to open and close the banner,
+      and use `tab` to move out of the banner without getting stuck.
+    test_status: conditional
+    status_details: Browser and assistive technology combinations can handle shadow DOM content differently.
+    test_type: keyboard
+    wcag_criterion: 2.1.1
 # Screen reader tests
   - summary: Screen reader announces button.
     summary_additional: |
@@ -119,3 +129,29 @@ test_items:
     test_type: screen_reader
     version_tested: 3.8.0
     wcag_criterion: 1.1.1
+  - summary: In the web component variant, screen readers announce banner content inside the shadow DOM.
+    summary_additional: |
+      When you use a screen reader with the web component variant,
+      the shadow DOM doesn't change what you hear.
+      The screen reader still announces the banner's "Official website of the United States government" label,
+      the "Here's how you know" button with its collapsed and expanded states,
+      and the banner content once you expand it.
+    test_status: conditional
+    status_details: Browser and assistive technology combinations can handle shadow DOM content differently.
+    test_type: screen_reader
+    wcag_criterion: 4.1.2
+  - summary: In the web component variant, screen readers announce customized slot content.
+    summary_additional: |
+      When you customize the banner text with slots (for example, `banner-action`,
+      which also sets the button text), a screen reader announces your custom content
+      in place of the default text.
+    test_status: conditional
+    test_type: screen_reader
+    wcag_criterion: 4.1.2
+  - summary: In the web component variant, screen readers read the banner in the correct language.
+    summary_additional: |
+      When you set `lang="es"` on the web component variant,
+      a screen reader reads the banner text in Spanish.
+    test_status: conditional
+    test_type: screen_reader
+    wcag_criterion: 3.1.2

--- a/_data/changelogs/component-banner-accessibility.yml
+++ b/_data/changelogs/component-banner-accessibility.yml
@@ -2,6 +2,12 @@ title: Banner accessibility tests
 type: component
 changelogURL:
 items:
+  - date: 2026-07-16
+    summary: Added web component variant tests.
+    summaryAdditional: New conditional tests cover keyboard and screen reader behavior for the web component variant's shadow DOM, custom slot content, and language support.
+    affectsGuidance: true
+    githubPr:
+    githubRepo: uswds-site
   - date: 2024-06-07
     summary: Added accessibility tests page.
     summaryAdditional:

--- a/_data/changelogs/component-banner-accessibility.yml
+++ b/_data/changelogs/component-banner-accessibility.yml
@@ -6,7 +6,7 @@ items:
     summary: Added web component variant tests.
     summaryAdditional: New conditional tests cover keyboard and screen reader behavior for the web component variant's shadow DOM, custom slot content, and language support.
     affectsGuidance: true
-    githubPr:
+    githubPr: 3248
     githubRepo: uswds-site
   - date: 2024-06-07
     summary: Added accessibility tests page.


### PR DESCRIPTION
# Summary

Added four accessibility test items covering the web component variant of the Banner — keyboard focus, screen reader behavior with the shadow DOM, customized slot content, and language support.

## Related issue

Closes #3190

## Problem statement

The Banner now ships a web-component variant, but the Banner accessibility tests page had no guidance at all about testing it. Teams adopting the web component had no checklist for the parts that are genuinely different: shadow DOM behavior with screen readers and keyboards, customized slot content, and the `lang` attribute.

## Solution

Added four checklist items to the Banner accessibility tests data (`_data/accessibility-tests/banner.yml`):

1. **Keyboard** — focus moves into and out of the shadow DOM without getting stuck (WCAG 2.1.1).
2. **Screen reader** — banner content inside the shadow DOM is announced (WCAG 4.1.2).
3. **Screen reader** — customized slot content is announced in place of default text (WCAG 4.1.2).
4. **Screen reader** — with `lang="es"`, the banner reads in Spanish (WCAG 3.1.2).

Also added a changelog entry to the Banner accessibility tests page (the PR number field can be backfilled with this PR's number).

**An honest note for reviewers:** all four items are marked **conditional**, with no "last tested" version, because the team's own screen-reader testing of the web component (uswds/uswds-elements#154) is still open. The items describe expected behavior derived from the component's actual source code and the site's existing test-item patterns — no pass results were invented. When the team completes real VoiceOver/NVDA testing, these items can be upgraded to pass with a tested version.

## Testing and review

- The site builds cleanly; the rendered Banner accessibility tests page shows all four new items and the updated summary counts (18 total, 6 conditional).
- `bundle exec rspec` passes (10 examples, 0 failures).
- To review: check the new items against the web component's source (`usa-banner` in `@uswds/uswds`) and flag any wording the team would like adjusted before real screen-reader results exist.
