### PR TITLE
USWDS-Site: Speed up CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,21 @@ jobs:
           keys:
             - gem-cache-{{ checksum "Gemfile.lock" }}
             - gem-cache
+      # _plugins/jekyll_get.rb hits the GitHub API for release/README/security
+      # content on every jekyll build, but only re-fetches a URL if its
+      # .jekyll_get_cache/<name>.json is missing. That dir is gitignored and
+      # was never persisted here, so it refetched from GitHub on every single
+      # build. Cache it, but rotate weekly (not indefinitely) since this data
+      # — release lists especially — does change over time. The date-into-a-
+      # file-then-checksum trick is because restore_cache/save_cache keys
+      # only support checksum/branch/env templating, no direct date function.
+      - run:
+          name: Compute weekly cache bucket
+          command: date +%Y-%U > /tmp/cache-week
+      - restore_cache:
+          keys:
+            - jekyll-get-cache-v1-{{ checksum "/tmp/cache-week" }}
+            - jekyll-get-cache-v1-
       - run:
           name: Build site assets
           command: npm run build:all-assets
@@ -71,15 +86,22 @@ jobs:
           command: |
             bundle config set --local path '~/project/vendor/bundle'
             bundle exec jekyll build
+      - save_cache:
+          key: jekyll-get-cache-v1-{{ checksum "/tmp/cache-week" }}
+          paths:
+            - .jekyll_get_cache
       - persist_to_workspace:
           root: ~/project
           paths:
             - "_site"
             - "assets"
             - "node_modules"
+  # No parallelism here on purpose: this job used to have parallelism: 2,
+  # but nothing split the rspec suite between the two containers, so both
+  # ran the identical full suite (2 spec files) for zero wall-clock benefit,
+  # just doubled compute. Removed rather than left as dead configuration.
   test_build:
     executor: my-executor
-    parallelism: 2
     steps:
       - checkout
       - attach_workspace:
@@ -100,9 +122,21 @@ jobs:
           name: Link bundler
           command: |
             bundle config set --local path '~/project/vendor/bundle'
+      # --skip-initial-build: `_site`/`assets` are already built and attached
+      # from the `build` job's workspace, so this just serves them. Without
+      # this flag, `jekyll serve` rebuilds from source on startup — which
+      # each of the 2 parallel containers here would do redundantly, plus
+      # re-trigger jekyll_get's GitHub fetches every time.
+      # The curl loop waits for --detach's background server to actually be
+      # ready before pa11y-ci starts hitting it.
+      # pa11y-ci:shard (not pa11y-ci:sitemap) is what makes parallelism: 2
+      # above actually cut wall-clock time — see config/shard-sitemap.js.
       - run:
           name: Run pa11y-ci desktop
-          command: npm run start-detached && npm run pa11y-ci:sitemap
+          command: |
+            bundle exec jekyll serve --detach --host=localhost --skip-initial-build
+            until curl -sf http://localhost:4000/sitemap.xml -o /dev/null; do sleep 1; done
+            npm run pa11y-ci:shard
   test_a11y_mobile:
     executor: my-executor
     parallelism: 2
@@ -114,9 +148,16 @@ jobs:
           name: Link bundler
           command: |
             bundle config set --local path '~/project/vendor/bundle'
+      # Same reasoning as test_a11y_desktop's "Run pa11y-ci desktop" step:
+      # --skip-initial-build avoids a redundant rebuild + jekyll_get refetch,
+      # the curl loop waits out --detach's startup race, and pa11y-ci:shard
+      # is what makes this job's parallelism: 2 actually save wall-clock time.
       - run:
           name: Run pa11y-ci mobile
-          command: npm run start-detached && npm run pa11y-ci:sitemap-mobile
+          command: |
+            bundle exec jekyll serve --detach --host=localhost --skip-initial-build
+            until curl -sf http://localhost:4000/sitemap.xml -o /dev/null; do sleep 1; done
+            npm run pa11y-ci:shard-mobile
 
 workflows:
   circle-uswds-site:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,14 @@ jobs:
     executor: my-executor
     steps:
       - checkout
