### PR TITLE
USWDS-Site - Date of birth: Give each date field its own hint

### DIFF
--- a/_data/changelogs/pattern-user-profile-date-of-birth.yml
+++ b/_data/changelogs/pattern-user-profile-date-of-birth.yml
@@ -2,6 +2,13 @@ title: Date of birth
 type: pattern
 changelogURL:
 items:
+  - date: NNNN-NN-NN
+    summary: Updated the pattern to give each date field its own hint.
+    summaryAdditional: Each field is described only by its own screen reader-only hint, and the hint above the fields is hidden from screen readers so it is not repeated for every field. Month options use month names without leading numbers. This matches the memorable date component.
+    affectsAccessibility: true
+    affectsContent: true
+    affectsMarkup: true
+    githubRepo: uswds-site
   - date: 2022-11-14
     summary: Pattern published.
     affectsGuidance: true

--- a/_includes/patterns/date-of-birth.html
+++ b/_includes/patterns/date-of-birth.html
@@ -1,33 +1,36 @@
 <fieldset class="usa-fieldset">
   <legend class="usa-legend">Date of Birth</legend>
-  <span class="usa-hint" id="mdHint">For example: January 19 2000</span>
+  <span class="usa-hint" aria-hidden="true" id="mdHint">Select a month. Enter 1 or 2 digits for the day and 4 digits for the year.</span>
   <div class="usa-memorable-date">
     <div class="usa-form-group usa-form-group--month usa-form-group--select">
       <label class="usa-label" for="date_of_birth_month">Month</label>
-      <select class="usa-select" id="date_of_birth_month" name="date_of_birth_month" aria-describedby="mdHint">
+      <span class="usa-hint usa-sr-only" id="mdMonthHint">Select a month from the dropdown.</span>
+      <select class="usa-select" id="date_of_birth_month" name="date_of_birth_month" aria-describedby="mdMonthHint">
         <option value>- Select -</option>
-        <option value="1">01 - January</option>
-        <option value="2">02 - February</option>
-        <option value="3">03 - March</option>
-        <option value="4">04 - April</option>
-        <option value="5">05 - May</option>
-        <option value="6">06 - June</option>
-        <option value="7">07 - July</option>
-        <option value="8">08 - August</option>
-        <option value="9">09 - September</option>
-        <option value="10">10 - October</option>
-        <option value="11">11 - November</option>
-        <option value="12">12 - December</option>
+        <option value="1">January</option>
+        <option value="2">February</option>
+        <option value="3">March</option>
+        <option value="4">April</option>
+        <option value="5">May</option>
+        <option value="6">June</option>
+        <option value="7">July</option>
+        <option value="8">August</option>
+        <option value="9">September</option>
+        <option value="10">October</option>
+        <option value="11">November</option>
+        <option value="12">December</option>
       </select>
     </div>
     <div class="usa-form-group usa-form-group--day">
       <label class="usa-label" for="date_of_birth_day">Day</label>
-      <input class="usa-input" aria-describedby="mdHint" id="date_of_birth_day" name="date_of_birth_day"
+      <span class="usa-hint usa-sr-only" id="mdDayHint">Enter 1 or 2 digits for the day.</span>
+      <input class="usa-input" aria-describedby="mdDayHint" id="date_of_birth_day" name="date_of_birth_day"
         maxlength="2" pattern="[0-9]*" inputmode="numeric" value="" />
     </div>
     <div class="usa-form-group usa-form-group--year">
       <label class="usa-label" for="date_of_birth_year">Year</label>
-      <input class="usa-input" aria-describedby="mdHint" id="date_of_birth_year" name="date_of_birth_year"
+      <span class="usa-hint usa-sr-only" id="mdYearHint">Enter 4 digits for the year.</span>
+      <input class="usa-input" aria-describedby="mdYearHint" id="date_of_birth_year" name="date_of_birth_year"
         minlength="4" maxlength="4" pattern="[0-9]*" inputmode="numeric" value="" />
     </div>
   </div>

