### PR TITLE
Add USWDS init script to the site

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -79,6 +79,35 @@
 
 <!-- USWDS INIT
 ================================================== -->
+<script>
+  /**
+   * This script block contains the contents of the uswds-init.js script.
+   * It's inlined because it's necessary for the first paint of the banner,
+   * and we want to avoid a round-trip to the server.
+   */
+  (function uswdsInit() {
+    "use strict";
+
+    const loadingClass = "usa-js-loading";
+    let fallback;
+
+    document.documentElement.classList.add(loadingClass);
+    function revertClass() {
+      document.documentElement.classList.remove(loadingClass);
+    }
+
+    fallback = setTimeout(revertClass, 8000);
+
+    function verifyLoaded() {
+      if (window.uswdsPresent) {
+        clearTimeout(fallback);
+        revertClass();
+        window.removeEventListener("load", verifyLoaded, true);
+      }
+    }
+
+    window.addEventListener("load", verifyLoaded, true);
+  })();
+</script>
 <script src="{{ site.baseurl }}/assets/uswds/components/usa-banner.js.mjs" type="module"></script>
 <link rel="preload" href="{{ site.baseurl }}/assets/js/vendor/uswds.min.js" as="script">
-<script src="{{ site.baseurl }}/assets/js/vendor/" type="text/javascript"></script>


### PR DESCRIPTION
## Summary

Add `uswds-init` script to the site. This inlines the script because it's small and needed for first paint. Previously, the script was missing and causing the banner to briefly show as expanded before the JS executes.

## Preview link

Preview link: https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/task/add-uswds-init/

## Problem statement

The `uswds-init` script was missing and causing the banner to briefly show as expanded and abuptly collapse to it's expected state.

## Solution

Inline the `uswds-init` script in the `<head>` of the site.

## Testing
1. open the preview link and verify that the banner shows as collapsed. If you're working on a fast computer, it's helpful to [throttle your CPU to 4x or 6x slowdown using Chrome Devtools](https://www.debugbear.com/blog/cpu-throttling-in-chrome-devtools-and-lighthouse) to see behavior on the live site and verify that it does not happen on the preview link