+      # Fallback keys allow partial cache hits when the lock file changes.
+      # Bump v1- to invalidate all caches.
       - restore_cache:
+          name: Restore gem cache
           keys:
-            - gem-cache-{{ checksum "Gemfile.lock" }}
+            - v1-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+            - v1-gem-cache-{{ arch }}-{{ .Branch }}-
+            - v1-gem-cache-{{ arch }}-
       - run:
           name: Install ruby dependencies
           command: |
@@ -24,8 +29,13 @@ jobs:
       - run:
           name: Install scss_lint
           command: gem install scss_lint
+      # Drop stale gems left by a partial cache restore.
+      - run:
+          name: Clean stale gems
+          command: bundle clean --force
       - save_cache:
-          key: gem-cache-{{ checksum "Gemfile.lock" }}
+          name: Save gem cache
+          key: v1-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
       - persist_to_workspace:
@@ -36,16 +46,22 @@ jobs:
     executor: my-executor
     steps:
       - checkout
+      # Fallback keys allow partial cache hits when the lock file changes.
       - restore_cache:
+          name: Restore npm cache
           keys:
-            - npm-cache-{{ checksum "package-lock.json" }}
+            - v1-node-{{ .Branch }}-{{ checksum "package-lock.json" }}
+            - v1-node-{{ .Branch }}-
+            - v1-node-
       - run:
           name: Install node dependencies
           command: npm ci
+      # Cache npm's download store, not node_modules; npm ci rebuilds node_modules from it.
       - save_cache:
-          key: npm-cache-{{ checksum "package-lock.json" }}
+          name: Save npm cache
+          key: v1-node-{{ .Branch }}-{{ checksum "package-lock.json" }}
           paths:
-            - node_modules
+            - ~/.npm
       - persist_to_workspace:
           root: ~/project
           paths:
@@ -54,15 +70,9 @@ jobs:
     executor: my-executor
     steps:
       - checkout
+      # Deps come from the workspace; no cache restore needed here.
       - attach_workspace:
           at: ~/project
-      - restore_cache:
-          keys:
-            - npm-cache-{{ checksum "package-lock.json" }}
-      - restore_cache:
-          keys:
-            - gem-cache-{{ checksum "Gemfile.lock" }}
-            - gem-cache
       - run:
           name: Build site assets
           command: npm run build:all-assets

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,21 +63,6 @@ jobs:
           keys:
             - gem-cache-{{ checksum "Gemfile.lock" }}
             - gem-cache
-      # _plugins/jekyll_get.rb hits the GitHub API for release/README/security
-      # content on every jekyll build, but only re-fetches a URL if its
-      # .jekyll_get_cache/<name>.json is missing. That dir is gitignored and
-      # was never persisted here, so it refetched from GitHub on every single
-      # build. Cache it, but rotate weekly (not indefinitely) since this data
-      # — release lists especially — does change over time. The date-into-a-
-      # file-then-checksum trick is because restore_cache/save_cache keys
-      # only support checksum/branch/env templating, no direct date function.
-      - run:
-          name: Compute weekly cache bucket
-          command: date +%Y-%U > /tmp/cache-week
-      - restore_cache:
-          keys:
-            - jekyll-get-cache-v1-{{ checksum "/tmp/cache-week" }}
-            - jekyll-get-cache-v1-
       - run:
           name: Build site assets
           command: npm run build:all-assets
@@ -86,20 +71,12 @@ jobs:
           command: |
             bundle config set --local path '~/project/vendor/bundle'
             bundle exec jekyll build
-      - save_cache:
-          key: jekyll-get-cache-v1-{{ checksum "/tmp/cache-week" }}
-          paths:
-            - .jekyll_get_cache
       - persist_to_workspace:
           root: ~/project
           paths:
             - "_site"
             - "assets"
             - "node_modules"
-  # No parallelism here on purpose: this job used to have parallelism: 2,
-  # but nothing split the rspec suite between the two containers, so both
-  # ran the identical full suite (2 spec files) for zero wall-clock benefit,
-  # just doubled compute. Removed rather than left as dead configuration.
   test_build:
     executor: my-executor
     steps:
