### PR TITLE
USWDS-Site - How to use USWDS: Update the Designers card to Figma and Sketch

### DIFF
--- a/_data/changelogs/docs-how-to-use-uswds.yml
+++ b/_data/changelogs/docs-how-to-use-uswds.yml
@@ -2,6 +2,10 @@ title: How to use USWDS
 type: documentation
 changelogURL:
 items:
+  - date: 2026-07-18
+    summary: Updated the Designers card to reference Figma and Sketch.
+    summaryAdditional: Removed mention of Adobe XD since we've stopped maintaining our Adobe XD assets.
+    githubRepo: uswds-site
   - date: 2022-01-27
     summary: Brought in "Before getting started" content from "Getting started for developers".
     summaryAdditional:

--- a/_data/changelogs/docs-how-to-use-uswds.yml
+++ b/_data/changelogs/docs-how-to-use-uswds.yml
@@ -5,6 +5,7 @@ items:
   - date: 2026-07-18
     summary: Updated the Designers card to reference Figma and Sketch.
     summaryAdditional: Removed mention of Adobe XD since we've stopped maintaining our Adobe XD assets.
+    githubPr: 3257
     githubRepo: uswds-site
   - date: 2022-01-27
     summary: Brought in "Before getting started" content from "Getting started for developers".

--- a/_data/changelogs/docs-how-to-use-uswds.yml
+++ b/_data/changelogs/docs-how-to-use-uswds.yml
@@ -4,9 +4,14 @@ changelogURL:
 items:
   - date: 2026-07-18
     summary: Updated the Designers card to reference Figma and Sketch.
-    summaryAdditional: Removed mention of Adobe XD since we've stopped maintaining our Adobe XD assets.
+    summaryAdditional: Added Figma to the mention of Sketch to reflect the [Getting started for designers page](https://designsystem.digital.gov/documentation/getting-started-for-designers/#uswds-for-designers-2).
     githubPr: 3257
     githubRepo: uswds-site
+  - date: 2026-07-18
+    summary: Updated the Designers card to remove Adobe XD.
+    summaryAdditional: Removed Adobe XD since XD is no longer supported by Adobe, and therefore USWDS no longer maintains the kit for it.
+    githubPr: 3257
+    githubRepo: uswds-site  
   - date: 2022-01-27
     summary: Brought in "Before getting started" content from "Getting started for developers".
     summaryAdditional:

--- a/_data/changelogs/docs-how-to-use-uswds.yml
+++ b/_data/changelogs/docs-how-to-use-uswds.yml
@@ -2,12 +2,12 @@ title: How to use USWDS
 type: documentation
 changelogURL:
 items:
-  - date: 2026-07-18
+  - date: 2026-08-03
     summary: Updated the Designers card to reference Figma and Sketch.
     summaryAdditional: Added Figma to the mention of Sketch to reflect the [Getting started for designers page](https://designsystem.digital.gov/documentation/getting-started-for-designers/#uswds-for-designers-2).
     githubPr: 3257
     githubRepo: uswds-site
-  - date: 2026-07-18
+  - date: 2026-08-03
     summary: Updated the Designers card to remove Adobe XD.
     summaryAdditional: Removed Adobe XD since XD is no longer supported by Adobe, and therefore USWDS no longer maintains the kit for it.
     githubPr: 3257

--- a/pages/documentation/overview.md
+++ b/pages/documentation/overview.md
@@ -30,7 +30,7 @@ changelog:
       <h3 class="font-lang-lg margin-0">
         <a href="{{ site.baseurl }}/documentation/getting-started-for-designers/" class="text-no-underline text-primary hover:text-underline block-link">Designers</a>
       </h3>
-      <p class="margin-top-1">Create wireframes and prototypes in Sketch or Adobe XD.</p>
+      <p class="margin-top-1">Create wireframes and prototypes in Figma or Sketch.</p>
     </div>
   </div>
   <div class="tablet:grid-col margin-top-2 tablet:margin-top-0 display-flex flex-align-stretch">


### PR DESCRIPTION
# Summary

Updated the Designers card on the "How to use USWDS" page to say Figma and Sketch instead of Sketch and Adobe XD.

## Related issue

Closes #2637

## Problem statement

The team stopped maintaining Adobe XD design assets, and the designers page already carries a note saying assets are maintained in Figma and Sketch. But the Designers card on the "How to use USWDS" overview page still advertised "Create wireframes and prototypes in Sketch or Adobe XD" — the last place on the site still presenting XD as a current option.

## Solution

Changed the card to "Create wireframes and prototypes in Figma or Sketch." (Figma first, matching the order in the maintained-formats note). A full repo sweep confirmed the only remaining Adobe XD mentions are the historical ones that should stay: the designers-page deprecation note itself, past changelog entries, and the old XD asset zip file (removing a hosted download felt like a maintainer decision, so it was left untouched and is flagged here).

Also added a changelog entry to the page's "Latest updates."

## Testing and review

- The rendered page shows the updated card; zero stale Adobe XD mentions remain in reader-facing copy.
- `bundle exec rspec` passes (10 examples, 0 failures).
- The changelog entry's PR number field will be filled in with this PR's number.
- To review: open Documentation → How to use USWDS and check the Designers card.
