### PR TITLE
USWDS-site: Update changelog with Input mask as "use with caution"

### DIFF
--- a/_data/changelogs/docs-component-status.yml
+++ b/_data/changelogs/docs-component-status.yml
@@ -4,14 +4,10 @@ changelogURL:
 items:
   - date: 2026-07-07
     summary: Changed Input mask to "use with caution."
+    affectsAccessibility: true
     affectsGuidance: true
     githubPr: 3232
     githubRepo: uswds-site
-
-title: Component status
-type: documentation
-changelogURL:
-items:
   - date: 2024-02-15
     summary: Added component status page.
     affectsGuidance: true

--- a/_data/changelogs/docs-component-status.yml
+++ b/_data/changelogs/docs-component-status.yml
@@ -2,6 +2,16 @@ title: Component status
 type: documentation
 changelogURL:
 items:
+  - date: 2026-07-07
+    summary: Changed Input mask to "use with caution."
+    affectsGuidance: true
+    githubPr: 3232
+    githubRepo: uswds-site
+
+title: Component status
+type: documentation
+changelogURL:
+items:
   - date: 2024-02-15
     summary: Added component status page.
     affectsGuidance: true


### PR DESCRIPTION
# Summary

Add changelog entry to reflect uswds/uswds#3232, noting that Input mask is now in the status "use with caution"

## Related PR

uswds/uswds#3232

## Preview link

[Input mask changelog →](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/ap-component-status-changelog-2026-07-16/components/status/)