--- a/spec/date_of_birth_pattern_spec.rb
+++ b/spec/date_of_birth_pattern_spec.rb
@@ -1,0 +1,100 @@
+require 'nokogiri'
+
+# https://github.com/uswds/uswds-site/issues/3289 — the date-of-birth pattern
+# include drifted from the usa-memorable-date component. uswds/uswds#6725 gave
+# each control its own screen-reader-only hint so that assistive technology
+# announces one relevant sentence per field instead of repeating a shared hint
+# three times, and the numeric month prefixes ("01 - January") were dropped
+# because they were read aloud as meaningless digits.
+RSpec.describe '_includes/patterns/date-of-birth.html' do
+  let(:fragment) do
+    Nokogiri::HTML5.fragment(File.read('./_includes/patterns/date-of-birth.html'))
+  end
+
+  let(:fieldset) { fragment.at_css('fieldset.usa-fieldset') }
+
+  # The month select and the day/year inputs, in document order.
+  let(:controls) { fieldset.css('.usa-memorable-date select, .usa-memorable-date input') }
+
+  # The hint that sits directly under the legend and describes the group.
+  let(:group_hint) { fieldset.xpath('./span[contains(@class, "usa-hint")]').first }
+
+  def hint_for(control)
+    fragment.at_css("##{control['aria-describedby']}")
+  end
+
+  it 'has a month, day, and year control' do
+    expect(controls.map { |c| c['id'] }.length).to eq(3)
+  end
+
+  describe 'the group hint under the legend' do
+    it 'is hidden from assistive technology' do
+      expect(group_hint).not_to be_nil
+      expect(group_hint['aria-hidden']).to eq('true'),
+        'the group hint must be aria-hidden so screen readers use the per-field hints instead'
+    end
+
+    it 'stays visible for sighted users' do
+      expect(group_hint['class'].split).not_to include('usa-sr-only')
+    end
+
+    it 'is not referenced by any control' do
+      described = controls.map { |control| control['aria-describedby'] }
+      expect(described).not_to include(group_hint['id']),
+        "controls still point at the shared group hint #{group_hint['id'].inspect}"
+    end
+  end
+
+  describe 'per-field hints' do
+    it 'gives every control its own hint' do
+      described = controls.map { |control| control['aria-describedby'] }
+      expect(described).to all(be_a(String).and(satisfy { |v| !v.strip.empty? }))
+      expect(described.uniq.length).to eq(3),
+        "each control needs its own hint, got #{described.inspect}"
+    end
+
+    it 'points every aria-describedby at an element that exists' do
+      controls.each do |control|
+        expect(hint_for(control)).not_to be_nil,
+          "#{control['id']} is described by #{control['aria-describedby'].inspect}, which is not in the document"
+      end
+    end
+
+    it 'marks each per-field hint screen-reader-only' do
+      controls.each do |control|
+        classes = hint_for(control)['class'].to_s.split
+        expect(classes).to include('usa-hint', 'usa-sr-only'),
+          "hint for #{control['id']} has classes #{classes.inspect}"
+      end
+    end
+
+    it 'keeps each hint in the same form group as its control' do
+      controls.each do |control|
+        group = control.ancestors('.usa-form-group').first
+        expect(group.at_css("##{control['aria-describedby']}")).not_to be_nil,
+          "hint for #{control['id']} is outside its own .usa-form-group"
+      end
+    end
+  end
+
+  describe 'month options' do
+    let(:month_labels) do
+      fieldset.css('select option').map { |option| option.text.strip }.reject { |t| t.start_with?('-') }
+    end
+
+    it 'lists all twelve months' do
+      expect(month_labels.length).to eq(12)
+    end
+
+    it 'uses name-only labels' do
+      numbered = month_labels.select { |label| label.match?(/\A\d/) }
+      expect(numbered).to be_empty,
+        "month labels must not lead with digits, got #{numbered.inspect}"
+    end
+  end
+
+  it 'has no duplicate ids' do
+    ids = fragment.css('[id]').map { |node| node['id'] }
+    expect(ids.uniq.length).to eq(ids.length), "duplicate ids: #{ids.tally.select { |_, n| n > 1 }.keys.inspect}"
+  end
+end


### PR DESCRIPTION
# Summary

Updated the date of birth pattern so the month, day, and year fields each have their own hint, matching the memorable date component.

## Related issue

Closes #3289

## Preview link

Preview link: _(pending — the deploy preview for this branch)_

