### PR TITLE
USWDS-Site - Font size and family: Add a note linking to the font size tokens

### DIFF
--- a/_data/changelogs/utilities-font-size.yml
+++ b/_data/changelogs/utilities-font-size.yml
@@ -2,6 +2,18 @@ title: Font size and family
 type: utility
 changelogURL:
 items:
+  - date: 2026-07-18
+    summary: Added a note directing readers to the font size tokens page to find the actual size of each font size token.
+    summaryAdditional:
+    isBreaking:
+    affectsAccessibility:
+    affectsAssets:
+    affectsGuidance: true
+    affectsJavascript:
+    affectsMarkup:
+    affectsStyles:
+    githubRepo: uswds-site
+    versionUswds:
   - date: 2023-08-23
     summary: Fixed a bug that caused `font-[family]-[size]` utility classes to not generate font-family rules.
     summaryAdditional:

--- a/_data/changelogs/utilities-font-size.yml
+++ b/_data/changelogs/utilities-font-size.yml
@@ -12,6 +12,7 @@ items:
     affectsJavascript:
     affectsMarkup:
     affectsStyles:
+    githubPr: 3262
     githubRepo: uswds-site
     versionUswds:
   - date: 2023-08-23

--- a/_utilities/font-size-and-family.md
+++ b/_utilities/font-size-and-family.md
@@ -59,6 +59,8 @@ utilities:
     %}
     <section class="utility-examples">
 
+      <p class="utility-note"><strong>Note:</strong> Font size and family utilities are built from USWDS font size tokens. To see the actual size each font size token outputs in each typeface, visit the <strong><a href="{{ site.baseurl }}/design-tokens/typesetting/font-size/">font size tokens</a></strong> page.</p>
+
       <h4 class="utility-examples-title margin-bottom-2">Type-based size and family utilities</h4>
 
       <p class="utility-note"><strong>Note:</strong> You can modify both the default theme sizes and default typefaces in your project settings. Use valid system tokens following the guidance in the <strong><a href="{{ site.baseurl }}/design-tokens/typesetting/">Typesetting</a></strong> section of USWDS <a href="{{ site.baseurl }}/design-tokens/">design tokens</a> documentation.</p>


### PR DESCRIPTION
# Summary

Added a note to the top of the Font size and family utility page pointing readers to the font size tokens page, where the actual size of every token is listed.

## Related issue

Closes #824

## Problem statement

A reader trying to find the actual font sizes available (for Public Sans) couldn't work them out from the Font size and family utility page — the page shows the utility classes but never points to where the real sizes live. A maintainer suggested the fix in the issue: the page "just needs a better note and link to the font size token page."

## Solution

Added a short note at the top of the utility examples — styled exactly like the page's existing notes — saying the utilities are built from USWDS font size tokens and linking "font size tokens" to the token reference page, where each token's output size in each typeface is listed. That's the page the original reporter eventually found the answer on.

A changelog entry is included in the page's "Latest updates."

## Testing and review

- Rendered page verified: the note appears at the top of the examples with a working link to the font size tokens page.
- `bundle exec rspec` passes (10 examples, 0 failures).
- The changelog entry's PR number field will be filled in with this PR's number.
- To review: open Utilities → Font size and family and check the first note.
