### PR TITLE
USWDS-Site - Styles: Match table background to the site background

### DIFF
--- a/css/settings/_uswds-theme-components.scss
+++ b/css/settings/_uswds-theme-components.scss
@@ -96,3 +96,6 @@ $theme-search-min-width: 27ch;
 // Sidenav
 $theme-sidenav-current-border-width: 0.5;
 $theme-sidenav-font-family: "ui";
+
+// Table
+$theme-table-background-color: $site-background-color;


### PR DESCRIPTION
# Summary

Borderless table headers no longer render as white boxes on the site's soft gray background — tables now blend with the page.

## Related issue

Closes #2748

## Problem statement

The site's page background is gray-1 (`#fcfcfc`), but borderless table headers kept USWDS's default white table background, so every borderless table header showed up as a white strip floating on the gray page.

## Solution

Added one theme setting, `$theme-table-background-color: $site-background-color;`, to `css/settings/_uswds-theme-components.scss` — the same pattern the file already uses for the in-page nav background. This is the fix the issue itself proposed.

One thing reviewers should know: the token also drives plain table cells and stacked-variant cells, so those shift from white to gray-1 too (visually near-imperceptible, and it's what makes tables blend with the page). Striped rows, sorted-state colors, and header-variant backgrounds use separate tokens and are unchanged, and no text-contrast rules changed.

## Testing and review

- Compiled CSS verified: `.usa-table--borderless th` went from `background-color:#fff` to `#fcfcfc`; a full before/after diff of the compiled stylesheet showed only table background colors changed.
- Sass lint passes; `bundle exec rspec` passes (10 examples, 0 failures).
- To review: look at the borderless tables on pages like Settings, Migration, or Packages — headers should match the page background instead of standing out white.