The pattern appears on **Patterns → Create a user profile → [Date of birth](https://designsystem.digital.gov/patterns/create-a-user-profile/date-of-birth/)**, in the "Pattern preview" section and in the code sample below it.

## Problem statement

**Desired state:** Someone using a screen reader on the date of birth pattern hears guidance specific to the field they are on — one sentence for the month, one for the day, one for the year.

**Actual state:** All three fields pointed at the same hint (`id="mdHint"`). Moving through the group, a screen reader user heard "For example: January 19 2000" three times and never heard anything about the individual field. The month dropdown also still listed months as "01 - January", which is read aloud as digits that carry no meaning.

**Consequence:** This is the pattern the site recommends other teams copy, so the older markup gets carried into government forms built from it. The memorable date component was fixed in uswds/uswds#6725, but this pattern was left behind, so the site now demonstrates something different from what it recommends.

The component documentation pages pull their markup straight from the USWDS package, so they update themselves. This pattern include is written by hand, which is why it drifted.

## Solution

The pattern now follows the same approach as the memorable date component:

- Each field has its own short, screen-reader-only hint, and points only at that hint.
- The hint above the fields stays exactly where it is and still reads the same way for sighted users. It is now hidden from screen readers, so it is not repeated three times.
- Month options use plain month names.

**A note on naming.** The issue suggested hint names in the form `{id}-month-hint`. This uses `mdMonthHint`, `mdDayHint`, and `mdYearHint` instead, because that is the naming every other pattern on this site already uses (`ssnHint`, `pnHint`, `gnHint`, and eleven more). Happy to switch to the wording in the issue if the team prefers it.

**Two things worth a look during review:**

1. The wording of the hint above the fields was also updated to match the component ("Select a month. Enter 1 or 2 digits for the day and 4 digits for the year."). The issue only asked for it to be hidden from screen readers, so flagging the text change explicitly.
2. This is a markup-only change and needs nothing from 3.14.0 to render correctly — both classes it uses already exist in the pinned 3.13.0. But it does land ahead of the 3.14.0 version bump in #3282.

The field names and ids were left alone, so nothing else that refers to them is affected.

## Major changes

- `_includes/patterns/date-of-birth.html` — added a hint for each field, hid the group hint from screen readers and updated its wording, removed the leading numbers from the month list.
- `_data/changelogs/pattern-user-profile-date-of-birth.yml` — added a changelog entry. The date is the `NNNN-NN-NN` placeholder and the PR number is blank, both to be filled in at merge.
- `spec/date_of_birth_pattern_spec.rb` — new. Checks the pattern keeps its per-field hints so this cannot quietly slip back.

## Testing and review

**Automated**

- `bundle exec rspec` — 21 examples, 0 failures (10 already existing, 11 new).
- The new tests check relationships rather than exact text: every field points at a hint that actually exists, is screen-reader-only, and sits in the same form group as its field; the group hint is hidden from screen readers and referenced by no field; month labels do not start with digits; no duplicate ids. Six of the eleven fail against the previous markup.
- `npx gulp lintJS lintSass` — clean. `bundle exec jekyll build` — clean.

**Accessibility**

Checked the built page in Chrome with axe (WCAG 2 A/AA) — no violations on the date fields or anywhere else on the page. `aria-valid-attr-value`, `aria-hidden-focus`, `duplicate-id`, `duplicate-id-aria`, `label`, and `form-field-multiple-labels` all pass.

What each field reports, before and after:

| Field | Before | After |
| --- | --- | --- |
| Month | For example: January 19 2000 | Select a month from the dropdown. |
| Day | For example: January 19 2000 | Enter 1 or 2 digits for the day. |
| Year | For example: January 19 2000 | Enter 4 digits for the year. |

**To review it yourself**

1. `npm start`, then open `/patterns/create-a-user-profile/date-of-birth/`.
2. The pattern should look unchanged — the hint above the fields is still visible and in the same place.
3. Tab through the three fields with a screen reader on. Each should read out its own sentence rather than the same one three times.
4. Open the month dropdown and confirm it reads "January" rather than "01 - January".

**Feedback I'm looking for:** whether the hint naming should follow the issue's wording instead of the site's existing convention, whether the reworded group hint is wanted here, and confirmation on a real screen reader — the checks above were automated and in-browser, not run with VoiceOver or NVDA.

**Note:** `pa11y-ci` would not run locally (its bundled browser crashes on Apple silicon), so the same axe checks were run in Chrome directly. CI's own pa11y run should be treated as the final word.
