### PR TITLE
USWDS-Site - Getting started: Clarify path settings prefix

### DIFF
--- a/pages/documentation/getting-started-developers/phase-two.md
+++ b/pages/documentation/getting-started-developers/phase-two.md
@@ -202,6 +202,9 @@ Setting | Default values - Version 2.x | Default values - Version 3.0 | Descript
 
 </div>
 
+{: .site-note }
+**Note:** When you reference these settings in your `gulpfile.js`, add a prefix that matches the `const` variable you declared in [Step 3](#step-3-import-the-uswds-compile-package). For example, because this guide imports `@uswds/compile` into a constant named `uswds`, the code samples on this page reference a setting like `paths.dist.css` as `uswds.paths.dist.css`.
+
 **paths.src:** The `paths.src` settings tell Gulp where to _find_ USWDS source files. The default values point to directories in the `uswds` node module that you installed during [Phase 1 of this guide]({{ site.baseurl }}/documentation/getting-started/developers/phase-one-install/).
 
 Note that the `paths.src` defaults are different for USWDS 2 and USWDS 3. `uswds-compile` chooses which set of defaults to use based on the USWDS version  defined in `settings.version` in [step 4](#step-4-set-uswds-version).


### PR DESCRIPTION
# Summary

Added a clarifying note to the path settings table on the "Phase 2: Compile" page explaining when to add the `uswds.` prefix, so the table and the code samples no longer appear to contradict each other.

## Related issue

Closes #2120

## Problem statement

The path settings table lists names like `paths.dist.img`, but the code samples on the same page write `uswds.paths.dist.img`. Nothing explained the difference, so developers new to the setup couldn't tell which form to type.

## Solution

Added a short note directly after the settings table: the prefix comes from the `const` variable declared in Step 3 (`const uswds = require("@uswds/compile")`), so a setting like `paths.dist.css` is referenced as `uswds.paths.dist.css` in your gulpfile. The note links back to Step 3 and uses the page's existing note styling.

This was the smaller of the two fixes the issue suggested. Renaming the table entries instead would have diverged from the `@uswds/compile` README, which uses the unprefixed names in its own settings table.

## Testing and review

- The site builds cleanly; the rendered page shows the note styled consistently with the page's other notes, with a working link to Step 3.
- `bundle exec rspec` passes (10 examples, 0 failures).
- To review: read the note under the path settings table on Getting started → Developers → Phase 2: Compile.
