### PR TITLE
USWDS-Site - Monthly calls: Shorten the in-page navigation links

### DIFF
--- a/pages/about/monthly-calls.md
+++ b/pages/about/monthly-calls.md
@@ -20,10 +20,10 @@ Register for [upcoming calls on Digital.gov](https://digital.gov/events/). All U
 {% for video in site.data.monthly-calls.videos %}
 
 {:.border-bottom-1px .padding-bottom-1 .border-base-lighter .measure-5}
-## {{ video.date }} {% if video.title %}: {{ video.title }}{% endif %}
+## {{ video.date }}
 
-{% if video.subtitle %}
-**{{ video.subtitle }}**
+{% if video.title %}
+**{{ video.title }}**
 {% endif %}
 
 {{ video.description }}


### PR DESCRIPTION
# Summary

Shortened the in-page navigation links on the Monthly Calls page by replicating the design the USWDS team prototyped on the `dw-mc-titles` branch: date-only headings with the call title as bold text below.

## Related issue

Closes #3077

## Problem statement

Each Monthly Calls section heading combined the date and the full call title (for example, "December 2024 : USWDS and Federal Website Standards"). The in-page navigation builds its links from those headings, so the nav was a column of very long links that were hard to scan.

## Solution

Replicated @thisisdano's prototype from the `dw-mc-titles` branch — the template is now byte-identical to it — per @amyleadem's comment that "We should use this design as a starting point." Headings become just the date ("December 2024"), and the call title renders as bold text directly below the heading.

Two things inherent to the prototype's design, flagged for reviewers rather than hidden:

- The bold line below the heading now shows the call **title** where the **subtitle** used to render, so subtitles (present on most entries) no longer appear on the page. This matches the prototype exactly, which has no subtitle reference.
- Heading anchor IDs shorten (for example `#december-2024--uswds-and-federal-website-standards` → `#december-2024`), so any external deep links to old anchors won't land on the heading anymore.

## Testing and review

- Rendered page verified: date-only headings, bold titles below, short in-page nav link text; also verified an entry without a title renders cleanly (no stray colon or empty bold line).
- `bundle exec rspec` passes (10 examples, 0 failures).
- To review: open About → Monthly calls in the preview and compare the in-page nav against the prototype branch.
