### PR TITLE
USWDS-Site - Combo box: Fix accessibility test for value vs state and add default selection test

### DIFF
--- a/_data/accessibility-tests/combo-box.yml
+++ b/_data/accessibility-tests/combo-box.yml
@@ -89,8 +89,14 @@ test_items:
     test_type: screen_reader
     version_tested: 3.8.0
     wcag_criterion: 3.3.2
-  - summary: Screen reader announces label, role, value, and controls for combo box. 
-    summary_additional: When using a screen reader with a combo box, you hear the label of the combo box, the role and the state. For example, the label is announced as "Select an option", the role is announced as "combo box", and the value is announced as "expanded". 
+  - summary: Screen reader announces label, role, value, and state for combo box.
+    summary_additional: When you tab to a combo box, you hear its label, that it is a combo box, its expanded or collapsed state, and the current value if the field has one. For example, "Select a fruit, combo box, collapsed." If a value is present, you also hear that value (for example, "Blackberry").
+    test_status: conditional
+    test_type: screen_reader
+    version_tested: 3.8.0
+    wcag_criterion: 4.1.2
+  - summary: Screen reader announces a default selection without opening the list.
+    summary_additional: Test a combo box that already has a value (`data-default-value` or an equivalent preset). When you tab to it while collapsed, you hear the current value. You should not have to expand the list to learn what is selected.
     test_status: conditional
     test_type: screen_reader
     version_tested: 3.8.0


### PR DESCRIPTION
USWDS-Site - Combo box: Fix accessibility test for value vs state and add default selection test

# Summary

Fixed the combo box 4.1.2 accessibility test so it correctly distinguishes label, role, value, and state, and added a conditional test so teams verify a preset value is announced while the list is collapsed.

## Related issue

Closes #3264

## Preview link

Preview link:
https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/bug/3264-combo-box-default-selection/components/combo-box/accessibility-tests/

## Problem statement

**Desired:** Manual accessibility testers and 508 auditors can confirm that screen reader users hear a combo box's current value (including preset selections) without opening the list.

**Actual:** The existing 4.1.2 test item incorrectly described "expanded" as the value. Expanded and collapsed are states, not values. Testers could pass the checklist using an empty combo box and never verify that a default selection is announced.

**Consequence:** Teams could report a pass on WCAG 4.1.2 Name, Role, Value without checking the scenario a 508 auditor raised: a user tabs to a combo box that already has a value and needs to hear that value while collapsed.

## Solution

Updated `_data/accessibility-tests/combo-box.yml` only. No component JS, markup, or implementation changes.

1. **Rewrote the existing 4.1.2 item** so it separates state (expanded/collapsed) from value (input text, or empty). Examples use phrasing like "Select a fruit, combo box, collapsed" and "Blackberry" when a value is present.
2. **Added a second conditional 4.1.2 item** for combo boxes with a preset value (`data-default-value` or equivalent). Testers confirm the current value is announced on focus while collapsed, without opening the list.
3. **Did not require the word "selected."** USWDS exposes the value as input text; announcements such as "Select a fruit, Blackberry, combobox, collapsed" are acceptable.

Test totals update automatically via the accessibility test summary template (16 tests: 14 pass, 2 conditional).

## Major changes

- Rewrote the 4.1.2 screen reader test: "Screen reader announces label, role, value, and state for combo box."
- Added conditional 4.1.2 test: "Screen reader announces a default selection without opening the list."

## Testing and review

1. Run the site locally and open `/components/combo-box/accessibility-tests/`.
2. Confirm the summary table shows **16 total tests** with **2 conditional**.
3. Under Screen reader tests, verify:
   - The 4.1.2 item no longer says the value is announced as "expanded."
   - The new default-selection item appears and is marked conditional.
4. No build or JS changes expected; YAML-only update.