### PR TITLE
USWDS-Site - Text input: Recategorize the labels and instructions accessibility test

### DIFF
--- a/_data/accessibility-tests/text-input.yml
+++ b/_data/accessibility-tests/text-input.yml
@@ -23,6 +23,12 @@ test_items:
     test_type: general
     version_tested: 3.8.0
     wcag_criterion: 1.4.1
+  - summary: Visible labels or instructions are present.
+    summary_additional: There are clearly visible instructions or labels to identify what type of data is expected in the field.
+    test_status: pass
+    test_type: general
+    version_tested: 3.8.0
+    wcag_criterion: 3.3.2
 # Zoom/screen magnification tests
   - summary: Text inputs remain functional when screen is magnified.
     summary_additional: When you zoom to 200%, the text area remains visible and functional.
@@ -68,4 +74,4 @@ test_items:
     test_status: pass
     test_type: screen_reader
     version_tested: 3.8.0
-    wcag_criterion: 3.3.2
+    wcag_criterion: 1.3.1

--- a/_data/changelogs/component-text-input-accessibility.yml
+++ b/_data/changelogs/component-text-input-accessibility.yml
@@ -1,6 +1,10 @@
 title: Text input accessibility tests
 type: component
 items:
+  - date: 2026-07-18
+    summary: Recategorized the screen reader labels and instructions test from WCAG 3.3.2 to WCAG 1.3.1 and added a general test for visible labels or instructions under WCAG 3.3.2.
+    affectsGuidance: true
+    githubRepo: uswds-site
   - date: 2024-06-19
     summary: Added accessibility tests page.
     affectsGuidance: true

--- a/_data/changelogs/component-text-input-accessibility.yml
+++ b/_data/changelogs/component-text-input-accessibility.yml
@@ -4,6 +4,7 @@ items:
   - date: 2026-07-18
     summary: Recategorized the screen reader labels and instructions test from WCAG 3.3.2 to WCAG 1.3.1 and added a general test for visible labels or instructions under WCAG 3.3.2.
     affectsGuidance: true
+    githubPr: 3255
     githubRepo: uswds-site
   - date: 2024-06-19
     summary: Added accessibility tests page.


### PR DESCRIPTION
# Summary

Recategorized a text input accessibility test under the correct WCAG criterion and added the missing visible-labels test, using the wording the accessibility audit supplied.

## Related issue

Closes #2845

## Problem statement

On the Text input accessibility tests page, the screen reader test "Screen reader announces field labels and instructions" was filed under WCAG 3.3.2 (Labels or Instructions). But 3.3.2 covers whether visible labels and instructions *exist* — what a screen reader announces is programmatic markup, which is WCAG 1.3.1 (Info and Relationships). This was an accessibility audit finding, and the audit spelled out the exact fix.

## Solution

Two changes to `_data/accessibility-tests/text-input.yml`, following the issue's instructions exactly:

- Moved the existing screen reader test from 3.3.2 to 1.3.1, keeping its wording unchanged (the issue: "Keep the same wording, it works for this success criteria").
- Added a new general test under 3.3.2 with the issue's wording: "Visible labels or instructions are present." It's marked pass — verified directly by checking that both text input examples on the component page show visible labels.

Also added a changelog entry to the Text input accessibility tests page. The new test's "version tested" follows the file's existing convention (3.8.0, matching all sibling entries); the team may prefer the currently-bundled version instead — happy to adjust.

## Testing and review

- The rendered page now shows 10 tests (was 9), with the screen reader test under "1.3.1 Info and relationships" and the new test under "3.3.2 Labels or instructions"; summary counts update consistently.
- `bundle exec rspec` passes (10 examples, 0 failures).
- The changelog entry's PR number field will be filled in with this PR's number.
- To review: open Components → Text input → Accessibility tests and check the two moved/added entries against the issue.
