### PR TITLE
USWDS-Site - Sample contract language: Add the sample QASP section

### DIFF
--- a/_data/changelogs/docs-sample-contract-language.yml
+++ b/_data/changelogs/docs-sample-contract-language.yml
@@ -5,6 +5,7 @@ items:
   - date: 2026-07-18
     summary: Added guidance on including a quality assessment surveillance plan (QASP).
     affectsGuidance: true
+    githubPr: 3261
     githubRepo: uswds-site
   - date: 2024-04-09
     summary: Updated Federal Web Council representative link.

--- a/_data/changelogs/docs-sample-contract-language.yml
+++ b/_data/changelogs/docs-sample-contract-language.yml
@@ -2,6 +2,10 @@ title: Sample contract language
 type: documentation
 changelogURL:
 items:
+  - date: 2026-07-18
+    summary: Added guidance on including a quality assessment surveillance plan (QASP).
+    affectsGuidance: true
+    githubRepo: uswds-site
   - date: 2024-04-09
     summary: Updated Federal Web Council representative link.
     affectsGuidance: true

--- a/pages/documentation/sample-contract-language.md
+++ b/pages/documentation/sample-contract-language.md
@@ -230,6 +230,9 @@ For the evaluation scenario, you can use it as an “all or nothing” factor (m
 
 Provide as many user scenarios as needed to describe your requirements. A user scenario is a method for telling a story about a user’s interaction with your product, service, or website, focusing on the what, how, and why. Check out the [user scenarios](https://guides.18f.gov/methods/decide/user-scenarios/) card in 18F Methods for more information on how to write scenarios.
 
+## Include a surveillance plan to assess quality
+Per the best practice to “require demos, not memos,” incorporate a quality assessment surveillance plan (QASP) into your solicitation. See the [sample QASP](https://guides.18f.org/derisking-government-tech/resources/quality-indicators/) in 18F's [De-risking Guide](https://guides.18f.org/derisking-government-tech/) for more details on deliverables, performance standards, acceptable quality levels, and methods of assessment to include in the plan.
+
 ## Accessibility requirements
 Accessibility is not only the law, it’s also fundamental to a great digital experience. To ensure your technology is usable by all, regardless of ability, address accessibility and other requirements up-front in all your IT-related contracts and purchases.
 


### PR DESCRIPTION
# Summary

Added the sample QASP (quality assessment surveillance plan) section to the Sample contract language page, using the copy supplied in the issue.

## Related issue

Closes #1241

## Problem statement

The issue (accepted by the team, with the copy already written) asks the Sample contract language page to cover including a surveillance plan in solicitations — "require demos, not memos." The page had no mention of a QASP or surveillance plan anywhere.

## Solution

Inserted the issue's section verbatim — "Include a surveillance plan to assess quality" — directly above "Accessibility requirements," exactly where the issue asked.

**One substitution reviewers should weigh in on:** the issue's links point at `derisking-guide.18f.gov`, which no longer resolves — 18F's guide domains went dark after March 2025. The links in this PR target the live community rehost maintained by 18F alumni (`guides.18f.org`), both verified working, since that's currently the only live home of the De-risking Guide and its sample QASP. If the team prefers an Internet Archive snapshot of the original government URL instead, that's a two-line swap.

Also worth noting (untouched, out of scope): the page's existing Resources section still links to the same dead 18F domains — a good candidate for a follow-up issue.

A changelog entry is included in the page's "Latest updates."

## Testing and review

- Rendered page verified: the new section sits above Accessibility requirements with both links present; both link targets return HTTP 200.
- `bundle exec rspec` passes (10 examples, 0 failures).
- The changelog entry's PR number field will be filled in with this PR's number.
- To review: open Documentation → Sample contract language and read the new section against the issue's copy.
