### PR TITLE
USWDS-Site - Site header: Remove a broken leftover script tag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -81,4 +81,3 @@
 ================================================== -->
 <script src="{{ site.baseurl }}/assets/uswds/components/usa-banner.js.mjs" type="module"></script>
 <link rel="preload" href="{{ site.baseurl }}/assets/js/vendor/uswds.min.js" as="script">
-<script src="{{ site.baseurl }}/assets/js/vendor/" type="text/javascript"></script>


### PR DESCRIPTION
# Summary

Removed a broken leftover script tag that made every page on the site request a directory as if it were a JavaScript file.

## Related issue

Closes #2168

## Problem statement

The issue reported `uswds.min.js` being loaded twice — once in the head and once in the scripts partial. Digging into the history shows the head copy was never actually removed: a later edit truncated the filename out of the tag instead of deleting it, leaving `<script src=".../assets/js/vendor/" type="text/javascript"></script>` — a script tag pointing at a directory — shipped in the head of every page since.

## Solution

Deleted that one broken line from `_includes/head.html`. The preload hint for `uswds.min.js` in the head and the real script load in the scripts partial stay exactly as they are — they pair correctly (same URL), so the page keeps its performance hint and its single, working script load.

## Testing and review

- Rendered pages verified before and after: the directory-request tag is gone, `uswds.min.js` appears exactly twice (one preload link, one script load) — checked on the homepage and a component page.
- `bundle exec rspec` passes (10 examples, 0 failures).
- To review: view source on any page of the preview build and search for `/assets/js/vendor/"` — no hits.
