### PR TITLE
USWDS-Site - Site header: Name banner landmarks, drop redundant role

### DIFF
--- a/_data/identifier.yml
+++ b/_data/identifier.yml
@@ -1,4 +1,4 @@
-ariaLabel: Agency identifier,,,,,,
+ariaLabel: Agency identifier
 logos:
   - path: img/gsa-logo.svg
     alt: GSA Logo

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -1,9 +1,9 @@
 <section
   class="usa-banner site-banner"
-  aria-label="Official website of the United States government,,,,,,"
+  aria-label="Official website of the United States government"
 >
   <div class="usa-accordion">
-    <header class="usa-banner__header">
+    <header class="usa-banner__header" aria-label="U.S. Government">
       <div class="usa-banner__inner">
         <div class="grid-col-auto">
           <img

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,6 +1,6 @@
 <a class="usa-skipnav" href="#main-content">Skip to main content</a>
 {% include banner.html %}
-<header class="usa-header usa-header--extended site-header site-header--dark" role="banner">
+<header class="usa-header usa-header--extended site-header site-header--dark" aria-label="{{ site.title }}">
   <div class="usa-navbar site-header__navbar">
     <div class="usa-logo site-logo" id="logo">
       <em class="usa-logo__text site-logo__text">


### PR DESCRIPTION
# Summary

Cleaned up the site's banner landmarks for screen reader users: removed stray commas from aria-labels, dropped a redundant `role="banner"`, and gave the government banner and site header distinct accessible names.

## Related issue

Closes #2226

## Problem statement

Screen reader users hit two problems in the site's chrome: stray commas inside the banner and identifier aria-labels made VoiceOver stutter through the landmark names, and the site header carried a redundant `role="banner"` (core USWDS dropped that role back in v2.2.0), leaving multiple unnamed banner landmarks that were hard to tell apart.

## Solution

Three small edits, following the fix maintainers spelled out in the issue comments:

- `_includes/banner.html` — removed the six stray commas from the banner section's aria-label, and added `aria-label="U.S. Government"` to the banner header (the exact markup suggested in the comments).
- `_includes/navbar.html` — replaced `role="banner"` on the site header with an aria-label naming it after the website.
- `_data/identifier.yml` — removed the stray commas from the identifier's aria-label.

One thing intentionally left alone: the identifier *component preview examples* on the Identifier component page still show commas — that markup ships from the core `@uswds/uswds` package, not this repo, and maintainers asked for upstream changes to be tracked separately.

## Testing and review

- The site builds cleanly; the rendered pages show clean aria-labels, no `role="banner"` anywhere in the site chrome, and distinctly named banner and header landmarks.
- `bundle exec rspec` passes (10 examples, 0 failures).
- To review: open any page with VoiceOver or NVDA and cycle through landmarks — the banner and header now announce cleanly with distinct names.