@@ -125,12 +102,11 @@ jobs:
       # --skip-initial-build: `_site`/`assets` are already built and attached
       # from the `build` job's workspace, so this just serves them. Without
       # this flag, `jekyll serve` rebuilds from source on startup — which
-      # each of the 2 parallel containers here would do redundantly, plus
-      # re-trigger jekyll_get's GitHub fetches every time.
+      # each of the 2 parallel containers here would do redundantly.
       # The curl loop waits for --detach's background server to actually be
       # ready before pa11y-ci starts hitting it.
       # pa11y-ci:shard (not pa11y-ci:sitemap) is what makes parallelism: 2
-      # above actually cut wall-clock time — see config/shard-sitemap.js.
+      # above actually cut time to completion when using a sharded sitemap.
       - run:
           name: Run pa11y-ci desktop
           command: |
@@ -148,10 +124,7 @@ jobs:
           name: Link bundler
           command: |
             bundle config set --local path '~/project/vendor/bundle'
-      # Same reasoning as test_a11y_desktop's "Run pa11y-ci desktop" step:
-      # --skip-initial-build avoids a redundant rebuild + jekyll_get refetch,
-      # the curl loop waits out --detach's startup race, and pa11y-ci:shard
-      # is what makes this job's parallelism: 2 actually save wall-clock time.
+      # Same reasoning as test_a11y_desktop's "Run pa11y-ci desktop" step.
       - run:
           name: Run pa11y-ci mobile
           command: |

--- a/config/shard-sitemap.js
+++ b/config/shard-sitemap.js
@@ -47,12 +47,37 @@ function fetchText(url) {
   });
 }
 
