### PR TITLE
USWDS-Site - Navigation: Point sidenav Latest updates links at their own page

### DIFF
--- a/_includes/nav/link-item.html
+++ b/_includes/nav/link-item.html
@@ -6,5 +6,11 @@
 {% else %}
   {% assign _href = link[_href_key] %}
 {% endif %}
+{% if include.owner and include.owner.url != page.url %}
+  {% assign _first_char = _href | slice: 0 %}
+  {% if _first_char == '#' %}
+    {% assign _href = include.owner.url | relative_url | append: _href %}
+  {% endif %}
+{% endif %}
 {% assign _text_key = include.text_key | default: 'text' %}
 <a href="{{ _href }}"{% if _href == page.permalink or _href == page.url %} class="usa-current"{% endif %}>{{ link[_text_key] | smartify }}</a>

--- a/_includes/nav/list.html
+++ b/_includes/nav/list.html
@@ -26,6 +26,7 @@
         subnav_class=include.subnav_class
         href_key=include.href_key
         text_key=include.text_key
+        owner=include.owner
       %}
     {% endif %}
   </li>

--- a/_includes/nav/page-item.html
+++ b/_includes/nav/page-item.html
@@ -24,6 +24,7 @@
       links=_links
       text_key=_text_key
       href_key=_href_key
+      owner=include.page
     %}</ul>
     {% endif %}
   {% endunless %}

--- a/pages/about/security.md
+++ b/pages/about/security.md
@@ -10,7 +10,7 @@ redirect_from:
 - /about/security-information/
 subnav:
 - text: Latest updates
-  href: '/about/security/#changelog'
+  href: '#changelog'
 changelog:
   key: about-security
 ---


### PR DESCRIPTION
# Summary

Fixed the sidenav so a parent page's "Latest updates" link goes to that page's changelog instead of silently pointing at whatever page you're currently reading.

## Related issue

Closes #2036

## Problem statement

The sidenav shows subnav links not just for the current page but also for its parent pages. Subnav links that are plain anchors (like `#changelog`) were rendered as-is, so a parent page's "Latest updates" link became `#changelog` on the *current* page — clicking it jumped to the current page's changelog (or nowhere), never the parent's. On the Phase 2: Compile page, for example, four different pages' "Latest updates" links all rendered as the identical `#changelog`. Pages that worked around this by hand-writing full paths hit the issue's second symptom: those hard-coded paths miss the site prefix on preview builds.

## Solution

The nav templates now pass each subnav's owning page down the chain, and when a link is a plain anchor belonging to a *different* page, it renders as that page's URL plus the anchor (run through Jekyll's `relative_url`, which also fixes the preview-build prefix problem). Links belonging to the current page keep their plain in-page anchors, so same-page scrolling behaves exactly as before. The one hand-written workaround in the codebase (on the Security page) was reverted to a plain anchor so it flows through the same logic.

The changed include is shared infrastructure, so its callers were audited: only the sidenav path passes an owning page; every other use renders byte-identical output to before.

## Testing and review

- Rendered pages verified: on Phase 2: Compile, the parent's "Latest updates" now links to `/documentation/getting-started-for-developers/#changelog` while the page's own link stays `#changelog`; the Security page still renders correctly; spot-checks across components, utilities, and design-token pages show no other link changed.
- A test build with a preview-style baseurl confirmed cross-page anchors pick up the prefix correctly.
- `bundle exec rspec` passes (10 examples, 0 failures).
- To review: on the preview build, open Documentation → Getting started for developers → Phase 2: Compile and click the sidenav "Latest updates" links — each lands on its own page's changelog.