-function extractUrls(sitemapXml) {
+// The sitemap is fetched over the network, so its <loc> entries are
+// untrusted input: validate each one resolves to a well-formed http(s) URL
+// on the same origin as the sitemap itself before it's allowed anywhere near
+// the shard config that gets written to disk and fed to pa11y-ci. Jekyll's
+// sitemap emits root-relative paths (e.g. "/components/button/"), so each
+// entry is resolved against sitemapUrl as a base — this also normalizes them
+// to the absolute URLs pa11y-ci needs to actually navigate to. This also
+// guards against a malformed/compromised sitemap pointing pa11y-ci at
+// arbitrary external hosts.
+function extractUrls(sitemapXml, sitemapUrl) {
+  const allowedOrigin = new URL(sitemapUrl).origin;
   const urls = [];
   const locRegex = /<loc>(.*?)<\/loc>/g;
   let match;
   while ((match = locRegex.exec(sitemapXml)) !== null) {
-    urls.push(match[1]);
+    const raw = match[1].trim();
+    let parsed;
+    try {
+      parsed = new URL(raw, sitemapUrl);
+    } catch {
+      console.warn(`Skipping malformed sitemap URL: ${raw}`);
+      continue;
+    }
+    if (
+      (parsed.protocol !== "http:" && parsed.protocol !== "https:") ||
+      parsed.origin !== allowedOrigin
+    ) {
+      console.warn(`Skipping out-of-origin sitemap URL: ${raw}`);
+      continue;
+    }
+    urls.push(parsed.href);
   }
   return urls;
 }
@@ -83,7 +108,7 @@ async function main() {
   const total = parseInt(process.env.CIRCLE_NODE_TOTAL || "1", 10);
 
   const sitemapXml = await fetchText(sitemapUrl);
-  const allUrls = extractUrls(sitemapXml).filter(
+  const allUrls = extractUrls(sitemapXml, sitemapUrl).filter(
     (url) => !EXCLUDE_PATTERN.test(url)
   );
   const shard = shardUrls(allUrls, index, total);

--- a/config/shard-sitemap.js
+++ b/config/shard-sitemap.js
@@ -1,22 +1,16 @@
 // test_a11y_desktop/test_a11y_mobile in .circleci/config.yml already run with
 // parallelism: 2, but before this script existed both containers ran the
 // exact same full sitemap through pa11y-ci — parallelism was configured but
-// did nothing for wall-clock time, just doubled compute. This script gives
+// actually scans of all URLs in duplicate. This script gives
 // each container a distinct slice of the sitemap so the parallelism is real.
 const fs = require("fs");
 const path = require("path");
 const http = require("http");
 const https = require("https");
 
-// cheerio/express aren't devDependencies here (removed in a prior dependency
-// cleanup), so this intentionally sticks to Node built-ins rather than
-// reintroducing an XML/HTTP library for a one-off script.
-
 // Same exclusion pa11y-ci:sitemap/-mobile already pass via
 // `--sitemap-exclude '/*.pdf|next/'`, kept in sync so sharded runs exclude
-// the same URLs as the unsharded ones. Built via `new RegExp(string)` rather
-// than a `/.../ ` literal because a literal can't start with `/*` (nothing
-// for the `*` to repeat) — the string form is just ordinary characters.
+// the same URLs as the unsharded ones.
 const EXCLUDE_PATTERN = new RegExp("/*.pdf|next/");
 
 function parseArgs(argv) {
@@ -52,10 +46,7 @@ function fetchText(url) {
 // on the same origin as the sitemap itself before it's allowed anywhere near
 // the shard config that gets written to disk and fed to pa11y-ci. Jekyll's
 // sitemap emits root-relative paths (e.g. "/components/button/"), so each
-// entry is resolved against sitemapUrl as a base — this also normalizes them
-// to the absolute URLs pa11y-ci needs to actually navigate to. This also
-// guards against a malformed/compromised sitemap pointing pa11y-ci at
-// arbitrary external hosts.
+// entry is resolved against sitemapUrl as a base.
 function extractUrls(sitemapXml, sitemapUrl) {
   const allowedOrigin = new URL(sitemapUrl).origin;
   const urls = [];
@@ -102,8 +93,6 @@ async function main() {
   }
 
   // CircleCI sets these automatically from a job's `parallelism:` value.
-  // Defaulting to 0/1 means running this script outside CircleCI (or with
-  // parallelism removed) still produces the full, unsharded URL list.
   const index = parseInt(process.env.CIRCLE_NODE_INDEX || "0", 10);
   const total = parseInt(process.env.CIRCLE_NODE_TOTAL || "1", 10);
 

--- a/config/shard-sitemap.js
+++ b/config/shard-sitemap.js
@@ -1,0 +1,114 @@
+// test_a11y_desktop/test_a11y_mobile in .circleci/config.yml already run with
+// parallelism: 2, but before this script existed both containers ran the
+// exact same full sitemap through pa11y-ci — parallelism was configured but
+// did nothing for wall-clock time, just doubled compute. This script gives
+// each container a distinct slice of the sitemap so the parallelism is real.
+const fs = require("fs");
+const path = require("path");
+const http = require("http");
+const https = require("https");
+
+// cheerio/express aren't devDependencies here (removed in a prior dependency
+// cleanup), so this intentionally sticks to Node built-ins rather than
+// reintroducing an XML/HTTP library for a one-off script.
+
+// Same exclusion pa11y-ci:sitemap/-mobile already pass via
+// `--sitemap-exclude '/*.pdf|next/'`, kept in sync so sharded runs exclude
+// the same URLs as the unsharded ones. Built via `new RegExp(string)` rather
+// than a `/.../ ` literal because a literal can't start with `/*` (nothing
+// for the `*` to repeat) — the string form is just ordinary characters.
+const EXCLUDE_PATTERN = new RegExp("/*.pdf|next/");
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 2) {
+    const key = argv[i].replace(/^--/, "");
+    args[key] = argv[i + 1];
+  }
+  return args;
+}
+
+function fetchText(url) {
+  const client = url.startsWith("https:") ? https : http;
+  return new Promise((resolve, reject) => {
+    client
+      .get(url, (res) => {
+        if (res.statusCode < 200 || res.statusCode >= 300) {
+          reject(new Error(`Failed to fetch ${url}: HTTP ${res.statusCode}`));
+          res.resume();
+          return;
+        }
+        let body = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => (body += chunk));
+        res.on("end", () => resolve(body));
+      })
+      .on("error", reject);
+  });
+}
+
+function extractUrls(sitemapXml) {
+  const urls = [];
+  const locRegex = /<loc>(.*?)<\/loc>/g;
+  let match;
+  while ((match = locRegex.exec(sitemapXml)) !== null) {
+    urls.push(match[1]);
+  }
+  return urls;
+}
+
+// Round-robin rather than contiguous slices: sitemap URLs cluster by
+// directory (components, templates, patterns, ...), so a contiguous split
+// would risk loading all the heavy pages onto one shard. Interleaving
+// spreads page types evenly across containers without needing per-page
+// timing data.
+function shardUrls(urls, index, total) {
+  return urls.filter((_, i) => i % total === index);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const sitemapUrl = args.sitemap || "http://localhost:4000/sitemap.xml";
+  const baseConfigPath = args["base-config"] || ".pa11yci";
+  const outPath = args.out;
+
+  if (!outPath) {
+    throw new Error("--out <path> is required");
+  }
+
+  // CircleCI sets these automatically from a job's `parallelism:` value.
+  // Defaulting to 0/1 means running this script outside CircleCI (or with
+  // parallelism removed) still produces the full, unsharded URL list.
+  const index = parseInt(process.env.CIRCLE_NODE_INDEX || "0", 10);
+  const total = parseInt(process.env.CIRCLE_NODE_TOTAL || "1", 10);
+
+  const sitemapXml = await fetchText(sitemapUrl);
+  const allUrls = extractUrls(sitemapXml).filter(
+    (url) => !EXCLUDE_PATTERN.test(url)
+  );
+  const shard = shardUrls(allUrls, index, total);
+
+  const baseConfig = JSON.parse(
+    fs.readFileSync(path.resolve(baseConfigPath), "utf8")
+  );
+
+  // Only `defaults` carries over from the base .pa11yci/.pa11yci--mobile —
+  // `urls` here is this shard's slice, not whatever (if anything) was in
+  // the base config.
+  const shardConfig = {
+    defaults: baseConfig.defaults,
+    urls: shard,
+  };
+
+  fs.writeFileSync(outPath, JSON.stringify(shardConfig, null, 2));
+
+  console.log(
+    `Shard ${index + 1}/${total}: ${shard.length}/${allUrls.length} URLs ` +
+      `(from ${sitemapUrl}) written to ${outPath}`
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/config/shard-sitemap.mjs
+++ b/config/shard-sitemap.mjs
@@ -3,10 +3,10 @@
 // exact same full sitemap through pa11y-ci — parallelism was configured but
 // actually scans of all URLs in duplicate. This script gives
 // each container a distinct slice of the sitemap so the parallelism is real.
-const fs = require("fs");
-const path = require("path");
-const http = require("http");
-const https = require("https");
+import fs from "node:fs";
+import path from "node:path";
+import http from "node:http";
+import https from "node:https";
 
 // Same exclusion pa11y-ci:sitemap/-mobile already pass via
 // `--sitemap-exclude '/*.pdf|next/'`, kept in sync so sharded runs exclude

--- a/package.json
+++ b/package.json
@@ -70,8 +70,8 @@
     "pa11y-ci:sitemap": "pa11y-ci --sitemap http://localhost:4000/sitemap.xml --sitemap-exclude '/*.pdf|next/'",
     "pa11y-ci:sitemap-mobile": "pa11y-ci --config .pa11yci--mobile --sitemap http://localhost:4000/sitemap.xml --sitemap-exclude '/*.pdf|next/'",
     "pa11y-ci:sitemap-json": "pa11y-ci --json > pa11y-results.json --sitemap http://localhost:4000/sitemap.xml --sitemap-exclude '/*.pdf|next/'",
-    "pa11y-ci:shard": "node config/shard-sitemap.js --base-config .pa11yci --out /tmp/pa11yci-shard.json && pa11y-ci --config /tmp/pa11yci-shard.json",
-    "pa11y-ci:shard-mobile": "node config/shard-sitemap.js --base-config .pa11yci--mobile --out /tmp/pa11yci-shard-mobile.json && pa11y-ci --config /tmp/pa11yci-shard-mobile.json",
+    "pa11y-ci:shard": "node config/shard-sitemap.mjs --base-config .pa11yci --out /tmp/pa11yci-shard.json && pa11y-ci --config /tmp/pa11yci-shard.json",
+    "pa11y-ci:shard-mobile": "node config/shard-sitemap.mjs --base-config .pa11yci--mobile --out /tmp/pa11yci-shard-mobile.json && pa11y-ci --config /tmp/pa11yci-shard-mobile.json",
     "prettier:scss": "npx prettier --write './css/**/*.scss'"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,8 @@
     "pa11y-ci:sitemap": "pa11y-ci --sitemap http://localhost:4000/sitemap.xml --sitemap-exclude '/*.pdf|next/'",
     "pa11y-ci:sitemap-mobile": "pa11y-ci --config .pa11yci--mobile --sitemap http://localhost:4000/sitemap.xml --sitemap-exclude '/*.pdf|next/'",
     "pa11y-ci:sitemap-json": "pa11y-ci --json > pa11y-results.json --sitemap http://localhost:4000/sitemap.xml --sitemap-exclude '/*.pdf|next/'",
+    "pa11y-ci:shard": "node config/shard-sitemap.js --base-config .pa11yci --out /tmp/pa11yci-shard.json && pa11y-ci --config /tmp/pa11yci-shard.json",
+    "pa11y-ci:shard-mobile": "node config/shard-sitemap.js --base-config .pa11yci--mobile --out /tmp/pa11yci-shard-mobile.json && pa11y-ci --config /tmp/pa11yci-shard-mobile.json",
     "prettier:scss": "npx prettier --write './css/**/*.scss'"
   },
   "devDependencies": {


### PR DESCRIPTION
# Summary

Improved CircleCI build performance by implementing true parallel accessibility testing and optimizing dependency caching.

## Related issue

Closes #3275 

## Problem statement

The CircleCI build had two inefficiencies:

1. Duplicate a11y testing: Jobs were configured with `parallelism: 2`, but both containers ran the exact same full sitemap through pa11y-ci, resulting in both containers doing scans across the entire sitemap instead of dividing the work in half..

2. Suboptimal caching: Dependency caches lacked fallback keys and didn't follow CircleCI best practices, leading to full reinstalls when lockfiles changed and caching the wrong paths for npm (caching `node_modules` instead of `~/.npm`).

## Solution

Implemented true parallelism and improved caching:

1. **Created sitemap sharding script** (`config/shard-sitemap.mjs`): Fetches the sitemap at test-time, validates and filters URLs, then splits them round-robin across CircleCI containers. This ensures each of the 2 containers tests a distinct half of the site.

2. **Updated CircleCI config**:
   - Replaced `pa11y-ci:sitemap` calls with `pa11y-ci:shard` in desktop/mobile a11y jobs
   - Added `--skip-initial-build` flag to `jekyll serve` since assets are pre-built
   - Added curl readiness check before running pa11y to ensure server is ready

3. **Improved dependency caching**:
   - Added fallback cache keys for both gem and npm caches
   - Changed npm cache from `node_modules` to `~/.npm` (npm's download store)
   - Added `bundle clean --force` to remove stale gems after partial cache restores
   - Added version prefix (`v1-`) for easy cache invalidation
   - Removed redundant cache restores in build job (deps come from workspace)

## Major changes

- **New file**: `config/shard-sitemap.mjs` — sitemap URL sharding script with origin validation
- **Package.json**: Added `pa11y-ci:shard` and `pa11y-ci:shard-mobile` npm scripts
- **CircleCI config**: Complete rework of caching strategy and a11y test execution

## Testing and review

To verify these changes:

1. **Parallelism**: Check CircleCI build logs — each container should report testing ~half the URLs (e.g., "Shard 1/2: 150/300 URLs" and "Shard 2/2: 150/300 URLs")
2. **Caching**: Watch for cache restore fallbacks in CI logs when lockfiles change
3. **Build time**: Compare total CI time before/after — a11y jobs should complete in roughly half the time

The a11y tests should pass with identical coverage to the previous approach, just faster. Build time went from 14-16 minutes down to 8-9 in my testing.